### PR TITLE
reset_parameters update

### DIFF
--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -356,19 +356,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
             self.register_buffer("library_log_means", torch.from_numpy(library_log_means).float())
             self.register_buffer("library_log_vars", torch.from_numpy(library_log_vars).float())
 
-        if self.dispersion == "gene":
-            self.px_r = torch.nn.Parameter(torch.randn(self.n_input))
-        elif self.dispersion == "gene-label":
-            raise NotImplementedError
-            # self.px_r = torch.nn.Parameter(torch.randn(self.n_input, n_labels))
-        elif self.dispersion == "gene-cell":
-            self.px_r = torch.nn.Parameter(torch.zeros(1))  # dummy
-        else:
-            raise ValueError(
-                "dispersion must be one of ['gene', "
-                " 'gene-label', 'gene-cell'], but input was "
-                "{}".format(self.dispersion)
-            )
+        self.px_r = torch.nn.Parameter(torch.torch.empty(self.n_input))
 
         self.batch_representation = batch_representation
         if self.batch_representation == "embedding":
@@ -445,7 +433,19 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
     def reset_parameters(self) -> None:
         for m in self.modules():
             m.apply(weights_init)
-        torch.nn.init.normal_(self.px_r, mean=0.0, std=1.0)
+
+        if self.dispersion == "gene":
+            torch.nn.init.normal_(self.px_r, mean=0.0, std=1.0)
+        elif self.dispersion == "gene-label":
+            raise NotImplementedError
+        elif self.dispersion == "gene-cell":
+            torch.nn.init.zeros_(self.px_r)
+        else:
+            raise ValueError(
+                "dispersion must be one of ['gene', "
+                " 'gene-label', 'gene-cell'], but input was "
+                "{}".format(self.dispersion)
+            )
 
     def inference(
         self,

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -356,7 +356,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
             self.register_buffer("library_log_means", torch.from_numpy(library_log_means).float())
             self.register_buffer("library_log_vars", torch.from_numpy(library_log_vars).float())
 
-        self.px_r = torch.nn.Parameter(torch.torch.empty(self.n_input))
+        self.px_r = torch.nn.Parameter(torch.empty(self.n_input))
 
         self.batch_representation = batch_representation
         if self.batch_representation == "embedding":


### PR DESCRIPTION
All parameters should be initialized the same time when calling reset_parameters()

px_r is the only torch.nn.Parameters rather than a neural network. We could initialize px_r in weight_init. However, there are 3 options of initialization of px_r depending on the setup of dispersion. Moving initialization of px_r into weight_init makes the choice of initialization of px_r inflexible.