### PR TITLE
Address flaky mup test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ lint = ["ruff"]
 mypy = ["mypy", "types-PyYAML"]
 test = [
   "pytest-xdist",
+  "tenacity",
   "tensorboard",
   "torchvision",
 ]


### PR DESCRIPTION
Closes #291 

Introduces a test dependency on the `tenacity` package.

Automatically retries the download of CIFAR10 if there is a urllib connection timeout error.  Currently this implements 3 tries with 10 seconds between each try.