### PR TITLE
Change `IncrementalPCA` default to `perform_mean_correction=True`

### DIFF
--- a/cellarium/ml/models/incremental_pca.py
+++ b/cellarium/ml/models/incremental_pca.py
@@ -46,7 +46,7 @@ class IncrementalPCA(CellariumModel, PredictMixin):
         var_names_g: np.ndarray,
         n_components: int,
         svd_lowrank_niter: int = 2,
-        perform_mean_correction: bool = False,
+        perform_mean_correction: bool = True,
     ) -> None:
         super().__init__()
         self.var_names_g = var_names_g

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "google-cloud-storage",
   "jsonargparse[signatures]==4.27.7",
   "lightning>=2.2.0",
+  "numpy<=1.26.4",
   "pyro-ppl>=1.9.1",
   "pytest",
   "torch>=2.2.0",
@@ -38,7 +39,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 lint = ["ruff"]
-mypy = ["mypy", "types-PyYAML"]
+mypy = ["mypy==1.10.0", "types-PyYAML"]
 test = [
   "pytest-xdist",
   "tensorboard",


### PR DESCRIPTION
`perform_mean_correction=True` default makes more sense. If the data is not centered then mean correction is necessary. If the data is not centered then mean correction is not necessary but doing mean correction doesn't result in a wrong model.