### PR TITLE
Move `cpu_transforms` back to `module_pipeline` at teardown

### DIFF
--- a/cellarium/ml/core/module.py
+++ b/cellarium/ml/core/module.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 from lightning.pytorch.utilities.types import STEP_OUTPUT, OptimizerLRSchedulerConfig
 
-from cellarium.ml.core.datamodule import CellariumAnnDataDataModule, collate_fn
+from cellarium.ml.core.datamodule import CellariumAnnDataDataModule
 from cellarium.ml.core.pipeline import CellariumPipeline
 from cellarium.ml.models import CellariumModel
 from cellarium.ml.utilities.core import FunctionComposer, copy_module
@@ -154,14 +154,7 @@ class CellariumModule(pl.LightningModule):
             self.hparams["is_initialized"] = True
 
         # move the cpu_transforms to the dataloader's collate_fn if the dataloader is going to apply them
-        if self._trainer is not None:
-            if hasattr(self.trainer, "datamodule"):
-                if isinstance(self.trainer.datamodule, CellariumAnnDataDataModule):
-                    self._cpu_transforms_in_module_pipeline = False
-                    self.trainer.datamodule.collate_fn = FunctionComposer(
-                        first_applied=collate_fn,
-                        second_applied=self.cpu_transforms,
-                    )
+        self.move_cpu_transforms_to_dataloader()
 
     def __repr__(self) -> str:
         if not self._cpu_transforms_in_module_pipeline:
@@ -356,3 +349,30 @@ class CellariumModule(pl.LightningModule):
         on_train_batch_end = getattr(self.model, "on_train_batch_end", None)
         if callable(on_train_batch_end):
             on_train_batch_end(self.trainer)
+
+    def move_cpu_transforms_to_dataloader(self) -> None:
+        if not self._cpu_transforms_in_module_pipeline:
+            warnings.warn(
+                "The CPU transforms are already moved to the dataloader's collate_fn. Skipping the move operation.",
+                UserWarning,
+            )
+            return
+        if self._trainer is not None:
+            if hasattr(self.trainer, "datamodule"):
+                if isinstance(self.trainer.datamodule, CellariumAnnDataDataModule):
+                    self._cpu_transforms_in_module_pipeline = False
+                    self.trainer.datamodule.collate_fn = FunctionComposer(
+                        first_applied=self.trainer.datamodule.collate_fn,
+                        second_applied=self.cpu_transforms,
+                    )
+
+    def setup(self, stage: str) -> None:
+        # move the cpu_transforms to the dataloader's collate_fn if the dataloader is going to apply them
+        if self.pipeline is not None:
+            self.move_cpu_transforms_to_dataloader()
+
+    def teardown(self, stage: str) -> None:
+        # move the cpu_transforms back to the module_pipeline from dataloader's collate_fn
+        if not self._cpu_transforms_in_module_pipeline:
+            self.trainer.datamodule.collate_fn = self.trainer.datamodule.collate_fn.first_applied  # type: ignore[attr-defined]
+            self._cpu_transforms_in_module_pipeline = True

--- a/notebooks/part_i.ipynb
+++ b/notebooks/part_i.ipynb
@@ -521,8 +521,10 @@
    ],
    "source": [
     "pca_module = CellariumModule(\n",
-    "    transforms=[\n",
+    "    cpu_transforms=[\n",
     "        Filter(filter_list=adata.var_names[adata.var[\"highly_variable\"]]),\n",
+    "    ],\n",
+    "    transforms=[\n",
     "        NormalizeTotal(target_count=10_000),\n",
     "        Log1p(),\n",
     "        ZScore(\n",

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -78,26 +78,23 @@ def test_cpu_transforms(
     print("✓")
 
     # lightning
-    print("Checking pipeline configuration when CellariumModule is used with a lightning Trainer... ")
+    print("Checking pipeline configuration when CellariumModule is used after a lightning Trainer... ")
     module = _new_module()
     trainer = pl.Trainer(accelerator=accelerator, devices=1, max_steps=1, default_root_dir=tmp_path)
     trainer.fit(module, datamodule)
     _check_pipeline(module)
     _check_transform_lists_match(
-        transforms,  # no CPU transforms in lightning
+        (cpu_transforms if cpu_transforms else []) + (transforms if transforms else []),
         module.module_pipeline[:-1],
         "Transforms in CellariumModule.module_pipeline are incorrect when used by lightning",
     )
     print("    ... ✓")
 
-    # ensure the data from the dataloader is filtered if appropriate
-    print("Checking that the data from the dataloader is filtered if appropriate... ", end="")
+    # ensure the data from the dataloader is not filtered
+    print("Checking that the data from the dataloader is not filtered outside of the trainer... ", end="")
     for batch in datamodule.train_dataloader():
         x_ng = batch["x_ng"]
-        if cpu_transforms is not None:
-            assert x_ng.shape[1] == 2
-        else:
-            assert x_ng.shape[1] == 36601  # full number of genes in test dataset
+        assert x_ng.shape[1] == 36601  # full number of genes in test dataset
         break
     print("✓")
 
@@ -170,8 +167,8 @@ def test_cpu_transforms(
     print("\nFull loaded module ---------")
     print(trainer.model)
     assert (
-        not trainer.model._cpu_transforms_in_module_pipeline
-    ), "Upon Trainer.fit() checkpoint restart, flag for CPU transforms should be False"
+        trainer.model._cpu_transforms_in_module_pipeline
+    ), "After Trainer.fit() checkpoint restart, flag for CPU transforms should be True"
     print("    ... ✓")
 
 


### PR DESCRIPTION
Fixes #244 