### PR TITLE
Fix README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,26 +15,21 @@ The code is organized as follows:
 
 - ``cellarium/ml/callbacks``: Contains custom PyTorch Lightning callbacks.
 - ``cellarium/ml/core``: Includes essential Cellarium ML components:
-  - ``CellariumModule``: A PyTorch Lightning Module tasked with defining and configuring the model,
-    training step, and optimizer.
-  - ``CellariumAnnDataDataModule``: A PyTorch Lightning DataModule designed for setting up a multi-GPU
-    DataLoader for a collection of AnnData objects.
+  - ``CellariumModule``: A PyTorch Lightning Module tasked with defining and configuring the model, training step, and optimizer.
+  - ``CellariumAnnDataDataModule``: A PyTorch Lightning DataModule designed for setting up a multi-GPU DataLoader for a collection of AnnData objects.
   - ``CellariumPipeline``: A Module List that pipes the input data through a series of transforms and a model.
 - ``cellarium/ml/data``: Contains Distributed AnnData Collection and multi-GPU Iterable Dataset implementations.
 - ``cellarium/ml/lr_schedulers``: Contains custom learning rate schedulers.
 - ``cellarium/ml/models``: Features Cellarium ML models:
   - Models must subclass ``CellariumModel`` and implement the ``.reset_parameters`` method.
   - The ``.forward`` method should return a dictionary containing the computed loss under the ``loss`` key.
-  - Optionally, hooks such as ``.on_train_start``, ``.on_epoch_end``, and ``.on_batch_end`` can be implemented
-    to be triggered by the ``CellariumModule`` during training phases.
+  - Optionally, hooks such as ``.on_train_start``, ``.on_epoch_end``, and ``.on_batch_end`` can be implemented to be triggered by the ``CellariumModule`` during training phases.
 - ``cellarium/ml/preprocessing``: Provides pre-processing functions.
 - ``cellarium/ml/transforms``: Contains data transformation modules:
   - Each transform is a subclass of ``torch.nn.Module``.
-  - The ``.forward`` method should output a dictionary where the keys correspond to the input arguments
-    of subsequent transforms and the model.
+  - The ``.forward`` method should output a dictionary where the keys correspond to the input arguments of subsequent transforms and the model.
 - ``cellarium/ml/utilities``: Contains utility functions for various submodules.
-- ``cellarium/ml/cli.py``: Implements the ``cellarium-ml`` CLI. Models must be registered here to be
-  accessible via the CLI.
+- ``cellarium/ml/cli.py``: Implements the ``cellarium-ml`` CLI. Models must be registered here to be accessible via the CLI.
 
 Installation
 ------------


### PR DESCRIPTION
Uploading to TestPyPI fails with the following message:

```
Checking dist/cellarium_ml-0.0.4.post12-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 19: Error: Unexpected indentation. 
```

This PR fixes indentation issue in the README file.