### PR TITLE
Fix Index import for the new version of anndata

### DIFF
--- a/cellarium/ml/data/distributed_anndata.py
+++ b/cellarium/ml/data/distributed_anndata.py
@@ -8,7 +8,8 @@ from contextlib import contextmanager
 import numpy as np
 import pandas as pd
 from anndata import AnnData, concat
-from anndata._core.index import Index, Index1D, _normalize_indices
+from anndata._core.index import _normalize_indices
+from anndata.compat import Index, Index1D
 from anndata.experimental.multi_files._anncollection import (
     AnnCollection,
     AnnCollectionView,


### PR DESCRIPTION
In the new version of anndata `Index` and  `Index1D` need to be imported directly from their original module `anndata.compat`. We were importing them from `anndata._core.index` which imports from `anndata.compat`. But in the new version of anndata `TYPE_CHECKING` clause was added before the import statement.