### PR TITLE
Allow `AnnDataField` to have more than one key

### DIFF
--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -54,7 +54,7 @@ class AnnDataField:
     """
 
     attr: str
-    key: str | None = None
+    key: list[str] | str | None = None
     convert_fn: Callable[[Any], np.ndarray] | None = None
 
     def __call__(self, adata: AnnData) -> np.ndarray:
@@ -134,18 +134,21 @@ def densify(x: scipy.sparse.csr_matrix) -> np.ndarray:
     return x.toarray()
 
 
-def categories_to_codes(x: pd.Series) -> np.ndarray:
+def categories_to_codes(x: pd.Series | pd.DataFrame) -> np.ndarray:
     """
-    Convert a pandas Series of categorical data to a numpy array of codes.
+    Convert a pandas Series or DataFrame of categorical data to a numpy array of codes.
     Returned array is always a copy.
 
     Args:
-        x: Pandas Series object.
+        x: Pandas Series object or a pandas DataFrame containing multiple categorical Series.
 
     Returns:
         Numpy array.
     """
-    return np.asarray(x.cat.codes)
+    if isinstance(x, pd.DataFrame):
+        return x.apply(lambda col: col.cat.codes).to_numpy()
+    else:
+        return np.asarray(x.cat.codes)
 
 
 def get_categories(x: pd.Series) -> np.ndarray:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import lightning.pytorch as pl
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 from anndata import AnnData
@@ -17,7 +18,7 @@ from cellarium.ml.data import (
     DistributedAnnDataCollection,
     IterableDistributedAnnDataCollectionDataset,
 )
-from cellarium.ml.utilities.data import AnnDataField, collate_fn
+from cellarium.ml.utilities.data import AnnDataField, collate_fn, categories_to_codes
 from tests.common import BoringModel
 
 # RuntimeError: Too many open files. Communication with the workers is no longer possible.
@@ -26,20 +27,41 @@ from tests.common import BoringModel
 torch.multiprocessing.set_sharing_strategy("file_system")
 
 
+@pytest.fixture()
+def obs() -> pd.DataFrame:
+    n_cell = 20
+    obs = pd.DataFrame(
+        data={
+            "batch": np.concatenate([np.zeros(3), np.ones(n_cell,)]).astype(int)[:n_cell], 
+            "assay": np.array(['10x', 'dropseq'] * (n_cell // 2 + 1))[:n_cell],
+        }
+    )
+    obs['batch'] = obs['batch'].astype('category')
+    obs['assay'] = obs['assay'].astype('category')
+    return obs
+
+
 @pytest.fixture(params=[[3, 6, 9, 12], [4, 8, 12], [4, 8, 11]])  # limits
-def dadc(tmp_path: Path, request: pytest.FixtureRequest):
+def dadc(tmp_path: Path, obs: pd.DataFrame, request: pytest.FixtureRequest) -> DistributedAnnDataCollection:
     limits = request.param
     n_cell = limits[-1]
     g_gene = 1
 
+    assert n_cell <= len(obs), "the pytest fixture called obs() is too small a dataframe. increase its n_cell value"
+
     X = np.arange(n_cell).reshape(n_cell, g_gene)
-    adata = AnnData(X, dtype=X.dtype)
+    # first 3 "batch" 0, rest 1; even "assay" 10x, odd dropseq
+    adata = AnnData(X, dtype=X.dtype, obs=obs[:n_cell])
     for i, limit in enumerate(zip([0] + limits, limits)):
         sliced_adata = adata[slice(*limit)]
+        # the following two lines exist because of https://github.com/scverse/anndata/issues/1710
+        sliced_adata.obs['batch'] = sliced_adata.obs['batch'].cat.set_categories(adata.obs['batch'].cat.categories)
+        sliced_adata.obs['assay'] = sliced_adata.obs['assay'].cat.set_categories(adata.obs['assay'].cat.categories)
         sliced_adata.write(os.path.join(tmp_path, f"adata.00{i}.h5ad"))
 
     # distributed anndata
     filenames = str(os.path.join(tmp_path, f"adata.{{000..00{len(limits)-1}}}.h5ad"))
+
     dadc = DistributedAnnDataCollection(
         filenames,
         limits,
@@ -47,6 +69,31 @@ def dadc(tmp_path: Path, request: pytest.FixtureRequest):
         cache_size_strictly_enforced=True,
     )
     return dadc
+
+
+def test_iterable_dataset_anndatafields(dadc: DistributedAnnDataCollection, obs: pd.DataFrame):
+    dataset = IterableDistributedAnnDataCollectionDataset(
+        dadc,
+        batch_keys={"x_ng": AnnDataField("X"), 
+                    "batch_n": AnnDataField("obs", key="batch", convert_fn=categories_to_codes),
+                    "assay_n": AnnDataField("obs", key="assay", convert_fn=categories_to_codes),
+                    "batch_assay_n2": AnnDataField("obs", key=["batch", "assay"], convert_fn=categories_to_codes)},
+        batch_size=1,
+        shuffle=False,
+        test_mode=True,
+    )
+    data_loader = torch.utils.data.DataLoader(
+        dataset,
+        collate_fn=collate_fn,
+    )
+
+    for i, batch in enumerate(data_loader):
+        assert "x_ng" in batch
+        assert batch["x_ng"].shape == (1, 1)
+        assert batch["x_ng"].dtype == torch.int64
+        assert batch["batch_n"] == torch.tensor([obs["batch"].cat.codes[i]])
+        assert batch["assay_n"] == torch.tensor([obs["assay"].cat.codes[i]])
+        torch.testing.assert_close(torch.cat([batch["batch_n"], batch["assay_n"]]).unsqueeze(0), batch["batch_assay_n2"])
 
 
 @pytest.mark.parametrize("iteration_strategy", ["same_order", "cache_efficient"])


### PR DESCRIPTION
Small change that allows `key` of `AnnDataField` to be a list of strings.

An accompanying change that allows `categories_to_codes` to handle a `DataFrame` (the result of accessing `adata.obs` with a list of keys) as well as a `Series`.

This enables the scvi model to be written much more efficiently.  We have a use case where we can have several `adata.obs` keys designated as "categorical covariates", and we would like to load them all into a single tensor that gets passed to the `forward` call of the model.  These changes enable that.