### PR TITLE
Fix `drop_incomplete_batch`

### DIFF
--- a/cellarium/ml/core/datamodule.py
+++ b/cellarium/ml/core/datamodule.py
@@ -67,6 +67,9 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             to make it evenly divisible across the number of replicas. If ``False``,
             the sampler will add extra indices to make the data evenly divisible across
             the replicas.
+        drop_incomplete_batch:
+            If ``True``, the dataloader will drop the incomplete batch if the dataset size is not divisible by
+            the batch size.
         train_size:
             Size of the train split. If :class:`float`, should be between ``0.0`` and ``1.0`` and represent
             the proportion of the dataset to include in the train split. If :class:`int`, represents
@@ -81,9 +84,6 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             If ``True`` enables tracking of cache and worker informations.
         num_workers:
             How many subprocesses to use for data loading. ``0`` means that the data will be loaded in the main process.
-        drop_last_batch:
-            If ``True``, the dataloader will drop the last incomplete batch if the dataset size is not divisible by
-            the batch size.
         prefetch_factor:
             Number of batches loaded in advance by each worker. 2 means there will be a total of 2 * num_workers batches
             prefetched across all workers. (default value depends on the set value for num_workers. If value of
@@ -103,12 +103,12 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
         shuffle: bool = False,
         seed: int = 0,
         drop_last_indices: bool = False,
+        drop_incomplete_batch: bool = False,
         train_size: float | int | None = None,
         val_size: float | int | None = None,
         test_mode: bool = False,
         # DataLoader args
         num_workers: int = 0,
-        drop_last_batch: bool = False,
         prefetch_factor: int | None = None,
         persistent_workers: bool = False,
     ) -> None:
@@ -130,7 +130,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
         # DataLoader args
         self.num_workers = num_workers
         self.collate_fn = collate_fn
-        self.drop_last_batch = drop_last_batch
+        self.drop_incomplete_batch = drop_incomplete_batch
         self.prefetch_factor = prefetch_factor
         self.persistent_workers = persistent_workers
 
@@ -151,7 +151,8 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
                 iteration_strategy=self.iteration_strategy,
                 shuffle=self.shuffle,
                 seed=self.seed,
-                drop_last=self.drop_last_indices,
+                drop_last_indices=self.drop_last_indices,
+                drop_incomplete_batch=self.drop_incomplete_batch,
                 test_mode=self.test_mode,
                 start_idx=0,
                 end_idx=self.n_train,
@@ -163,7 +164,8 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
                 iteration_strategy="same_order",
                 shuffle=False,
                 seed=self.seed,
-                drop_last=False,
+                drop_last_indices=self.drop_last_indices,
+                drop_incomplete_batch=self.drop_incomplete_batch,
                 test_mode=self.test_mode,
                 start_idx=self.n_train,
                 end_idx=self.n_train + self.n_val,
@@ -177,7 +179,8 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
                 iteration_strategy=self.iteration_strategy,
                 shuffle=self.shuffle,
                 seed=self.seed,
-                drop_last=self.drop_last_indices,
+                drop_last_indices=self.drop_last_indices,
+                drop_incomplete_batch=self.drop_incomplete_batch,
                 test_mode=self.test_mode,
             )
 
@@ -187,7 +190,6 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             self.train_dataset,
             num_workers=self.num_workers,
             collate_fn=self.collate_fn,
-            drop_last=self.drop_last_batch,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
         )
@@ -198,7 +200,6 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             self.val_dataset,
             num_workers=self.num_workers,
             collate_fn=self.collate_fn,
-            drop_last=self.drop_last_batch,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
         )
@@ -209,7 +210,6 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             self.predict_dataset,
             num_workers=self.num_workers,
             collate_fn=self.collate_fn,
-            drop_last=self.drop_last_batch,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
         )

--- a/cellarium/ml/data/dadc_dataset.py
+++ b/cellarium/ml/data/dadc_dataset.py
@@ -75,11 +75,14 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
             If ``True``, the data is reshuffled at every epoch.
         seed:
             Random seed used to shuffle the sampler if :attr:`shuffle=True`.
-        drop_last:
+        drop_last_indices:
             If ``True``, then the sampler will drop the tail of the data
             to make it evenly divisible across the number of replicas. If ``False``,
             the sampler will add extra indices to make the data evenly divisible across
             the replicas.
+        drop_incomplete_batch:
+            If ``True``, the dataloader will drop the incomplete batch if the dataset size is not divisible by
+            the batch size.
         start_idx:
             The starting index of the dataset. If ``None``, then the dataset will start from the first index.
         end_idx:
@@ -97,7 +100,8 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
         iteration_strategy: Literal["same_order", "cache_efficient"] = "cache_efficient",
         shuffle: bool = False,
         seed: int = 0,
-        drop_last: bool = False,
+        drop_last_indices: bool = False,
+        drop_incomplete_batch: bool = False,
         start_idx: int | None = None,
         end_idx: int | None = None,
         test_mode: bool = False,
@@ -111,7 +115,8 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
         self.iteration_strategy = iteration_strategy
         self.shuffle = shuffle
         self.seed = seed
-        self.drop_last = drop_last
+        self.drop_last_indices = drop_last_indices
+        self.drop_incomplete_batch = drop_incomplete_batch
         self.start_idx = 0 if start_idx is None else start_idx
         self.end_idx = dadc.n_obs if end_idx is None else end_idx
         self.epoch = 0
@@ -124,13 +129,18 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
         _, num_replicas = get_rank_and_num_replicas()
 
         n_obs = self.end_idx - self.start_idx
-        if self.drop_last and n_obs % num_replicas != 0:
+        if self.drop_last_indices and n_obs % num_replicas != 0:
             # Split to nearest available length that is evenly divisible.
             # This is to ensure each rank receives the same amount of data.
             per_replica = n_obs // num_replicas
         else:
             per_replica = math.ceil(n_obs / num_replicas)
-        return math.ceil(per_replica / float(self.batch_size))
+
+        if self.drop_incomplete_batch:
+            batches_per_replica = per_replica // self.batch_size
+        else:
+            batches_per_replica = math.ceil(per_replica / float(self.batch_size))
+        return batches_per_replica
 
     def set_epoch(self, epoch: int) -> None:
         r"""
@@ -166,7 +176,7 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
     def __iter__(self):
         r"""
         Iterate through the dataset by trying to minimize the amount of anndata files fetched by each worker.
-        Iterated indices are evenly divided between replicas (see :attr:`drop_last`).
+        Iterated indices are evenly divided between replicas (see :attr:`drop_last_indices`).
 
         .. note::
 
@@ -263,9 +273,37 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
 
         **Example 4**::
 
+            indices=[0, 1, 2, 3, 4, 5, 6, 7]
+            num_replicas=1
+            batch_size=3
+            drop_incomplete_batch=True
+            num_workers=2
+
+        Same order:
+
+        +------------+---------+---------+
+        | batch idx  | 0       | 1       |
+        +============+=========+=========+
+        | indices    | (0,1,2) | (3,4,5) |
+        +------------+---------+---------+
+        | worker id  | 0       | 1       |
+        +------------+---------+---------+
+
+        Cache efficient:
+
+        +------------+---------+---------+
+        | batch idx  | 0       | 2       |
+        +============+=========+=========+
+        | indices    | (0,1,2) | (3,4,5) |
+        +------------+---------+---------+
+        | worker id  | 0       | 0       |
+        +------------+---------+---------+
+
+        **Example 5**::
+
             indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             num_replicas=2
-            drop_last=True
+            drop_last_indices=True
             batch_size=2
             num_workers=1
 
@@ -314,11 +352,11 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
         +------------+-------+-------+------+
 
 
-        **Example 5**::
+        **Example 6**::
 
             indices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             num_replicas=2
-            drop_last=False
+            drop_last_indices=False
             batch_size=2
             num_workers=1
 
@@ -373,12 +411,13 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
         # replicas
         rank, num_replicas = get_rank_and_num_replicas()
 
-        if self.drop_last and len(self.dadc) % num_replicas != 0:
+        n_obs = self.end_idx - self.start_idx
+        if self.drop_last_indices and n_obs % num_replicas != 0:
             # Split to nearest available length that is evenly divisible.
             # This is to ensure each rank receives the same amount of data.
-            per_replica = len(self.dadc) // num_replicas
+            per_replica = n_obs // num_replicas
         else:
-            per_replica = math.ceil(len(self.dadc) / num_replicas)
+            per_replica = math.ceil(n_obs / num_replicas)
         total_size = per_replica * num_replicas
 
         # workers
@@ -400,7 +439,7 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
         else:
             indices = list(range(self.start_idx, self.end_idx))
 
-        if not self.drop_last:
+        if not self.drop_last_indices:
             # add extra samples to make it evenly divisible
             padding_size = total_size - len(indices)
             if padding_size <= len(indices):
@@ -422,6 +461,8 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
 
             # in python 3.12 `chunked_iter` can be replaced with `itertools.batched`
             for batch_indices in islice(chunked_iter(indices, self.batch_size), worker_id, None, num_workers):
+                if self.drop_incomplete_batch and len(batch_indices) < self.batch_size:
+                    continue
                 yield self[batch_indices]
 
         elif self.iteration_strategy == "cache_efficient":
@@ -444,6 +485,8 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
 
             # in python 3.12 `chunked_iter` can be replaced with `itertools.batched`
             for batch_indices in chunked_iter(indices, self.batch_size):
+                if self.drop_incomplete_batch and len(batch_indices) < self.batch_size:
+                    continue
                 yield self[batch_indices]
 
         # Sets epoch for persistent workers

--- a/examples/cli_workflow/ipca_train_config.yaml
+++ b/examples/cli_workflow/ipca_train_config.yaml
@@ -121,9 +121,9 @@ data:
   shuffle: false
   seed: 0
   drop_last_indices: false
+  drop_incomplete_batch: false
   test_mode: false
   num_workers: 2
-  drop_last_batch: false
   prefetch_factor: null
   persistent_workers: false
 ckpt_path: null

--- a/examples/cli_workflow/lr_train_config.yaml
+++ b/examples/cli_workflow/lr_train_config.yaml
@@ -99,9 +99,9 @@ data:
   shuffle: false
   seed: 0
   drop_last_indices: false
+  drop_incomplete_batch: false
   test_mode: false
   num_workers: 2
-  drop_last_batch: false
   prefetch_factor: null
   persistent_workers: false
 ckpt_path: null

--- a/examples/cli_workflow/onepass_train_config.yaml
+++ b/examples/cli_workflow/onepass_train_config.yaml
@@ -102,9 +102,9 @@ data:
   shuffle: false
   seed: 0
   drop_last_indices: false
+  drop_incomplete_batch: false
   test_mode: false
   num_workers: 2
-  drop_last_batch: false
   prefetch_factor: null
   persistent_workers: false
 ckpt_path: null


### PR DESCRIPTION
- When batch sampler is used then `drop_last_batch` must be handled by the sampler rather than the dataloader. See for example https://pytorch.org/docs/stable/data.html#torch.utils.data.BatchSampler
- For `cache_efficient` strategy dropped batch is not always the last one. Therefore a better name might be `drop_incomplete_batch`.
- Updated the test to include `drop_last_indices`, `drop_incomplete_batch`, and `start_idx` and `end_idx`.