### PR TITLE
Fix `GatherLayer.backward` and make the test more stringent

### DIFF
--- a/cellarium/ml/distributed/__init__.py
+++ b/cellarium/ml/distributed/__init__.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
 from cellarium.ml.distributed.gather import GatherLayer
 
 __all__ = [

--- a/cellarium/ml/distributed/gather.py
+++ b/cellarium/ml/distributed/gather.py
@@ -15,7 +15,7 @@ class GatherLayer(torch.autograd.Function):
         return tuple(output)
 
     @staticmethod
-    def backward(ctx, *grads) -> torch.Tensor:
-        grad_out = grads[dist.get_rank()].contiguous()
-        dist.all_reduce(grad_out, op=dist.ReduceOp.SUM)
-        return grad_out
+    def backward(ctx, *grads: torch.Tensor) -> torch.Tensor:
+        all_grads = torch.stack(grads)
+        dist.all_reduce(all_grads, op=dist.ReduceOp.SUM)
+        return all_grads[dist.get_rank()]


### PR DESCRIPTION
In `GatherLayer.backward` each gradient in `*grads` needs to be reduced across *all* ranks. Here is my initial fix that worked for `ContrastiveMLP`:

```py
    @staticmethod
    def backward(ctx, *grads) -> torch.Tensor:
        new_grads = []
        for grad in grads:
            grad = grad.contiguous()
            dist.all_reduce(grad, op=dist.ReduceOp.SUM)
            new_grads.append(grad)
        grad_out = new_grads[dist.get_rank()]
        return grad_out
```

Then we updated it to the current version (which select `grads[rank]` and then does reduction which then returns averaged `grad_out` for all ranks) but didn't test it using `ContrastiveMLP` model. The test in `test_gather.py` has passed because it was symmetric and not stringent enough. I have updated the test to be asymmetric across ranks which catches the bug in the current implementation. See discussion at https://github.com/lightly-ai/lightly/pull/1531 where I also borrowed stacking implementation instead of using for loop.
