### PR TITLE
`compute_var_names_g`

### DIFF
--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -71,13 +71,13 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
         batch_idx: int,
         dataloader_idx: int,
     ) -> None:
-        z_nk = prediction["z_nk"]
+        x_ng = prediction["x_ng"]
         if self.prediction_size is not None:
-            z_nk = z_nk[:, : self.prediction_size]
+            x_ng = x_ng[:, : self.prediction_size]
 
         assert isinstance(batch["obs_names"], np.ndarray)
         write_prediction(
-            prediction=z_nk,
+            prediction=x_ng,
             ids=batch["obs_names"],
             output_dir=self.output_dir,
             postfix=batch_idx * trainer.world_size + trainer.global_rank,

--- a/cellarium/ml/core/datamodule.py
+++ b/cellarium/ml/core/datamodule.py
@@ -4,7 +4,6 @@
 from collections.abc import Iterable, Sequence
 
 import lightning.pytorch as pl
-import numpy as np
 import torch
 
 from cellarium.ml.data import DistributedAnnDataCollection, IterableDistributedAnnDataCollectionDataset
@@ -174,18 +173,6 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             indices_strict=self.indices_strict,
             obs_columns=obs_columns,
         )
-
-    @property
-    def n_obs(self) -> int:
-        return self.dadc.n_obs
-
-    @property
-    def n_vars(self) -> int:
-        return self.dadc.n_vars
-
-    @property
-    def var_names(self) -> np.ndarray:
-        return self.dadc.var_names.values
 
     def setup(self, stage: str | None = None) -> None:
         """

--- a/cellarium/ml/core/module.py
+++ b/cellarium/ml/core/module.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from collections.abc import Iterable
-from typing import IO, Any
+from typing import Any
 from unittest.mock import patch
 
 import lightning.pytorch as pl
@@ -30,11 +30,11 @@ class CellariumModule(pl.LightningModule):
           keyword arguments.
 
     Args:
-        model:
-            A :class:`cellarium.ml.models.CellariumModel` to train.
         transforms:
             A list of transforms to apply to the input data before passing it to the model.
             If ``None``, no transforms are applied.
+        model:
+            A :class:`cellarium.ml.models.CellariumModel` to train.
         optim_fn:
             A Pytorch optimizer class, e.g., :class:`~torch.optim.Adam`. If ``None``,
             defaults to :class:`torch.optim.Adam`.
@@ -53,8 +53,8 @@ class CellariumModule(pl.LightningModule):
 
     def __init__(
         self,
-        model: CellariumModel,
         transforms: Iterable[torch.nn.Module] | None = None,
+        model: CellariumModel | None = None,
         optim_fn: type[torch.optim.Optimizer] | None = None,
         optim_kwargs: dict[str, Any] | None = None,
         scheduler_fn: type[torch.optim.lr_scheduler.LRScheduler] | None = None,
@@ -64,6 +64,8 @@ class CellariumModule(pl.LightningModule):
     ) -> None:
         super().__init__()
         self.pipeline = CellariumPipeline(transforms)
+        if model is None:
+            raise ValueError(f"`model` must be an instance of {CellariumModel}. Got {model}")
         self.pipeline.append(model)
 
         # set up optimizer and scheduler
@@ -99,7 +101,7 @@ class CellariumModule(pl.LightningModule):
     @patch("lightning.pytorch.core.saving._load_state", new=_load_state)
     def load_from_checkpoint(
         cls,
-        checkpoint_path: _PATH | IO,
+        checkpoint_path: _PATH,
         map_location: _MAP_LOCATION_TYPE = None,
         hparams_file: _PATH | None = None,
         strict: bool = True,

--- a/cellarium/ml/core/pipeline.py
+++ b/cellarium/ml/core/pipeline.py
@@ -34,13 +34,15 @@ class CellariumPipeline(torch.nn.ModuleList):
     """
 
     def forward(self, batch: dict[str, np.ndarray | torch.Tensor]) -> dict[str, torch.Tensor | np.ndarray]:
+        from cellarium.ml import CellariumModule
+
         for module in self:
-            # get the module input keys
-            ann = module.forward.__annotations__
-            if "batch" in ann and len(ann) == 2:
+            if isinstance(module, CellariumModule):
                 # in case module is a CellariumModule, e.g. PCA checkpoint is used as a transform
                 batch |= module(batch)
             else:
+                # get the module input keys
+                ann = module.forward.__annotations__
                 input_keys = {key for key in ann if key != "return" and key in batch}
                 # allow all keys to be passed to the module
                 if "kwargs" in ann:

--- a/cellarium/ml/core/pipeline.py
+++ b/cellarium/ml/core/pipeline.py
@@ -37,11 +37,15 @@ class CellariumPipeline(torch.nn.ModuleList):
         for module in self:
             # get the module input keys
             ann = module.forward.__annotations__
-            input_keys = {key for key in ann if key != "return" and key in batch}
-            # allow all keys to be passed to the module
-            if "kwargs" in ann:
-                input_keys |= batch.keys()
-            batch |= module(**{key: batch[key] for key in input_keys})
+            if "batch" in ann and len(ann) == 2:
+                # in case module is a CellariumModule, e.g. PCA checkpoint is used as a transform
+                batch |= module(batch)
+            else:
+                input_keys = {key for key in ann if key != "return" and key in batch}
+                # allow all keys to be passed to the module
+                if "kwargs" in ann:
+                    input_keys |= batch.keys()
+                batch |= module(**{key: batch[key] for key in input_keys})
 
         return batch
 

--- a/cellarium/ml/data/dadc_dataset.py
+++ b/cellarium/ml/data/dadc_dataset.py
@@ -116,7 +116,7 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
 
     def __getitem__(self, idx: int | list[int] | slice) -> dict[str, np.ndarray]:
         r"""
-        Returns a dictionary containing the data from the :attr:`dadc` with keys specified by its :attr:`dadc.convert`
+        Returns a dictionary containing the data from the :attr:`dadc` with keys specified by the :attr:`batch_keys`
         at the given index ``idx``.
         """
 

--- a/cellarium/ml/models/incremental_pca.py
+++ b/cellarium/ml/models/incremental_pca.py
@@ -249,10 +249,12 @@ class IncrementalPCA(CellariumModel, PredictMixin):
         Returns:
             A dictionary with the following keys:
 
-            - ``z_nk``: Embedding of the input data into the principal component space.
+            - ``x_ng``: Embedding of the input data into the principal component space.
+            - ``var_names_g``: The list of variable names for the output data.
         """
         assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
         assert_arrays_equal("var_names_g", var_names_g, "var_names_g", self.var_names_g)
 
         z_nk = (x_ng - self.x_mean_g) @ self.V_kg.T
-        return {"z_nk": z_nk}
+        var_names_k = np.array([f"PC{i + 1}" for i in range(self.n_components)])
+        return {"x_ng": z_nk, "var_names_g": var_names_k}

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -114,7 +114,7 @@ def test_iterable_dataset_multi_device(
 
     # fit
     model = BoringModel()
-    module = CellariumModule(model)
+    module = CellariumModule(model=model)
     trainer = pl.Trainer(
         barebones=True,
         accelerator="cpu",
@@ -176,7 +176,7 @@ def test_iterable_dataset_set_epoch_multi_device(
 
     # fit
     model = BoringModel()
-    module = CellariumModule(model)
+    module = CellariumModule(model=model)
     trainer = pl.Trainer(
         barebones=True,
         accelerator="cpu",

--- a/tests/test_geneformer.py
+++ b/tests/test_geneformer.py
@@ -45,7 +45,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path):
             }
         }
     }
-    module = CellariumModule(model, config=config)
+    module = CellariumModule(model=model, config=config)
     # trainer
     trainer = pl.Trainer(
         accelerator="cpu",

--- a/tests/test_ipca.py
+++ b/tests/test_ipca.py
@@ -52,7 +52,7 @@ def test_incremental_pca_multi_device(x_ng: torch.Tensor, perform_mean_correctio
         n_components=k,
         perform_mean_correction=perform_mean_correction,
     )
-    module = CellariumModule(ipca)
+    module = CellariumModule(model=ipca)
     # trainer
     strategy = DDPStrategy(broadcast_buffers=False) if devices > 1 else "auto"
     trainer = pl.Trainer(
@@ -112,7 +112,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path):
             }
         }
     }
-    module = CellariumModule(model, config=config)
+    module = CellariumModule(model=model, config=config)
     # trainer
     strategy = DDPStrategy(broadcast_buffers=False) if devices > 1 else "auto"
     trainer = pl.Trainer(

--- a/tests/test_onepass_mean_var_std.py
+++ b/tests/test_onepass_mean_var_std.py
@@ -76,7 +76,7 @@ def test_onepass_mean_var_std_multi_device(
 
     # fit
     model = OnePassMeanVarStd(var_names_g=dadc.var_names)
-    module = CellariumModule(model, transforms=transforms)
+    module = CellariumModule(transforms=transforms, model=model)
     strategy = DDPStrategy(broadcast_buffers=False) if devices > 1 else "auto"
     trainer = pl.Trainer(
         barebones=True,
@@ -132,7 +132,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path):
             }
         }
     }
-    module = CellariumModule(model, config=config)
+    module = CellariumModule(model=model, config=config)
     # trainer
     strategy = DDPStrategy(broadcast_buffers=False) if devices > 1 else "auto"
     trainer = pl.Trainer(

--- a/tests/test_ppca.py
+++ b/tests/test_ppca.py
@@ -71,7 +71,7 @@ def test_probabilistic_pca_multi_device(
         sigma_init_scale=s,
     )
     module = CellariumModule(
-        ppca,
+        model=ppca,
         optim_fn=torch.optim.Adam,
         optim_kwargs={"lr": 3e-2},
         scheduler_fn=torch.optim.lr_scheduler.CosineAnnealingLR,
@@ -127,7 +127,7 @@ def test_variance_monitor(x_ng: np.ndarray):
     )
     # model
     ppca = ProbabilisticPCA(n, [f"gene_{i}" for i in range(g)], k, "marginalized")
-    module = CellariumModule(ppca)
+    module = CellariumModule(model=ppca)
     # trainer
     var_monitor = VarianceMonitor(total_variance=np.var(x_ng, axis=0).sum())
     trainer = pl.Trainer(
@@ -169,7 +169,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path):
             }
         }
     }
-    module = CellariumModule(model, config=config)
+    module = CellariumModule(model=model, config=config)
     # trainer
     trainer = pl.Trainer(
         accelerator="cpu",

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -85,7 +85,7 @@ def test_tdigest_multi_device(
 
     # fit
     model = TDigest(var_names_g=dadc.var_names)
-    module = CellariumModule(model, transforms=transforms)
+    module = CellariumModule(transforms=transforms, model=model)
     trainer = pl.Trainer(
         barebones=True,
         accelerator="cpu",
@@ -139,7 +139,7 @@ def test_load_from_checkpoint_multi_device():
             },
         }
     }
-    module = CellariumModule(model, config=config)
+    module = CellariumModule(model=model, config=config)
     # trainer
     trainer = pl.Trainer(
         accelerator="cpu",


### PR DESCRIPTION
- `compute_var_names_g` computes `var_names_g` by applying transforms to batch (of single cell) of data under fake mode (this ensures that no actual torch computation is performed)
- rename `get_n_categories` to `compute_n_categories`
- create `compute_n_obs` that is used instead of `n_obs` attribute in `CellariumAnnDataDataModule`
- use `LinkArguments` dataclass to pass args to `link_arguments`