### PR TITLE
Fix the docs

### DIFF
--- a/cellarium/ml/core/module.py
+++ b/cellarium/ml/core/module.py
@@ -1,8 +1,6 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from __future__ import annotations
-
 from importlib import import_module
 from typing import IO, Any
 from unittest.mock import patch
@@ -96,7 +94,7 @@ class CellariumModule(pl.LightningModule):
         hparams_file: _PATH | None = None,
         strict: bool = True,
         **kwargs: Any,
-    ) -> CellariumModule:
+    ) -> "CellariumModule":
         r"""
         Primary way of loading a model from a checkpoint. When Cellarium ML saves a checkpoint it stores the config
         argument passed to ``__init__``  in the checkpoint under ``"hyper_parameters"``.

--- a/cellarium/ml/core/saving.py
+++ b/cellarium/ml/core/saving.py
@@ -1,8 +1,6 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from __future__ import annotations
-
 from typing import TYPE_CHECKING, Any
 
 from jsonargparse import ArgumentParser, Namespace
@@ -13,11 +11,11 @@ if TYPE_CHECKING:
 
 
 def _load_state(
-    cls: type[CellariumModule],
+    cls: type["CellariumModule"],
     checkpoint: dict[str, Any],
     strict: bool | None = None,
     **cls_kwargs_new: Any,
-) -> CellariumModule:
+) -> "CellariumModule":
     """
     Re-implementation of :func:`lightning.pytorch.core.saving._load_state` that instantiates the model
     using the configuration saved in the checkpoint.

--- a/cellarium/ml/data/distributed_anndata.py
+++ b/cellarium/ml/data/distributed_anndata.py
@@ -1,8 +1,6 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from __future__ import annotations
-
 import gc
 from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
@@ -50,7 +48,7 @@ class DistributedAnnDataCollectionView(AnnCollectionView):
     of :class:`LazyAnnData` objects.
     """
 
-    def __getitem__(self, index: Index) -> DistributedAnnDataCollectionView:
+    def __getitem__(self, index: Index) -> "DistributedAnnDataCollectionView":
         oidx, vidx = _normalize_indices(index, self.obs_names, self.var_names)
         resolved_idx = self._resolve_idx(oidx, vidx)
 

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,7 @@
+/*
+Fix for horizontal stacking weirdness in the RTD theme with Python properties:
+https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
+*/
+.py.property {
+    display: block !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinx_rtd_theme",
 ]
@@ -32,13 +31,12 @@ exclude_patterns = []
 
 autodoc_inherit_docstrings = False
 autodoc_member_order = "bysource"
-
-# Add a default annotation
-
-typehints_defaults = "comma"
+autodoc_typehints = "both"
+autodoc_typehints_format = "short"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -5,3 +5,4 @@ Data
    :members:
    :special-members:
    :show-inheritance:
+   :exclude-members: __weakref__

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -5,3 +5,4 @@ Models
    :members:
    :special-members:
    :show-inheritance:
+   :exclude-members: __weakref__

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -5,6 +5,7 @@ Utilities
    :members:
    :special-members:
    :show-inheritance:
+   :exclude-members: __weakref__
 
 .. automodule:: cellarium.ml.utilities.testing
    :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ docs = [
   "Pillow",
   "sphinx",
   "sphinx_rtd_theme",
-  "sphinx-autodoc-typehints",
   "sphinx-copybutton",
 ]
 dev = ["cellarium-ml[docs,lint,mypy,test]"]


### PR DESCRIPTION
- Remove `from __future__ import annotations` (type hints are rendered better without it)
- Fix the stacking of `py:property` on a single line (https://github.com/readthedocs/sphinx_rtd_theme/issues/1301#issuecomment-1876120817)
- Use `sphinx.ext.autodoc` for displaying type hints instead of `sphinx_autodoc_typehints`
- Remove `__weakref__` method from the docs

Before:
<img width="716" alt="Screenshot 2024-01-11 at 10 33 23 AM" src="https://github.com/cellarium-ai/cellarium-ml/assets/50752571/bd1c6e8a-dd07-4b5c-b6f3-1b41d1cbb949">

After:
<img width="717" alt="Screenshot 2024-01-11 at 10 39 30 AM" src="https://github.com/cellarium-ai/cellarium-ml/assets/50752571/b2bbd99e-2533-48f0-aa01-d921174cfad8">