### PR TITLE
Fix pandas groupby FutureWarning

### DIFF
--- a/cellarium/ml/preprocessing/highly_variable_genes.py
+++ b/cellarium/ml/preprocessing/highly_variable_genes.py
@@ -70,7 +70,7 @@ def get_highly_variable_genes(
     df["means"] = mean
     df["dispersions"] = dispersion
     df["mean_bin"] = pd.cut(df["means"], bins=n_bins)
-    disp_grouped = df.groupby("mean_bin")["dispersions"]
+    disp_grouped = df.groupby("mean_bin", observed=False)["dispersions"]
     disp_mean_bin = disp_grouped.mean()
     disp_std_bin = disp_grouped.std(ddof=1)
     df.index = gene_names


### PR DESCRIPTION
Closes #216 

I have seen this warning before.  `pandas` is going to change the default behavior of groupby.  If you do not have all categories present in the grouping categorical (i.e. you have "unused" categories), then the new behavior will be to drop the unused categories.  Here, I think you want to keep all the categories (which is the current behavior, `observed=False`).  I suggest pinning to the current behavior, which will also silence this warning.