### PR TITLE
Ruff upgrade to v0.9.1

### DIFF
--- a/cellarium/ml/callbacks/variance_monitor.py
+++ b/cellarium/ml/callbacks/variance_monitor.py
@@ -29,9 +29,9 @@ class VarianceMonitor(pl.Callback):
             AssertionError: If ``pl_module.model`` is not a ``ProbabilisticPCA`` instance.
             MisconfigurationException: If ``Trainer`` has no ``logger``.
         """
-        assert isinstance(
-            pl_module.model, ProbabilisticPCA
-        ), "VarianceMonitor callback should only be used in conjunction with ProbabilisticPCA"
+        assert isinstance(pl_module.model, ProbabilisticPCA), (
+            "VarianceMonitor callback should only be used in conjunction with ProbabilisticPCA"
+        )
 
         if not trainer.loggers:
             raise pl.utilities.exceptions.MisconfigurationException(

--- a/cellarium/ml/models/incremental_pca.py
+++ b/cellarium/ml/models/incremental_pca.py
@@ -96,7 +96,7 @@ class IncrementalPCA(CellariumModel, PredictMixin):
         other_X_size = x_ng.size(0)
         total_X_size = self_X_size + other_X_size
         assert k <= min(other_X_size, g), (
-            f"Rank of svd_lowrank (n_components): {k}" f" must be less than min(n_obs, n_vars): {min(other_X_size, g)}"
+            f"Rank of svd_lowrank (n_components): {k} must be less than min(n_obs, n_vars): {min(other_X_size, g)}"
         )
 
         # compute SVD of new data
@@ -132,10 +132,10 @@ class IncrementalPCA(CellariumModel, PredictMixin):
     def on_train_start(self, trainer: pl.Trainer) -> None:
         if trainer.world_size > 1:
             assert isinstance(trainer.strategy, DDPStrategy), (
-                "Distributed and Incremental PCA requires that " "the trainer uses the DDP strategy."
+                "Distributed and Incremental PCA requires that the trainer uses the DDP strategy."
             )
             assert trainer.strategy._ddp_kwargs["broadcast_buffers"] is False, (
-                "Distributed and Incremental PCA requires that " "broadcast_buffers is set to False."
+                "Distributed and Incremental PCA requires that broadcast_buffers is set to False."
             )
 
     def on_train_epoch_end(self, trainer: pl.Trainer) -> None:

--- a/cellarium/ml/models/onepass_mean_var_std.py
+++ b/cellarium/ml/models/onepass_mean_var_std.py
@@ -101,12 +101,12 @@ class OnePassMeanVarStd(CellariumModel):
 
     def on_train_start(self, trainer: pl.Trainer) -> None:
         if trainer.world_size > 1:
-            assert isinstance(
-                trainer.strategy, DDPStrategy
-            ), "OnePassMeanVarStd requires that the trainer uses the DDP strategy."
-            assert (
-                trainer.strategy._ddp_kwargs["broadcast_buffers"] is False
-            ), "OnePassMeanVarStd requires that broadcast_buffers is set to False."
+            assert isinstance(trainer.strategy, DDPStrategy), (
+                "OnePassMeanVarStd requires that the trainer uses the DDP strategy."
+            )
+            assert trainer.strategy._ddp_kwargs["broadcast_buffers"] is False, (
+                "OnePassMeanVarStd requires that broadcast_buffers is set to False."
+            )
 
     def on_train_epoch_end(self, trainer: pl.Trainer) -> None:
         # no need to merge if only one process

--- a/cellarium/ml/preprocessing/highly_variable_genes.py
+++ b/cellarium/ml/preprocessing/highly_variable_genes.py
@@ -109,7 +109,7 @@ def get_highly_variable_genes(
             n_top_genes = len(dispersion_norm)
         disp_cut_off = dispersion_norm[n_top_genes - 1]
         gene_subset = np.nan_to_num(df["dispersions_norm"].values) >= disp_cut_off
-        logging.debug(f"the {n_top_genes} top genes correspond to a " f"normalized dispersion cutoff of {disp_cut_off}")
+        logging.debug(f"the {n_top_genes} top genes correspond to a normalized dispersion cutoff of {disp_cut_off}")
     else:
         dispersion_norm[np.isnan(dispersion_norm)] = 0  # similar to Seurat
         gene_subset = np.logical_and.reduce(

--- a/cellarium/ml/utilities/distributed.py
+++ b/cellarium/ml/utilities/distributed.py
@@ -57,7 +57,7 @@ def get_rank_and_num_replicas() -> tuple[int, int]:
             num_replicas = 1
             rank = 0
     if rank >= num_replicas or rank < 0:
-        raise ValueError(f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas-1}]")
+        raise ValueError(f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas - 1}]")
     return rank, num_replicas
 
 

--- a/cellarium/ml/utilities/testing.py
+++ b/cellarium/ml/utilities/testing.py
@@ -96,7 +96,7 @@ def assert_arrays_equal(
         ValueError: If the arrays are not equal.
     """
     if not np.array_equal(a1, a2):
-        raise ValueError(f"`{a1_name}` must match `{a2_name}`. " f"Got {a1} != {a2}")
+        raise ValueError(f"`{a1_name}` must match `{a2_name}`. Got {a1} != {a2}")
 
 
 def assert_slope_equals(data: pd.Series, slope: float, loglog: bool = False, atol: float = 1e-4) -> None:

--- a/tests/dataloader/test_datamodule.py
+++ b/tests/dataloader/test_datamodule.py
@@ -100,7 +100,7 @@ def test_cpu_transforms(
 
     # ensure loading from a checkpoint manually results in the correct location of transforms
     print(
-        "Checking whether we can load a module from a checkpoint " "using CellariumModule.load_from_checkpoint()... ",
+        "Checking whether we can load a module from a checkpoint using CellariumModule.load_from_checkpoint()... ",
         end="",
     )
     ckpt_path = str(tmp_path / "lightning_logs/version_0/checkpoints/epoch=0-step=1.ckpt")
@@ -130,9 +130,9 @@ def test_cpu_transforms(
 
     print("\nFull loaded module ---------")
     print(loaded_module)
-    assert (
-        loaded_module._cpu_transforms_in_module_pipeline
-    ), "Upon manual loading, flag for CPU transforms should be True"
+    assert loaded_module._cpu_transforms_in_module_pipeline, (
+        "Upon manual loading, flag for CPU transforms should be True"
+    )
     print("    ... ✓")
 
     # ensure loading from a checkpoint at lightning `fit` time results in the correct location of transforms
@@ -166,9 +166,9 @@ def test_cpu_transforms(
 
     print("\nFull loaded module ---------")
     print(trainer.model)
-    assert (
-        trainer.model._cpu_transforms_in_module_pipeline
-    ), "After Trainer.fit() checkpoint restart, flag for CPU transforms should be True"
+    assert trainer.model._cpu_transforms_in_module_pipeline, (
+        "After Trainer.fit() checkpoint restart, flag for CPU transforms should be True"
+    )
     print("    ... ✓")
 
 

--- a/tests/dataloader/test_dataset.py
+++ b/tests/dataloader/test_dataset.py
@@ -67,7 +67,7 @@ def dadc(tmp_path: Path, obs: pd.DataFrame, request: pytest.FixtureRequest) -> D
         sliced_adata.write(os.path.join(tmp_path, f"adata.00{i}.h5ad"))
 
     # distributed anndata
-    filenames = str(os.path.join(tmp_path, f"adata.{{000..00{len(limits)-1}}}.h5ad"))
+    filenames = str(os.path.join(tmp_path, f"adata.{{000..00{len(limits) - 1}}}.h5ad"))
 
     dadc = DistributedAnnDataCollection(
         filenames,

--- a/tests/dataloader/test_distributed_anndata.py
+++ b/tests/dataloader/test_distributed_anndata.py
@@ -110,7 +110,7 @@ def test_init_dat(dat: DistributedAnnDataCollection):
 @pytest.mark.parametrize("last_shard_size", [1, 2, 3, None])
 def test_init_shard_size(adatas_path: Path, num_shards: int, last_shard_size: int | None):
     shard_size = 2
-    filenames = str(os.path.join(adatas_path, f"adata.{{000..{num_shards-1:03}}}.h5ad"))
+    filenames = str(os.path.join(adatas_path, f"adata.{{000..{num_shards - 1:03}}}.h5ad"))
     dadc = DistributedAnnDataCollection(
         filenames,
         shard_size=shard_size,


### PR DESCRIPTION
Ruff v0.9.1 seems to have changed the handling of assertions and f-strings

`make format` changes the code currently on `main` when ruff is v0.9.1 (which it currently is on github actions CI tests)

These changes are the changes to the `main` branch induced by running `make format`