### PR TITLE
Transforms split into before and after batch transfer

### DIFF
--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -39,7 +39,7 @@ class FileLoader:
     .. code-block:: yaml
 
         model:
-          transforms:
+          before_batch_transfer_transforms:
             - class_path: cellarium.ml.transforms.Filter
               init_args:
                 filter_list:

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -144,7 +144,7 @@ def register_model(model: Callable[[ArgsType], None]):
     return model
 
 
-CellariumModuleLoadFromCheckpoint = class_from_function(CellariumModule.load_from_checkpoint, CellariumModule)
+CellariumModuleLoadFromCheckpoint = class_from_function(CellariumModule.load_from_checkpoint, CellariumModule)  # type: ignore[arg-type]
 
 
 @dataclass

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -224,10 +224,8 @@ def compute_var_names_g(
     adata = data.dadc[0]
     batch = {key: field(adata) for key, field in data.batch_keys.items()}
     pipeline = CellariumPipeline(
-        {
-            "before_batch_transfer_transforms": before_batch_transfer_transforms,
-            "after_batch_transfer_transforms": after_batch_transfer_transforms,
-        }
+        before_batch_transfer_transforms=before_batch_transfer_transforms,
+        after_batch_transfer_transforms=after_batch_transfer_transforms,
     )
     with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
         fake_batch = collate_fn([batch])

--- a/cellarium/ml/core/pipeline.py
+++ b/cellarium/ml/core/pipeline.py
@@ -21,13 +21,13 @@ class CellariumPipeline(torch.nn.Module):
         >>> from cellarium.ml import CellariumPipeline
         >>> from cellarium.ml.transforms import Filter, NormalizeTotal, Log1p
         >>> from cellarium.ml.models import IncrementalPCA
-        >>> pipeline = CellariumPipeline({
-        ...     'before_batch_transfer_transforms': [Filter(filter_list=[f"gene_{i}" for i in range(20)])],
-        ...     'after_batch_transfer_transforms': [NormalizeTotal(), Log1p()],
-        ...     'model': IncrementalPCA(var_names_g=[f"gene_{i}" for i in range(20)], n_components=10),
-        ... })
+        >>> pipeline = CellariumPipeline(
+        ...     before_batch_transfer_transforms=[Filter(filter_list=[f"gene_{i}" for i in range(20)])],
+        ...     after_batch_transfer_transforms=[NormalizeTotal(), Log1p()],
+        ...     model=IncrementalPCA(var_names_g=[f"gene_{i}" for i in range(20)], n_components=10),
+        ... )
         >>> batch = {"x_ng": x_ng, "total_mrna_umis_n": total_mrna_umis_n, "var_names_g": var_names_g}
-        >>> output = pipeline(batch)  # or pipeline.predict(batch)
+        >>> output = pipeline.forward(batch)  # or pipeline.predict(batch)
 
     Args:
         modules:

--- a/cellarium/ml/models/logistic_regression.py
+++ b/cellarium/ml/models/logistic_regression.py
@@ -104,11 +104,11 @@ class LogisticRegression(CellariumModel, PredictMixin):
     def model(self, x_ng: torch.Tensor, y_n: torch.Tensor) -> None:
         W_gc = pyro.sample(
             "W",
-            dist.Laplace(0, self.W_prior_scale).expand([self.n_vars, self.n_categories]).to_event(2),
+            dist.Laplace(0, self.W_prior_scale).expand([self.n_vars, self.n_categories]).to_event(2),  # type: ignore[attr-defined]
         )
         with pyro.plate("batch", size=self.n_obs, subsample_size=x_ng.shape[0]):
             logits_nc = x_ng @ W_gc + self.b_c
-            pyro.sample("y", dist.Categorical(logits=logits_nc), obs=y_n)
+            pyro.sample("y", dist.Categorical(logits=logits_nc), obs=y_n)  # type: ignore[attr-defined]
 
     def guide(self, x_ng: torch.Tensor, y_n: torch.Tensor) -> None:
         pyro.sample("W", dist.Delta(self.W_gc).to_event(2))

--- a/cellarium/ml/models/probabilistic_pca.py
+++ b/cellarium/ml/models/probabilistic_pca.py
@@ -86,7 +86,7 @@ class ProbabilisticPCA(CellariumModel, PredictMixin):
         self.W_init_scale = W_init_scale
         self.sigma_init_scale = sigma_init_scale
         self.W_kg = torch.nn.Parameter(torch.empty(n_components, n_vars))
-        self.sigma = PyroParam(torch.empty(()), constraint=constraints.positive)
+        self.sigma = PyroParam(torch.empty(()), constraint=constraints.positive)  # type: ignore[call-arg]
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
@@ -120,7 +120,7 @@ class ProbabilisticPCA(CellariumModel, PredictMixin):
             if self.ppca_flavor == "marginalized":
                 pyro.sample(
                     "counts",
-                    dist.LowRankMultivariateNormal(
+                    dist.LowRankMultivariateNormal(  # type: ignore[attr-defined]
                         loc=self.mean_g,
                         cov_factor=self.W_kg.T,
                         cov_diag=self.sigma**2 * x_ng.new_ones(self.n_vars),  # type: ignore[operator]
@@ -130,11 +130,11 @@ class ProbabilisticPCA(CellariumModel, PredictMixin):
             else:
                 z_nk = pyro.sample(
                     "z",
-                    dist.Normal(x_ng.new_zeros(self.n_components), 1).to_event(1),
+                    dist.Normal(x_ng.new_zeros(self.n_components), 1).to_event(1),  # type: ignore[attr-defined]
                 )
                 pyro.sample(
                     "counts",
-                    dist.Normal(self.mean_g + z_nk @ self.W_kg, self.sigma).to_event(1),
+                    dist.Normal(self.mean_g + z_nk @ self.W_kg, self.sigma).to_event(1),  # type: ignore[attr-defined]
                     obs=x_ng,
                 )
 
@@ -145,7 +145,7 @@ class ProbabilisticPCA(CellariumModel, PredictMixin):
         with pyro.plate("cells", size=self.n_obs, subsample_size=x_ng.shape[0]):
             V_gk = torch.linalg.solve(self.M_kk, self.W_kg).T
             D_k = self.sigma / torch.sqrt(torch.diag(self.M_kk))
-            pyro.sample("z", dist.Normal((x_ng - self.mean_g) @ V_gk, D_k).to_event(1))
+            pyro.sample("z", dist.Normal((x_ng - self.mean_g) @ V_gk, D_k).to_event(1))  # type: ignore[attr-defined]
 
     def predict(self, x_ng: torch.Tensor, var_names_g: np.ndarray) -> dict[str, np.ndarray | torch.Tensor]:
         """

--- a/examples/cli_workflow/ipca_train_config.yaml
+++ b/examples/cli_workflow/ipca_train_config.yaml
@@ -57,7 +57,7 @@ trainer:
   reload_dataloaders_every_n_epochs: 0
   default_root_dir: /tmp/test_examples/ipca
 model:
-  transforms:
+  after_batch_transfer_transforms:
     - class_path: cellarium.ml.transforms.NormalizeTotal
       init_args:
         target_count: 10_000

--- a/examples/cli_workflow/lr_train_config.yaml
+++ b/examples/cli_workflow/lr_train_config.yaml
@@ -41,7 +41,7 @@ trainer:
   reload_dataloaders_every_n_epochs: 0
   default_root_dir: /tmp/test_examples/lr
 model:
-  transforms:
+  after_batch_transfer_transforms:
     - !CheckpointLoader
       file_path: /tmp/test_examples/ipca/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
       attr: null

--- a/examples/cli_workflow/onepass_train_config.yaml
+++ b/examples/cli_workflow/onepass_train_config.yaml
@@ -57,7 +57,7 @@ trainer:
   reload_dataloaders_every_n_epochs: 0
   default_root_dir: /tmp/test_examples/onepass
 model:
-  transforms:
+  after_batch_transfer_transforms:
     - class_path: cellarium.ml.transforms.NormalizeTotal
       init_args:
         target_count: 10_000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "google-cloud-storage",
   "jsonargparse[signatures]==4.27.7",
   "lightning>=2.2.0",
+  "numpy<=1.26.4",
   "pyro-ppl>=1.9.1",
   "pytest",
   "torch>=2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "anndata",
   "boltons",
   "braceexpand",
-  "crick>=0.0.4",
+  "crick==0.0.5",
   "google-cloud-storage",
   "jsonargparse[signatures]==4.27.7",
   "lightning>=2.2.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,7 +454,9 @@ CONFIGS = [
 
 
 @pytest.mark.parametrize(
-    "config", CONFIGS, ids=[config["model_name"] + "-" + config["subcommand"] for config in CONFIGS]
+    "config",
+    CONFIGS,
+    ids=[config["model_name"] + "-" + config["subcommand"] for config in CONFIGS],  # type: ignore[operator]
 )
 def test_cpu_multi_device(config: dict[str, Any]):
     if config["subcommand"] == "predict":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -130,6 +130,14 @@ def test_transform_integration(tmp_path: Path, filter_before_transfer: bool) -> 
     print(transformed_data_during_training)
     torch.testing.assert_allclose(transformed_data_during_training, expected_transformed_data)
 
+    # CellariumModule.forward()
+    with pytest.raises(AttributeError):
+        # BoringModel() has no predict method, which is what is called by module.forward
+        module.forward({"x_ng": torch.tensor(x_ng.todense()), "var_names_g": var_names_g})
+
+    # CellariumPipeline.forward()
+    module.pipeline.forward({"x_ng": torch.tensor(x_ng.todense()), "var_names_g": var_names_g})  # type: ignore[union-attr]
+
     # ensure training runs
     trainer = pl.Trainer(accelerator="cpu", devices=1, max_steps=1, default_root_dir=tmp_path)
     trainer.fit(module, datamodule)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -87,8 +87,8 @@ def test_transform_integration(tmp_path: Path, filter_before_transfer: bool) -> 
     var_name_list = ["ENSG00000078808", "ENSG00000272106", "ENSG00000162585"]
     filter_transform = Filter(var_name_list)
     if filter_before_transfer:
-        before_transforms = [filter_transform]
-        after_transforms = [Log1p()]
+        before_transforms: list[torch.nn.Module] = [filter_transform]
+        after_transforms: list[torch.nn.Module] = [Log1p()]
     else:
         before_transforms = []
         after_transforms = [filter_transform, Log1p()]
@@ -113,7 +113,7 @@ def test_transform_integration(tmp_path: Path, filter_before_transfer: bool) -> 
     assert expected_transformed_data.shape == (batch_size, len(var_name_list))
 
     # CellariumPipeline.transform()
-    transformed_data = module.pipeline.transform({"x_ng": torch.tensor(x_ng.todense()), "var_names_g": var_names_g})[
+    transformed_data = module.pipeline.transform({"x_ng": torch.tensor(x_ng.todense()), "var_names_g": var_names_g})[  # type: ignore[union-attr]
         "x_ng"
     ]
     print(transformed_data)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,7 +36,7 @@ def test_datamodule(tmp_path: Path, batch_size: int | None) -> None:
     kwargs = {"dadc": adata}
     if batch_size is not None:
         kwargs["batch_size"] = batch_size
-    loaded_datamodule = CellariumAnnDataDataModule.load_from_checkpoint(ckpt_path, **kwargs)
+    loaded_datamodule = CellariumAnnDataDataModule.load_from_checkpoint(ckpt_path, **kwargs)  # type: ignore[operator]
 
     assert loaded_datamodule.batch_keys == datamodule.batch_keys
     assert loaded_datamodule.batch_size == batch_size or datamodule.batch_size

--- a/tests/test_geneformer.py
+++ b/tests/test_geneformer.py
@@ -55,7 +55,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path):
     # load model from checkpoint
     ckpt_path = tmp_path / f"lightning_logs/version_0/checkpoints/epoch=0-step={math.ceil(n / devices)}.ckpt"
     assert ckpt_path.is_file()
-    loaded_model: Geneformer = CellariumModule.load_from_checkpoint(ckpt_path).model
+    loaded_model: Geneformer = CellariumModule.load_from_checkpoint(ckpt_path).model  # type: ignore[operator]
     # assert
     assert np.array_equal(model.var_names_g, loaded_model.var_names_g)
     np.testing.assert_allclose(model.feature_ids, loaded_model.feature_ids)

--- a/tests/test_ipca.py
+++ b/tests/test_ipca.py
@@ -125,7 +125,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path):
     # load model from checkpoint
     ckpt_path = tmp_path / f"lightning_logs/version_0/checkpoints/epoch=0-step={math.ceil(n / devices)}.ckpt"
     assert ckpt_path.is_file()
-    loaded_model: IncrementalPCA = CellariumModule.load_from_checkpoint(ckpt_path).model
+    loaded_model: IncrementalPCA = CellariumModule.load_from_checkpoint(ckpt_path).model  # type: ignore[operator]
     # assert
     np.testing.assert_allclose(model.V_kg.detach(), loaded_model.V_kg.detach())
     np.testing.assert_allclose(model.S_k.detach(), loaded_model.S_k.detach())

--- a/tests/test_onepass_mean_var_std.py
+++ b/tests/test_onepass_mean_var_std.py
@@ -148,7 +148,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path, algorithm: Literal["n
     # load model from checkpoint
     ckpt_path = tmp_path / f"lightning_logs/version_0/checkpoints/epoch=0-step={math.ceil(n / devices)}.ckpt"
     assert ckpt_path.is_file()
-    loaded_model: OnePassMeanVarStd = CellariumModule.load_from_checkpoint(ckpt_path).model
+    loaded_model: OnePassMeanVarStd = CellariumModule.load_from_checkpoint(ckpt_path).model  # type: ignore[operator]
     # assert
     np.testing.assert_allclose(model.mean_g, loaded_model.mean_g, atol=1e-6)
     np.testing.assert_allclose(model.var_g, loaded_model.var_g, atol=1e-6)

--- a/tests/test_onepass_mean_var_std.py
+++ b/tests/test_onepass_mean_var_std.py
@@ -79,7 +79,7 @@ def test_onepass_mean_var_std_multi_device(
 
     # fit
     model = OnePassMeanVarStd(var_names_g=dadc.var_names, algorithm=algorithm)
-    module = CellariumModule(transforms=transforms, model=model)
+    module = CellariumModule(after_batch_transfer_transforms=transforms, model=model)
     strategy = DDPStrategy(broadcast_buffers=False) if devices > 1 else "auto"
     trainer = pl.Trainer(
         barebones=True,

--- a/tests/test_ppca.py
+++ b/tests/test_ppca.py
@@ -180,7 +180,7 @@ def test_load_from_checkpoint_multi_device(tmp_path: Path):
     # load model from checkpoint
     ckpt_path = tmp_path / f"lightning_logs/version_0/checkpoints/epoch=0-step={math.ceil(n / devices)}.ckpt"
     assert ckpt_path.is_file()
-    loaded_model: ProbabilisticPCA = CellariumModule.load_from_checkpoint(ckpt_path).model
+    loaded_model: ProbabilisticPCA = CellariumModule.load_from_checkpoint(ckpt_path).model  # type: ignore[operator]
     # assert
     np.testing.assert_allclose(model.W_kg.detach(), loaded_model.W_kg.detach())
     np.testing.assert_allclose(model.sigma.detach(), loaded_model.sigma.detach())  # type: ignore[attr-defined]

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -149,7 +149,7 @@ def test_load_from_checkpoint_multi_device():
     # load model from checkpoint
     ckpt_path = tmp_path / f"lightning_logs/version_0/checkpoints/epoch=0-step={math.ceil(n / devices)}.ckpt"
     assert ckpt_path.is_file()
-    loaded_model: TDigest = CellariumModule.load_from_checkpoint(ckpt_path).model
+    loaded_model: TDigest = CellariumModule.load_from_checkpoint(ckpt_path).model  # type: ignore[operator]
     # assert
     np.testing.assert_allclose(model.median_g, loaded_model.median_g)
 

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -85,7 +85,7 @@ def test_tdigest_multi_device(
 
     # fit
     model = TDigest(var_names_g=dadc.var_names)
-    module = CellariumModule(transforms=transforms, model=model)
+    module = CellariumModule(after_batch_transfer_transforms=transforms, model=model)
     trainer = pl.Trainer(
         barebones=True,
         accelerator="cpu",

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -28,11 +28,13 @@ def log_normalize(x_ng: torch.Tensor):
     std_g = y_ng.std(dim=0)
     var_names_g = np.array([f"gene_{i}" for i in range(g)])
     transform = CellariumPipeline(
-        [
-            NormalizeTotal(target_count),
-            Log1p(),
-            ZScore(mean_g, std_g, var_names_g),
-        ]
+        {
+            "after_batch_transfer_transforms": [
+                NormalizeTotal(target_count),
+                Log1p(),
+                ZScore(mean_g, std_g, var_names_g),
+            ]
+        }
     )
     return transform
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -28,13 +28,11 @@ def log_normalize(x_ng: torch.Tensor):
     std_g = y_ng.std(dim=0)
     var_names_g = np.array([f"gene_{i}" for i in range(g)])
     transform = CellariumPipeline(
-        {
-            "after_batch_transfer_transforms": [
-                NormalizeTotal(target_count),
-                Log1p(),
-                ZScore(mean_g, std_g, var_names_g),
-            ]
-        }
+        after_batch_transfer_transforms=[
+            NormalizeTotal(target_count),
+            Log1p(),
+            ZScore(mean_g, std_g, var_names_g),
+        ]
     )
     return transform
 


### PR DESCRIPTION
Addresses the issue discussed in #204 , so that `Filter` (or any transform) can be applied on CPU before data is transferred to GPU.

Transforms are now implemented in two categories:
1. those that happen before transfer to device
2. those that happen after transfer to device

The config file will need to change a bit: instead of 
```
model:
  transforms:
    - class_path: cellarium.ml.transforms.NormalizeTotal
      init_args:
        target_count: 10_000
    - cellarium.ml.transforms.Log1p
```
you will need to write
```
model:
  after_batch_transfer_transforms:
    - class_path: cellarium.ml.transforms.NormalizeTotal
      init_args:
        target_count: 10_000
    - cellarium.ml.transforms.Log1p
```
and optionally you could do something like
```
model:
  before_batch_transfer_transforms:
    - class_path: cellarium.ml.transforms.Filter
      init_args:
        filter_list: ['gene1', 'gene2', 'gene3']
  after_batch_transfer_transforms:
    - class_path: cellarium.ml.transforms.NormalizeTotal
      init_args:
        target_count: 10_000
    - cellarium.ml.transforms.Log1p
```

Training now makes use of pytorch lightning hooks `on_before_batch_transfer()` and `on_after_batch_transfer()` to apply all transforms before the `batch` is passed to the `training_step()`.  The `training_step()` now only calls `forward()` on the model, and is not responsible for applying the transforms.

There are methods implemented in `CellariumPipeline` which still allow an entire pipeline to be applied to a dataset, say from the context of an interactive jupyter notebook.