### PR TITLE
Allow deep (nested) attributes in `AnnDataField`

### DIFF
--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -10,6 +10,7 @@ This module contains helper functions for data loading and processing.
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from operator import attrgetter
 from typing import Any
 
 import numpy as np
@@ -56,7 +57,7 @@ class AnnDataField:
     convert_fn: Callable[[Any], np.ndarray] | None = None
 
     def __call__(self, adata: AnnData) -> np.ndarray:
-        value = getattr(adata, self.attr)
+        value = attrgetter(self.attr)(adata)
         if self.key is not None:
             value = value[self.key]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "google-cloud-storage",
   "jsonargparse[signatures]==4.27.7",
   "lightning>=2.2.0",
+  "numpy<=1.26.4",
   "pyro-ppl>=1.9.1",
   "pytest",
   "torch>=2.2.0",
@@ -38,7 +39,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 lint = ["ruff"]
-mypy = ["mypy", "types-PyYAML"]
+mypy = ["mypy==1.10.0", "types-PyYAML"]
 test = [
   "pytest-xdist",
   "tensorboard",


### PR DESCRIPTION
This PR adds a change to `AnnDataField` to allow deep (nested) attributes:

```py
batch_keys = {
    "x_ng": AnnDataField(attr="raw.X")
}
```