### PR TITLE
Add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ lightning_logs/
 build/
 notebooks/.ipynb_checkpoints/
 output/
+*.h5ad
+*.csv
+*.csv.gz
+*.tsv
+*.tsv.gz
+*.ckpt


### PR DESCRIPTION
Suggestion: add a couple file types to gitignore, things I frequently end up with in the repo, like output csv files, input tsv files, h5ad data files, and checkpoint files for trained models.