### PR TITLE
AnnDataSchema validate_anndata fix

### DIFF
--- a/cellarium/ml/data/schema.py
+++ b/cellarium/ml/data/schema.py
@@ -59,11 +59,19 @@ class AnnDataSchema:
                         ".obs attribute columns for anndata passed in does not match .obs attribute columns "
                         "of the reference anndata."
                     )
-                if not ref_value.dtypes.equals(value.dtypes):
-                    raise ValueError(
-                        ".obs attribute dtypes for anndata passed in does not match .obs attribute dtypes "
-                        "of the reference anndata."
-                    )
+                # compare dtypes
+                for col in ref_value.columns:
+                    if ref_value[col].dtype != value[col].dtype:
+                        if ref_value[col].dtype == "category":
+                            diff = set(ref_value[col].cat.categories).symmetric_difference(set(value[col].cat.categories))
+                            raise ValueError(
+                                f".obs['{col}'].cat.categories for anndata passed in "
+                                f"do not match those in the reference anndata. symmetric_differece: {diff}"
+                            )
+                        raise ValueError(
+                            f".obs['{col}'] dtype for anndata passed in {value[col].dtype} "
+                            f"does not match .obs['{col}'] dtype of the reference anndata {ref_value[col].dtype}"
+                        )
             elif attr in ["var", "var_names"]:
                 # For var compare if two DataFrames have the same shape and elements
                 # and the same row/column index.

--- a/cellarium/ml/data/schema.py
+++ b/cellarium/ml/data/schema.py
@@ -63,7 +63,9 @@ class AnnDataSchema:
                 for col in ref_value.columns:
                     if ref_value[col].dtype != value[col].dtype:
                         if ref_value[col].dtype == "category":
-                            diff = set(ref_value[col].cat.categories).symmetric_difference(set(value[col].cat.categories))
+                            diff = set(ref_value[col].cat.categories).symmetric_difference(
+                                set(value[col].cat.categories)
+                            )
                             raise ValueError(
                                 f".obs['{col}'].cat.categories for anndata passed in "
                                 f"do not match those in the reference anndata. symmetric_differece: {diff}"

--- a/cellarium/ml/data/schema.py
+++ b/cellarium/ml/data/schema.py
@@ -71,8 +71,8 @@ class AnnDataSchema:
                                 f"do not match those in the reference anndata. symmetric_differece: {diff}"
                             )
                         raise ValueError(
-                            f".obs['{col}'] dtype for anndata passed in {value[col].dtype} "
-                            f"does not match .obs['{col}'] dtype of the reference anndata {ref_value[col].dtype}"
+                            f".obs['{col}'] dtype for anndata passed in ({value[col].dtype}) "
+                            f"does not match .obs['{col}'] dtype of the reference anndata ({ref_value[col].dtype})"
                         )
             elif attr in ["var", "var_names"]:
                 # For var compare if two DataFrames have the same shape and elements

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -125,14 +125,14 @@ def change_adata(adata: AnnData, request: pytest.FixtureRequest):
 
     elif request.param == "change_obs_dtype":
         adata.obs["A"] = np.ones(n_cell)
-        err_msg = ".obs attribute dtypes for anndata passed in"
+        err_msg = r".obs.* dtype for anndata passed in"
 
     elif request.param == "change_obs_categories":
         adata.obs["C"] = pd.Categorical(
             np.array(["g", "h"])[np.random.randint(0, 2, n_cell)],
             categories=["g", "h"],
         )
-        err_msg = ".obs attribute dtypes for anndata passed in"
+        err_msg = r".obs.*categories for anndata passed in"
 
     return err_msg
 
@@ -163,7 +163,7 @@ def test_validate_obs_columns(
         schema = AnnDataSchema(ref_adata)
 
     if change_obs_categories and not subset_obs_columns:
-        with pytest.raises(ValueError, match=".obs attribute dtypes for anndata passed in"):
+        with pytest.raises(ValueError, match=r".obs.*categories for anndata passed in"):
             schema.validate_anndata(adata)
     else:
         schema.validate_anndata(adata)


### PR DESCRIPTION
Closes #179 

There was a problem with categoricals in obs where `dataframe.dtypes.equals(dataframe2.dtypes)` would say `False` even when it wasn't.

This solution looks uglier for sure, but I tried to include some helpful error messages for debugging.