### PR TITLE
Update cNMF requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "numpy<=1.26.4",
   "pyro-ppl>=1.9.1",
   "pytest",
+  "scikit-learn",
   "torch>=2.2.0",
   "transformers",
 ]
@@ -45,6 +46,7 @@ test = [
   "tensorboard",
   "torchvision",
 ]
+scanpy = ["scanpy[leiden]"]
 docs = [
   "nbsphinx",
   "Pillow",
@@ -53,7 +55,7 @@ docs = [
   "sphinx_rtd_theme",
   "sphinx-copybutton",
 ]
-dev = ["cellarium-ml[docs,lint,mypy,test]"]
+dev = ["cellarium-ml[docs,lint,mypy,test,scanpy]"]
 
 [project.scripts]
 cellarium-ml = "cellarium.ml.cli:main"


### PR DESCRIPTION
Closes #273

Adds a real dependency on scikit-learn (which we probably do not want long term, but is currently in the code), and adds a "scanpy" optional dependency which does install in [dev] installs (for notebook tutorials).