### PR TITLE
Automatically add lightning hooks to CellariumModule as passthroughs

### DIFF
--- a/cellarium/ml/core/module.py
+++ b/cellarium/ml/core/module.py
@@ -8,7 +8,7 @@ from typing import Any
 import lightning.pytorch as pl
 import numpy as np
 import torch
-from lightning.pytorch.utilities.types import STEP_OUTPUT, OptimizerLRSchedulerConfig
+from lightning.pytorch.utilities.types import OptimizerLRSchedulerConfig
 
 from cellarium.ml.core.datamodule import CellariumAnnDataDataModule
 from cellarium.ml.core.pipeline import CellariumPipeline
@@ -329,15 +329,9 @@ class CellariumModule(pl.LightningModule):
             if callable(set_epoch):
                 set_epoch(self.current_epoch)
 
-    def on_train_start(self) -> None:
-        """
-        Calls the ``on_train_start`` method on the :attr:`model` attribute.
-        If the :attr:`model` attribute has ``on_train_start`` method defined, then
-        ``on_train_start`` must be called at the beginning of training.
-        """
-        on_train_start = getattr(self.model, "on_train_start", None)
-        if callable(on_train_start):
-            on_train_start(self.trainer)
+        on_train_epoch_start = getattr(self.model, "on_train_epoch_start", None)
+        if callable(on_train_epoch_start):
+            on_train_epoch_start(self.trainer)
 
     def on_train_epoch_end(self) -> None:
         """
@@ -363,14 +357,6 @@ class CellariumModule(pl.LightningModule):
         on_train_epoch_end = getattr(self.model, "on_train_epoch_end", None)
         if callable(on_train_epoch_end):
             on_train_epoch_end(self.trainer)
-
-    def on_train_batch_end(self, outputs: STEP_OUTPUT, batch: Any, batch_idx: int) -> None:
-        """
-        Calls the ``on_train_batch_end`` method on the module.
-        """
-        on_train_batch_end = getattr(self.model, "on_train_batch_end", None)
-        if callable(on_train_batch_end):
-            on_train_batch_end(self.trainer)
 
     def move_cpu_transforms_to_dataloader(self) -> None:
         if not self._cpu_transforms_in_module_pipeline:
@@ -416,3 +402,65 @@ class CellariumModule(pl.LightningModule):
                 checkpoint["loops"]["fit_loop"]["epoch_progress"]["total"]["completed"] += 1
                 checkpoint["loops"]["fit_loop"]["epoch_progress"]["current"]["completed"] += 1
                 checkpoint["CellariumAnnDataDataModule"]["epoch"] += 1
+
+
+# define a decorator to dynamically add methods
+def add_delegate_method(method_name):
+    def delegate_method(self, *args, **kwargs):
+        method = getattr(self.model, method_name, None)
+        if callable(method):
+            method(self.trainer, *args, **kwargs)
+
+    delegate_method.__name__ = method_name
+    delegate_method.__doc__ = f"Delegates the `{method_name}` hook to the model if defined."
+    setattr(CellariumModule, method_name, delegate_method)
+
+
+# list of all Lightning hook methods to delegate, which comes from:
+# >>> all_methods = dir(pl.LightningModule)
+# >>> all_hooks = [method for method in all_methods if method.startswith("on_") and not ("checkpoint" in method)]
+# >>> explicitly_implemented_hooks = ["on_train_epoch_start", "on_train_epoch_end"]
+# >>> passthrough_hooks = [hook for hook in all_hooks if hook not in explicitly_implemented_hooks]
+passthrough_hooks = [
+    "on_after_backward",
+    "on_after_batch_transfer",
+    "on_before_backward",
+    "on_before_batch_transfer",
+    "on_before_optimizer_step",
+    "on_before_zero_grad",
+    "on_fit_end",
+    "on_fit_start",
+    "on_gpu",
+    "on_predict_batch_end",
+    "on_predict_batch_start",
+    "on_predict_end",
+    "on_predict_epoch_end",
+    "on_predict_epoch_start",
+    "on_predict_model_eval",
+    "on_predict_start",
+    "on_test_batch_end",
+    "on_test_batch_start",
+    "on_test_end",
+    "on_test_epoch_end",
+    "on_test_epoch_start",
+    "on_test_model_eval",
+    "on_test_model_train",
+    "on_test_start",
+    "on_train_batch_end",
+    "on_train_batch_start",
+    "on_train_end",
+    "on_train_start",
+    "on_validation_batch_end",
+    "on_validation_batch_start",
+    "on_validation_end",
+    "on_validation_epoch_end",
+    "on_validation_epoch_start",
+    "on_validation_model_eval",
+    "on_validation_model_train",
+    "on_validation_model_zero_grad",
+    "on_validation_start",
+]
+
+# dynamically add all hooks
+for hook in passthrough_hooks:
+    add_delegate_method(hook)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,94 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from pathlib import Path
+
+import lightning.pytorch as pl
+import pytest
+
+from cellarium.ml import CellariumAnnDataDataModule, CellariumModule
+from cellarium.ml.data import DistributedAnnDataCollection
+from cellarium.ml.models import CellariumModel, PredictMixin
+from cellarium.ml.utilities.data import AnnDataField, densify
+
+
+class BlankModel(CellariumModel, PredictMixin):
+    """model that does nothing but throw exceptions when a hook method is called"""
+
+    def __init__(self):
+        super().__init__()
+        self.hooks_called: list[str] = []
+
+    def reset_parameters(self):
+        self.hooks_called = []
+
+    def forward(self, *args, **kwargs):
+        return {}
+
+    def predict(self, *args, **kwargs):
+        return {}
+
+    def on_train_epoch_start(self, *args, **kwargs):
+        self.hooks_called.append("on_train_epoch_start")
+
+    def on_train_batch_end(self, *args, **kwargs):
+        self.hooks_called.append("on_train_batch_end")
+
+    def on_train_epoch_end(self, *args, **kwargs):
+        self.hooks_called.append("on_train_epoch_end")
+
+    def on_predict_batch_end(self, *args, **kwargs):
+        self.hooks_called.append("on_predict_batch_end")
+
+    def on_predict_epoch_end(self, *args, **kwargs):
+        self.hooks_called.append("on_predict_epoch_end")
+
+
+@pytest.fixture(scope="function")
+def training_run_setup(tmp_path: Path, accelerator: str = "cpu") -> dict:
+    n_cells_in_shard = 100
+    datamodule = CellariumAnnDataDataModule(
+        DistributedAnnDataCollection(
+            filenames="https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_0.h5ad",
+            shard_size=n_cells_in_shard,
+        ),
+        batch_size=n_cells_in_shard // 2,
+        batch_keys={
+            "x_ng": AnnDataField(attr="X", convert_fn=densify),
+            "obs_names_n": AnnDataField(attr="obs_names"),
+        },
+        train_size=1.0,
+    )
+    module = CellariumModule(model=BlankModel())
+    trainer = pl.Trainer(accelerator=accelerator, devices=1, max_epochs=2, default_root_dir=tmp_path)
+    return {"trainer": trainer, "module": module, "datamodule": datamodule}
+
+
+def test_module_implemented_hooks(training_run_setup: dict) -> None:
+    trainer = training_run_setup["trainer"]
+    module = training_run_setup["module"]
+    datamodule = training_run_setup["datamodule"]
+
+    # ensure hooks are called as expected during fit
+    trainer.fit(module, datamodule)
+    print("hooks called by 2 epoch training run with 2 batches per epoch, in order:")
+    print(module.model.hooks_called)
+    expected_order_of_hooks = [
+        "on_train_epoch_start",
+        "on_train_batch_end",
+        "on_train_batch_end",
+        "on_train_epoch_end",
+        "on_train_epoch_start",
+        "on_train_batch_end",
+        "on_train_batch_end",
+        "on_train_epoch_end",
+    ]
+    assert module.model.hooks_called == expected_order_of_hooks
+
+    # ensure hooks are called as expected during predict
+    module.model.reset_parameters()
+    datamodule.setup(stage="predict")
+    trainer.predict(module, datamodule)
+    print("hooks called by 2 batch predict run:")
+    print(module.model.hooks_called)
+    assert 0


### PR DESCRIPTION
The idea here is to add a whole bunch of lightning hooks to CellariumModule so that CellariumModule can pass them all through to CellariumModel.  Different CellariumModels may want to use different hooks.