### PR TITLE
Fix the logic for merging odd number of devices in IncrementalPCA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10"]
-        devices: ["1", "2"]
+        devices: ["1", "2", "3"]
 
     env:
       TEST_DEVICES: ${{ matrix.devices }}

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ typecheck: FORCE
 test: FORCE
 ifeq (${TEST_DEVICES}, 2)
 	pytest -v -k multi_device --ignore=tests/dataloader
+else ifeq (${TEST_DEVICES}, 3)
+	pytest -v -k multi_device --ignore=tests/dataloader
 else
 	# default
 	pytest -v --ignore=tests/dataloader
@@ -33,6 +35,8 @@ endif
 
 test-dataloader: FORCE
 ifeq (${TEST_DEVICES}, 2)
+	pytest -v -k multi_device tests/dataloader
+else ifeq (${TEST_DEVICES}, 3)
 	pytest -v -k multi_device tests/dataloader
 else
 	# default

--- a/cellarium/ml/models/incremental_pca.py
+++ b/cellarium/ml/models/incremental_pca.py
@@ -89,15 +89,11 @@ class IncrementalPCA(CellariumModel, PredictMixin):
         assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
         assert_arrays_equal("var_names_g", var_names_g, "var_names_g", self.var_names_g)
 
-        g = self.n_vars
         k = self.n_components
         niter = self.svd_lowrank_niter
         self_X_size = self.x_size
         other_X_size = x_ng.size(0)
         total_X_size = self_X_size + other_X_size
-        assert k <= min(other_X_size, g), (
-            f"Rank of svd_lowrank (n_components): {k} must be less than min(n_obs, n_vars): {min(other_X_size, g)}"
-        )
 
         # compute SVD of new data
         if self.perform_mean_correction:
@@ -173,7 +169,7 @@ class IncrementalPCA(CellariumModel, PredictMixin):
             # level i
             # at most two local ranks (leading and trailing)
             if rank % 2 == 0:  # leading rank
-                if rank < world_size:
+                if rank + 1 < world_size:
                     # if there is a trailing rank
                     # then concatenate and merge SVDs
                     src = (rank + 1) * 2**i

--- a/tests/test_ipca.py
+++ b/tests/test_ipca.py
@@ -19,7 +19,7 @@ from tests.common import BoringDataset
 
 @pytest.fixture
 def x_ng():
-    n, g = 10000, 100
+    n, g = 10002, 100
     rng = torch.Generator()
     rng.manual_seed(1465)
     mean_g = torch.randn((g,), generator=rng)

--- a/tests/test_onepass_mean_var_std.py
+++ b/tests/test_onepass_mean_var_std.py
@@ -23,7 +23,7 @@ from tests.common import BoringDataset
 
 @pytest.fixture
 def adata():
-    n_cell, g_gene = 10, 5
+    n_cell, g_gene = 12, 5
     rng = np.random.default_rng(1465)
     X = rng.integers(10, size=(n_cell, g_gene))
     return AnnData(X, dtype=X.dtype)
@@ -32,7 +32,7 @@ def adata():
 @pytest.fixture
 def dadc(adata: AnnData, tmp_path: Path):
     # save anndata files
-    limits = [2, 5, 10]
+    limits = [2, 5, 12]
     for i, limit in enumerate(zip([0] + limits, limits)):
         sliced_adata = adata[slice(*limit)]
         sliced_adata.write(os.path.join(tmp_path, f"adata.00{i}.h5ad"))


### PR DESCRIPTION
This fixes a bug in IncrementalPCA. There is a logic that checks that an even rank should be merged with an odd rank only when a corresponding odd rank exists. Instead of checking that even rank is less than the world size `rank < world_size` it should check that the corresponding odd rank is less than the world size `rank + 1 < world_size`. Without this fix the model just halts because it cannot receive the tensor from another rank.

To include it in the test, I added `TEST_DEVICES=3` to the test matrix. This requires fixing some tests by making the number of cells divisible by three so that no cells are dropped.