### PR TITLE
Allow nested `batch_keys`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ runs/
 .mypy_cache/
 .ruff_cache/
 .pytest_cache/
+.vscode/
 docs/build/
 docs/source/examples/
 docs/source/tutorials/

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -22,9 +22,10 @@ from jsonargparse._loaders_dumpers import DefaultLoader
 from jsonargparse._util import import_object
 from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCLI
 from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
+from torch.utils._pytree import tree_map
 
 from cellarium.ml import CellariumAnnDataDataModule, CellariumModule, CellariumPipeline
-from cellarium.ml.utilities.data import collate_fn
+from cellarium.ml.utilities.data import AnnDataField, collate_fn
 
 cached_loaders = {}
 
@@ -199,6 +200,7 @@ def compute_y_categories(data: CellariumAnnDataDataModule) -> np.ndarray:
     """
     adata = data.dadc[0]
     field = data.batch_keys["y_categories"]
+    assert isinstance(field, AnnDataField)
     return field(adata)
 
 
@@ -222,7 +224,7 @@ def compute_var_names_g(
         The variable names.
     """
     adata = data.dadc[0]
-    batch = {key: field(adata) for key, field in data.batch_keys.items()}
+    batch = tree_map(lambda field: field(adata), data.batch_keys)
     pipeline = CellariumPipeline(cpu_transforms) + CellariumPipeline(transforms)
     with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
         fake_batch = collate_fn([batch])

--- a/cellarium/ml/core/datamodule.py
+++ b/cellarium/ml/core/datamodule.py
@@ -37,7 +37,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
         ...     iteration_strategy="cache_efficient",
         ...     shuffle=True,
         ...     seed=0,
-        ...     drop_last=True,
+        ...     drop_last_indices=True,
         ...     num_workers=4,
         ... )
         >>> dm.setup()
@@ -97,7 +97,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
         self,
         dadc: DistributedAnnDataCollection | AnnData,
         # IterableDistributedAnnDataCollectionDataset args
-        batch_keys: dict[str, AnnDataField] | None = None,
+        batch_keys: dict[str, dict[str, AnnDataField] | AnnDataField] | None = None,
         batch_size: int = 1,
         iteration_strategy: Literal["same_order", "cache_efficient"] = "cache_efficient",
         shuffle: bool = False,

--- a/cellarium/ml/core/module.py
+++ b/cellarium/ml/core/module.py
@@ -219,7 +219,7 @@ class CellariumModule(pl.LightningModule):
         return self.pipeline if self._cpu_transforms_in_module_pipeline else self.pipeline[self._num_cpu_transforms :]
 
     def training_step(  # type: ignore[override]
-        self, batch: dict[str, np.ndarray | torch.Tensor], batch_idx: int
+        self, batch: dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor], batch_idx: int
     ) -> torch.Tensor | None:
         """
         Forward pass for training step.
@@ -251,7 +251,9 @@ class CellariumModule(pl.LightningModule):
 
         return loss
 
-    def forward(self, batch: dict[str, np.ndarray | torch.Tensor]) -> dict[str, np.ndarray | torch.Tensor]:
+    def forward(
+        self, batch: dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]
+    ) -> dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]:
         """
         Forward pass for inference step.
 

--- a/cellarium/ml/core/pipeline.py
+++ b/cellarium/ml/core/pipeline.py
@@ -41,13 +41,17 @@ class CellariumPipeline(torch.nn.ModuleList):
     def __add__(self, other: Iterable[torch.nn.Module]) -> Self:
         return self.__class__(chain(self, other))
 
-    def forward(self, batch: dict[str, np.ndarray | torch.Tensor]) -> dict[str, torch.Tensor | np.ndarray]:
+    def forward(
+        self, batch: dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]
+    ) -> dict[str, dict[str, np.ndarray | torch.Tensor] | torch.Tensor | np.ndarray]:
         for module in self:
             batch |= call_func_with_batch(module.forward, batch)
 
         return batch
 
-    def predict(self, batch: dict[str, np.ndarray | torch.Tensor]) -> dict[str, np.ndarray | torch.Tensor]:
+    def predict(
+        self, batch: dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]
+    ) -> dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]:
         for module in self[:-1]:
             batch |= call_func_with_batch(module.forward, batch)
 
@@ -58,7 +62,7 @@ class CellariumPipeline(torch.nn.ModuleList):
 
         return batch
 
-    def validate(self, batch: dict[str, np.ndarray | torch.Tensor]) -> None:
+    def validate(self, batch: dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]) -> None:
         for module in self[:-1]:
             batch |= call_func_with_batch(module.forward, batch)
 

--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -18,6 +18,7 @@ import pandas as pd
 import scipy
 import torch
 from anndata import AnnData
+from torch.utils._pytree import tree_map
 
 
 @dataclass
@@ -69,7 +70,15 @@ class AnnDataField:
         return value
 
 
-def collate_fn(batch: list[dict[str, np.ndarray]]) -> dict[str, np.ndarray | torch.Tensor]:
+def convert_to_tensor(value: np.ndarray) -> np.ndarray | torch.Tensor:
+    if np.issubdtype(value.dtype, np.str_) or np.issubdtype(value.dtype, np.object_):
+        return value
+    return torch.tensor(value, device="cpu")
+
+
+def collate_fn(
+    batch: list[dict[str, dict[str, np.ndarray] | np.ndarray]],
+) -> dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]:
     """
     Collate function for the ``DataLoader``. This function assumes that the batch is a list of
     dictionaries, where each dictionary has the same keys. If the key ends with ``_g`` or
@@ -86,26 +95,28 @@ def collate_fn(batch: list[dict[str, np.ndarray]]) -> dict[str, np.ndarray | tor
         the batch dimension.
     """
     keys = batch[0].keys()
-    collated_batch: dict[str, np.ndarray | torch.Tensor] = {}
-    if len(batch) > 1:
-        if not all(keys == data.keys() for data in batch[1:]):
-            raise ValueError("All dictionaries in the batch must have the same keys.")
+    collated_batch: dict[str, dict[str, np.ndarray] | np.ndarray] = {}
+    if len(batch) > 1 and not all(keys == data.keys() for data in batch[1:]):
+        raise ValueError("All dictionaries in the batch must have the same keys.")
     for key in keys:
         if key.endswith("_g") or key.endswith("_categories"):
             # Check that all values are the same
             if len(batch) > 1:
-                if not all(np.array_equal(batch[0][key], data[key]) for data in batch[1:]):
+                if not all(np.array_equal(batch[0][key], data[key]) for data in batch[1:]):  # type: ignore[arg-type]
                     raise ValueError(f"All dictionaries in the batch must have the same {key}.")
             # If so, just take the first one
             value = batch[0][key]
+        elif isinstance(batch[0][key], dict):
+            subkeys = batch[0][key].keys()  # type: ignore[union-attr]
+            if len(batch) > 1 and not all(subkeys == data[key].keys() for data in batch[1:]):  # type: ignore[union-attr]
+                raise ValueError(f"All '{key}' sub-dictionaries in the batch must have the same subkeys.")
+            value = {subkey: np.concatenate([data[key][subkey] for data in batch], axis=0) for subkey in subkeys}
         else:
             value = np.concatenate([data[key] for data in batch], axis=0)
 
-        if not np.issubdtype(value.dtype, np.str_) and not np.issubdtype(value.dtype, np.object_):
-            collated_batch[key] = torch.tensor(value, device="cpu")
-        else:
-            collated_batch[key] = value
-    return collated_batch
+        collated_batch[key] = value
+
+    return tree_map(convert_to_tensor, collated_batch)
 
 
 def densify(x: scipy.sparse.csr_matrix) -> np.ndarray:

--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -107,6 +107,8 @@ def collate_fn(
             # If so, just take the first one
             value = batch[0][key]
         elif isinstance(batch[0][key], dict):
+            if not key.endswith("_n") or not key.endswith("_ng"):
+                raise ValueError(f"Sub-dictionary '{key}' must have a batch dimension (end with '_n' or '_ng').")
             subkeys = batch[0][key].keys()  # type: ignore[union-attr]
             if len(batch) > 1 and not all(subkeys == data[key].keys() for data in batch[1:]):  # type: ignore[union-attr]
                 raise ValueError(f"All '{key}' sub-dictionaries in the batch must have the same subkeys.")

--- a/tests/test_distributed_anndata.py
+++ b/tests/test_distributed_anndata.py
@@ -204,10 +204,12 @@ def test_indexing_dataset(
     else:
         adt_X = adt[oidx].X
         dataset_X = dataset[oidx]["x_ng"]
+        assert isinstance(dataset_X, np.ndarray)
         np.testing.assert_array_equal(adt_X, dataset_X)
 
         adt_obs_names = adt[oidx].obs_names
         dataset_obs_names = dataset[oidx]["obs_names"]
+        assert isinstance(dataset_obs_names, np.ndarray)
         np.testing.assert_array_equal(adt_obs_names, dataset_obs_names)
 
 
@@ -223,5 +225,5 @@ def test_pickle_dataset(dat: DistributedAnnDataCollection):
 
     assert len(new_dataset.dadc.cache) == 1
 
-    np.testing.assert_array_equal(new_dataset[:2]["x_ng"], dataset[:2]["x_ng"])
-    np.testing.assert_array_equal(new_dataset[:2]["obs_names"], dataset[:2]["obs_names"])
+    np.testing.assert_array_equal(new_dataset[:2]["x_ng"], dataset[:2]["x_ng"])  # type: ignore[arg-type]
+    np.testing.assert_array_equal(new_dataset[:2]["obs_names"], dataset[:2]["obs_names"])  # type: ignore[arg-type]


### PR DESCRIPTION
Allow nested batch keys, e.g.:

```yaml
batch_keys:
  metadata_tokens_n:
    cell_type:
      attr: obs
      key: cell_type
    development_stage:
      attr: obs
      key: development_stage
```