### PR TITLE
CI docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update && sudo apt-get install -y pandoc
         python -m pip install --upgrade pip
         pip install .[docs]
     - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
 
   test:
 
+    needs: [lint, mypy, docs]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,26 @@ jobs:
     - name: Lint check
       run: make lint
 
+  docs:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[docs]
+    - name: Build docs
+      run: make docs
+
   mypy:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
+        sudo apt-get update && sudo apt-get install -y pandoc
         python -m pip install --upgrade pip
     - id: deployment
       uses: sphinx-notes/pages@v3

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ lint: FORCE
 	ruff check .
 	black --check .
 
+docs: FORCE
+	cd docs && make html
+
 license: FORCE
 	python scripts/update_headers.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
 ]
 docs = [
   "nbsphinx",
+  "pandoc",
   "Pillow",
   "seaborn>=0.13.0",
   "sphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ test = [
 ]
 docs = [
   "nbsphinx",
-  "pandoc",
   "Pillow",
   "seaborn>=0.13.0",
   "sphinx",


### PR DESCRIPTION
`nbsphinx` dependency introduced in #107 requires `pandoc`. This PR installs `pandoc` on system level (`pip install pandoc` doesn't install pandoc) and also adds building of the docs to the CI.