### PR TITLE
`PredictionWriter`: optional gzip, use ThreadPoolExecutor

### DIFF
--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -187,6 +187,4 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
         if self.sufficient_disk_space_exists is None:
             self.sufficient_disk_space_exists = self.check_disk_space(num_files=trainer.num_predict_batches[0])
             if self.sufficient_disk_space_exists is False:
-                raise RuntimeError(
-                    f"Insufficient disk space at {self.output_dir} to write all predictions"
-                )
+                raise RuntimeError(f"Insufficient disk space at {self.output_dir} to write all predictions")

--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -130,7 +130,7 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
 
     def check_disk_space(self, num_files: int | float) -> bool | None:
         """Check if there is enough disk space to write all predictions.
-        
+
         Args:
             num_files:
                 The total number of files to be written (num_predict_batches).

--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import shutil
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -121,10 +122,32 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
             max_queue_size=max_threadpool_workers * 2,
         )
         self.gzip = gzip
+        self.sufficient_disk_space_exists: bool | None = None
 
     def __del__(self):
         """Ensure the executor shuts down on object deletion."""
         self.executor.shutdown(wait=True)
+
+    def check_disk_space(self, num_files: int | float) -> bool | None:
+        """Check if there is enough disk space to write all predictions.
+        
+        Args:
+            num_files:
+                The total number of files to be written (num_predict_batches).
+
+        Returns:
+            bool | None:
+                True if there is enough disk space to write all predictions, False otherwise.
+                None if the first output file does not exist yet.
+        """
+        first_file_path = os.path.join(self.output_dir, "batch_0.csv" + (".gz" if self.gzip else ""))
+        if not os.path.isfile(first_file_path):
+            return None
+        first_file_size = os.path.getsize(first_file_path)  # single file in bytes
+        total_required_space = first_file_size * num_files  # total required space in bytes
+        usage = shutil.disk_usage(self.output_dir)
+        available_space = usage.free  # free space in bytes
+        return total_required_space <= available_space
 
     def write_on_batch_end(
         self,
@@ -159,3 +182,11 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
             gzip=self.gzip,
             executor=self.executor,
         )
+
+        # check output directory for sufficient disk space once
+        if self.sufficient_disk_space_exists is None:
+            self.sufficient_disk_space_exists = self.check_disk_space(num_files=trainer.num_predict_batches[0])
+            if self.sufficient_disk_space_exists is False:
+                raise RuntimeError(
+                    f"Insufficient disk space at {self.output_dir} to write all predictions"
+                )

--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -3,6 +3,7 @@
 
 import os
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import lightning.pytorch as pl
@@ -16,6 +17,8 @@ def write_prediction(
     obs_names_n: np.ndarray,
     output_dir: Path | str,
     postfix: int | str,
+    gzip: bool = True,
+    executor: ThreadPoolExecutor | None = None,
 ) -> None:
     """
     Write prediction to a CSV file.
@@ -29,13 +32,27 @@ def write_prediction(
             The directory to write the prediction to.
         postfix:
             A postfix to add to the CSV file name.
+        gzip:
+            Whether to compress the CSV file using gzip.
+        executor:
+            The executor used to write the prediction. If ``None``, no executor will be used.
     """
     if not os.path.exists(output_dir):
         os.makedirs(output_dir, exist_ok=True)
     df = pd.DataFrame(prediction.cpu())
     df.insert(0, "obs_names_n", obs_names_n)
-    output_path = os.path.join(output_dir, f"batch_{postfix}.csv")
-    df.to_csv(output_path, header=False, index=False)
+    output_path = os.path.join(output_dir, f"batch_{postfix}.csv" + (".gz" if gzip else ""))
+    to_csv_kwargs: dict[str, str | bool] = {"header": False, "index": False}
+    if gzip:
+        to_csv_kwargs |= {"compression": "gzip"}
+
+    def _write_csv(frame: pd.DataFrame, path: str) -> None:
+        frame.to_csv(path, **to_csv_kwargs)
+
+    if executor is None:
+        _write_csv(df, output_path)
+    else:
+        executor.submit(_write_csv, df, output_path)
 
 
 class PredictionWriter(pl.callbacks.BasePredictionWriter):
@@ -56,6 +73,10 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
             written. If not ``None``, only the first ``prediction_size`` columns will be written.
         key:
             PredictionWriter will write this key from the output of `predict()`.
+        gzip:
+            Whether to compress the CSV file using gzip.
+        max_threadpool_workers:
+            The maximum number of threads to use to write the predictions using a ThreadPoolExecutor.
     """
 
     def __init__(
@@ -63,11 +84,19 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
         output_dir: Path | str,
         prediction_size: int | None = None,
         key: str = "x_ng",
+        gzip: bool = True,
+        max_threadpool_workers: int = 4,
     ) -> None:
         super().__init__(write_interval="batch")
         self.output_dir = output_dir
         self.prediction_size = prediction_size
         self.key = key
+        self.executor = ThreadPoolExecutor(max_workers=max_threadpool_workers)
+        self.gzip = gzip
+
+    def __del__(self):
+        """Ensure the executor shuts down on object deletion."""
+        self.executor.shutdown(wait=True)
 
     def write_on_batch_end(
         self,
@@ -99,4 +128,6 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
             obs_names_n=batch["obs_names_n"],
             output_dir=self.output_dir,
             postfix=batch_idx * trainer.world_size + trainer.global_rank,
+            gzip=self.gzip,
+            executor=self.executor,
         )

--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -85,7 +85,7 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
         prediction_size: int | None = None,
         key: str = "x_ng",
         gzip: bool = True,
-        max_threadpool_workers: int = 4,
+        max_threadpool_workers: int = 8,
     ) -> None:
         super().__init__(write_interval="batch")
         self.output_dir = output_dir

--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -121,7 +121,6 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
             max_queue_size=max_threadpool_workers * 2,
         )
         self.gzip = gzip
-        self.sufficient_disk_space_exists: bool | None = None
 
     def __del__(self):
         """Ensure the executor shuts down on object deletion."""

--- a/cellarium/ml/callbacks/prediction_writer.py
+++ b/cellarium/ml/callbacks/prediction_writer.py
@@ -88,7 +88,18 @@ class PredictionWriter(pl.callbacks.BasePredictionWriter):
 
     .. note::
         To prevent an out-of-memory error, set the ``return_predictions`` argument of the
-        :class:`~lightning.pytorch.Trainer` to ``False``.
+        :class:`~lightning.pytorch.Trainer` to ``False``. This is accomplished in the config
+        file by including ``return_predictions: false`` at indent level 0. For example,
+
+        .. code-block:: yaml
+
+            trainer:
+              ...
+            model:
+              ...
+            data:
+              ...
+            return_predictions: false
 
     Args:
         output_dir:

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -309,6 +309,13 @@ def lightning_cli_factory(
                 }
             )
 
+        def predict(self, *args, **kwargs):
+            """Not well documented, but defining this here overrides the default predict subcommand.
+            This method injects return_predictions=False into the kwargs to prevent the predictions from
+            being returned, which prevents memory overflow when writing predictions to a file."""
+            kwargs["return_predictions"] = False
+            self.trainer.predict(*args, **kwargs)
+
     return NewLightningCLI
 
 

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -637,7 +637,6 @@ def main(args: ArgsType = None) -> None:
     if model_name not in REGISTERED_MODELS:
         raise ValueError(f"'model_name' must be one of {list(REGISTERED_MODELS.keys())}. Got '{model_name}'")
     model_cli = REGISTERED_MODELS[model_name]
-
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Transforming to str index.")
         warnings.filterwarnings("ignore", message="LightningCLI's args parameter is intended to run from within Python")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import copy
 import os
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -631,3 +633,135 @@ def test_compute_var_names_g(tmp_path: Path) -> None:
     with open(tmp_path / "onepass_config_with_cpu_filter.yaml", "w") as f:
         f.write(onepass_config_with_cpu_filter)
     main(["onepass_mean_var_std", "fit", "--config", str(tmp_path / "onepass_config_with_cpu_filter.yaml")])
+
+
+def test_return_predictions_userwarning(tmp_path: Path):
+    """Ensure a warning is emitted when return_predictions is set to true and the subcommand is predict."""
+
+    # using a pre-parsed config
+    config: dict[str, Any] = {
+        "model_name": "geneformer",
+        "subcommand": "predict",
+        "predict": {
+            "model": {
+                "model": {
+                    "class_path": "cellarium.ml.models.Geneformer",
+                    "init_args": {
+                        "hidden_size": "2",
+                        "num_hidden_layers": "1",
+                        "num_attention_heads": "1",
+                        "intermediate_size": "4",
+                        "max_position_embeddings": "2",
+                    },
+                },
+            },
+            "data": {
+                "dadc": {
+                    "class_path": "cellarium.ml.data.DistributedAnnDataCollection",
+                    "init_args": {
+                        "filenames": "https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_0.h5ad",
+                        "shard_size": "100",
+                        "max_cache_size": "2",
+                        "obs_columns_to_validate": [],
+                    },
+                },
+                "batch_keys": {
+                    "x_ng": {
+                        "attr": "X",
+                        "convert_fn": "cellarium.ml.utilities.data.densify",
+                    },
+                    "var_names_g": {"attr": "var_names"},
+                },
+                "batch_size": "5",
+                "num_workers": "1",
+            },
+            "trainer": {
+                "accelerator": "cpu",
+                "devices": devices,
+                "max_steps": "1",
+                "limit_predict_batches": "1",
+            },
+            "return_predictions": "true",
+        },
+    }
+
+    with pytest.warns(UserWarning):
+        main(copy.deepcopy(config))  # running main modifies the config dict
+
+    config["predict"]["return_predictions"] = "false"
+    match_str = r"`return_predictions` argument should"
+    with pytest.warns(UserWarning, match=match_str) as record:
+        warnings.warn("we need one warning: " + match_str, UserWarning)
+        main(copy.deepcopy(config))
+    n = 0
+    for r in record:
+        assert isinstance(r.message, Warning)
+        warning_message = r.message.args[0]
+        if match_str in warning_message:
+            n += 1
+    assert n < 2, "Unexpected UserWarning when running predict with return_predictions=false"
+
+    # using a config file
+    config_file_text = f"""
+    # lightning.pytorch==2.5.0.post0
+    seed_everything: true
+    trainer:
+      accelerator: cpu
+      devices: 1
+      max_steps: 1
+      limit_predict_batches: 1
+      default_root_dir: {tmp_path}
+    model:
+      cpu_transforms: null
+      transforms: null
+      model:
+        class_path: cellarium.ml.models.Geneformer
+        init_args:
+          hidden_size: 2
+          num_hidden_layers: 1
+          num_attention_heads: 1
+          intermediate_size: 4
+          max_position_embeddings: 2
+    data:
+      dadc:
+        class_path: cellarium.ml.data.DistributedAnnDataCollection
+        init_args:
+          filenames: https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_0.h5ad
+          shard_size: 100
+          max_cache_size: 2
+          obs_columns_to_validate: []
+      batch_keys:
+        x_ng:
+          attr: X
+          convert_fn: cellarium.ml.utilities.data.densify
+        var_names_g:
+          attr: var_names
+      batch_size: 5
+      num_workers: 1
+    return_predictions: RETURN_PREDICTIONS_VALUE
+    ckpt_path: null
+    """
+
+    # there should be a warning with return_predictions=true
+    with open(config_file_path := tmp_path / "config.yaml", "w") as f:
+        f.write(config_file_text.replace("RETURN_PREDICTIONS_VALUE", "true"))
+
+    with pytest.warns(UserWarning):
+        main(["geneformer", "predict", "--config", str(config_file_path)])
+
+    # there should be no warning with return_predictions=false
+    with open(config_file_path, "w") as f:
+        f.write(config_file_text.replace("RETURN_PREDICTIONS_VALUE", "false"))
+
+    match_str = r"`return_predictions` argument should"
+    with pytest.warns(UserWarning, match=match_str) as record:
+        warnings.warn("we need one warning: " + match_str, UserWarning)
+        main(["geneformer", "predict", "--config", str(config_file_path)])
+    n = 0
+    for r in record:
+        assert isinstance(r.message, Warning)
+        warning_message = r.message.args[0]
+        if match_str in warning_message:
+            print(warning_message)
+            n += 1
+    assert n < 2, "Unexpected UserWarning when running predict with return_predictions=false"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -685,11 +685,12 @@ def test_return_predictions_userwarning(tmp_path: Path):
         },
     }
 
-    with pytest.warns(UserWarning):
+    match_str = r"`return_predictions` argument should"
+
+    with pytest.warns(UserWarning, match=match_str):
         main(copy.deepcopy(config))  # running main modifies the config dict
 
     config["predict"]["return_predictions"] = "false"
-    match_str = r"`return_predictions` argument should"
     with pytest.warns(UserWarning, match=match_str) as record:
         warnings.warn("we need one warning: " + match_str, UserWarning)
         main(copy.deepcopy(config))
@@ -746,14 +747,13 @@ def test_return_predictions_userwarning(tmp_path: Path):
     with open(config_file_path := tmp_path / "config.yaml", "w") as f:
         f.write(config_file_text.replace("RETURN_PREDICTIONS_VALUE", "true"))
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match=match_str):
         main(["geneformer", "predict", "--config", str(config_file_path)])
 
     # there should be no warning with return_predictions=false
     with open(config_file_path, "w") as f:
         f.write(config_file_text.replace("RETURN_PREDICTIONS_VALUE", "false"))
 
-    match_str = r"`return_predictions` argument should"
     with pytest.warns(UserWarning, match=match_str) as record:
         warnings.warn("we need one warning: " + match_str, UserWarning)
         main(["geneformer", "predict", "--config", str(config_file_path)])


### PR DESCRIPTION
Closes #285 

These changes add two init args to `PredictionWriter`: `gzip` (bool) and `max_threadpool_workers` (int), each of which have default values.

`PredictionWriter` now gzips saved CSVs by default, and runs the saving-and-gzip process in a background thread that does not block further `lightning` compute.

`NewLightningCLI` in `cli.py` also now injects `return_predictions=False` into calls to `trainer.predict()`.

Testing indicates the following outcomes for scvi reconstructions which involve computing a dense output CSV with 250 columns:

```
               |    before changes     |     after changes
---------------------------------------------------------------
file size      |            12 MB      |        5 MB
total time     |            18 hr      |        5 hr
```

(the 18 hrs is gzipping the CSVs without the ThreadPool.  if you don't gzip, the total time would be 7.5 hours.)