### PR TITLE
scvi: implement KL annealing, tons of tests, and fix a bug

### DIFF
--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -5,8 +5,10 @@
 
 import importlib
 import itertools
+import logging
 from typing import Any, Literal, Sequence
 
+import lightning.pytorch as pl
 import numpy as np
 import pandas as pd
 import torch
@@ -22,6 +24,10 @@ from cellarium.ml.utilities.testing import (
     assert_arrays_equal,
     assert_columns_and_array_lengths_equal,
 )
+
+# get a logger for use with pytorch lightning
+# (this is the same logger as in scvi-tools)
+logger = logging.getLogger(__name__)
 
 
 def class_from_class_path(class_path: str):
@@ -155,14 +161,14 @@ class FullyConnectedWithBatchArchitecture(torch.nn.Module):
             out_features = in_features
         else:
             module_list = torch.nn.ModuleList()
-            n_hidden = [layer["init_args"].pop("out_features") for layer in layers]
+            n_hidden = [layer["init_args"].get("out_features") for layer in layers]
             for layer, n_in, n_out in zip(layers, [in_features] + n_hidden, n_hidden):
+                layer["init_args"]["out_features"] = n_out
                 module_list.append(
                     DressedLayer(
                         instantiate_from_class_path(
                             layer["class_path"],
                             in_features=n_in,
-                            out_features=n_out,
                             bias=True,
                             **layer["init_args"],
                         ),
@@ -390,6 +396,39 @@ class DecoderSCVI(torch.nn.Module):
         return dist
 
 
+def compute_annealed_kl_weight(
+    epoch: int,
+    step: int,
+    n_epochs_kl_warmup: int | None,
+    n_steps_kl_warmup: int | None,
+    max_kl_weight: float = 1.0,
+    min_kl_weight: float = 0.0,
+) -> float:
+    """Computes the kl weight for the current step or epoch.
+    If both `n_epochs_kl_warmup` and `n_steps_kl_warmup` are None `max_kl_weight` is returned.
+    Args:
+        epoch: Current epoch.
+        step: Current step.
+        n_epochs_kl_warmup: Number of epochs to warm up the KL weight.
+        n_steps_kl_warmup: Number of steps to warm up the KL weight.
+        max_kl_weight: Maximum KL weight.
+        min_kl_weight: Minimum KL weight.
+    Returns:
+        The KL weight for the current step or epoch.
+    """
+    if min_kl_weight > max_kl_weight:
+        raise ValueError(f"min_kl_weight={min_kl_weight} is larger than max_kl_weight={max_kl_weight}.")
+
+    slope = max_kl_weight - min_kl_weight
+    if n_epochs_kl_warmup:
+        if epoch < n_epochs_kl_warmup:
+            return slope * (epoch / n_epochs_kl_warmup) + min_kl_weight
+    elif n_steps_kl_warmup:
+        if step < n_steps_kl_warmup:
+            return slope * (step / n_steps_kl_warmup) + min_kl_weight
+    return max_kl_weight
+
+
 class SingleCellVariationalInference(CellariumModel, PredictMixin):
     """
     Flexible version of single-cell variational inference (scVI) [1] re-implemented in Cellarium ML.
@@ -463,12 +502,13 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
         batch_embedded: bool = False,
         batch_representation_sampled: bool = False,
         n_latent_batch: int | None = None,
-        batch_kl_weight_max: float = 0.0,
         z_kl_weight_max: float = 1.0,
-        kl_annealing_start: float = 0.0,
-        kl_warmup_epochs: int | None = 400,
+        batch_kl_weight_max: float = 0.0,
         use_batch_norm: Literal["encoder", "decoder", "none", "both"] = "both",
         use_layer_norm: Literal["encoder", "decoder", "none", "both"] = "none",
+        kl_warmup_epochs: int | None = 400,
+        kl_warmup_steps: int | None = None,
+        kl_annealing_start: float = 0.0,
         use_size_factor_key: bool = False,
         use_observed_lib_size: bool = True,
     ):
@@ -487,8 +527,20 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
         self.batch_embedded = batch_embedded
         self.batch_representation_sampled = batch_representation_sampled
         self.n_latent_batch = n_latent_batch
+        if not (kl_annealing_start >= 0.0 and kl_annealing_start <= 1.0):
+            raise ValueError(f"kl_annealing_start={kl_annealing_start} must be in the range [0.0, 1.0].")
+        self.kl_annealing_start = kl_annealing_start
+        assert not ((kl_warmup_steps is not None) and (kl_warmup_epochs is not None)), (
+            "Only one of kl_warmup_epochs or kl_warmup_steps can be specified, not both."
+        )
+        self.kl_warmup_epochs = kl_warmup_epochs
+        self.kl_warmup_steps = kl_warmup_steps
         assert batch_kl_weight_max >= 0.0, "batch_kl_weight must be non-negative"
-        self.batch_kl_weight = batch_kl_weight_max
+        self.batch_kl_weight_max = batch_kl_weight_max
+        assert z_kl_weight_max >= 0.0, "z_kl_weight must be non-negative"
+        self.z_kl_weight_max = z_kl_weight_max
+        self.epoch = 0
+        self.step = 0
 
         if n_continuous_cov > 0:
             raise NotImplementedError("Continuous covariates are not yet implemented")
@@ -548,9 +600,24 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
                 layer["init_args"]["categorical_covariate_dimensions"] = n_cats_per_cov
             if "dressing_init_args" not in layer:
                 layer["dressing_init_args"] = {}
-            layer["dressing_init_args"]["use_batch_norm"] = use_batch_norm_encoder
-            layer["dressing_init_args"]["use_layer_norm"] = use_layer_norm_encoder
-            layer["dressing_init_args"]["dropout_rate"] = dropout_rate
+            if "use_batch_norm" not in layer["dressing_init_args"]:
+                logger.info(
+                    "use_batch_norm not specified individually in encoder hidden layer, "
+                    f"setting to {use_batch_norm_encoder}"
+                )
+                layer["dressing_init_args"]["use_batch_norm"] = use_batch_norm_encoder
+            if "use_layer_norm" not in layer["dressing_init_args"]:
+                logger.info(
+                    "use_layer_norm not specified individually in encoder hidden layer, "
+                    f"setting to {use_layer_norm_encoder}"
+                )
+                layer["dressing_init_args"]["use_layer_norm"] = use_layer_norm_encoder
+            if "dropout_rate" not in layer["dressing_init_args"]:
+                logger.info(
+                    "dropout_rate not specified individually in encoder hidden layer, "
+                    f"setting to {dropout_rate}"
+                )
+                layer["dressing_init_args"]["dropout_rate"] = dropout_rate
         assert isinstance(encoder["final_layer"], dict)
         if encoder["final_layer"]["class_path"] == "cellarium.ml.models.scvi.LinearWithBatch":
             encoder["final_layer"]["init_args"]["n_batch"] = self.n_latent_batch
@@ -564,9 +631,25 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
                 layer["init_args"]["categorical_covariate_dimensions"] = n_cats_per_cov
             if "dressing_init_args" not in layer:
                 layer["dressing_init_args"] = {}
-            layer["dressing_init_args"]["use_batch_norm"] = use_batch_norm_decoder
-            layer["dressing_init_args"]["use_layer_norm"] = use_layer_norm_decoder
-            layer["dressing_init_args"]["dropout_rate"] = 0.0  # scvi-tools does not use dropout in the decoder
+            if "use_batch_norm" not in layer["dressing_init_args"]:
+                logger.info(
+                    "use_batch_norm not specified individually in decoder hidden layer, "
+                    f"setting to {use_batch_norm_decoder}"
+                )
+                layer["dressing_init_args"]["use_batch_norm"] = use_batch_norm_decoder
+            if "use_layer_norm" not in layer["dressing_init_args"]:
+                logger.info(
+                    "use_layer_norm not specified individually in decoder hidden layer, "
+                    f"setting to {use_layer_norm_decoder}"
+                )
+                layer["dressing_init_args"]["use_layer_norm"] = use_layer_norm_decoder
+            if "dropout_rate" in layer["dressing_init_args"]:
+                if layer["dressing_init_args"]["dropout_rate"] != 0.0:
+                    logger.warning(
+                        "Dropout is not supported in the decoder of scVI. "
+                        "dropout_rate is being set to 0.0 in all decoder hidden layers."
+                    )
+                    layer["dressing_init_args"]["dropout_rate"] = 0.0  # scvi-tools does not use dropout in the decoder
         assert isinstance(decoder["final_layer"], dict)
         if decoder["final_layer"]["class_path"] == "cellarium.ml.models.scvi.LinearWithBatch":
             decoder["final_layer"]["init_args"]["n_batch"] = self.n_latent_batch
@@ -788,21 +871,46 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
 
         # optional KL divergence for batch representation
         kl_divergence_batch: torch.Tensor | int
-        if self.batch_representation_sampled and (self.batch_kl_weight > 0):
-            kl_divergence_batch = self.batch_kl_weight * kl(
+        if self.batch_representation_sampled and (self.batch_kl_weight_max > 0):
+            kl_divergence_batch = kl(
                 self.batch_embedding_distribution(batch_index_n=batch_index_n),
                 Normal(torch.zeros_like(batch_nb), torch.ones_like(batch_nb)),
             ).sum(dim=1)
         else:
             kl_divergence_batch = 0
 
+        # compute the annealed KL weight
+        kl_annealing_weight = compute_annealed_kl_weight(
+            epoch=self.epoch,
+            step=self.step,
+            n_epochs_kl_warmup=self.kl_warmup_epochs,
+            n_steps_kl_warmup=self.kl_warmup_steps,
+            max_kl_weight=1.0,
+            min_kl_weight=self.kl_annealing_start,
+        )
+
         # reconstruction loss
         rec_loss = -generative_outputs["px"].log_prob(x_ng).sum(-1)
 
         # full loss
-        loss = torch.mean(rec_loss + kl_divergence_z + kl_divergence_batch)
+        assert kl_annealing_weight >= 0.0 and kl_annealing_weight <= 1.0, (
+            f"Invalid KL annealing weight: {kl_annealing_weight}"
+        )
+        loss = torch.mean(
+            rec_loss 
+            + kl_annealing_weight * (
+                self.z_kl_weight_max * kl_divergence_z 
+                + self.batch_kl_weight_max * kl_divergence_batch
+            ),
+            dim=0,
+        )
 
-        return {"loss": loss, "reconstruction_loss": rec_loss, "kl_divergence_z": kl_divergence_z, "z_nk": inference_outputs["z"]}
+        return {
+            "loss": loss, 
+            "reconstruction_loss": rec_loss, 
+            "kl_divergence_z": kl_divergence_z, 
+            "z_nk": inference_outputs["z"],
+        }
 
     def predict(
         self,
@@ -963,6 +1071,25 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
 
         x_tilde_np = output_counts_sum_np / len(transformed_batch_index_n_list)
         return {"x_ng": x_tilde_np}
+    
+    def on_train_batch_end(self, trainer: pl.Trainer) -> None:
+        self.step = trainer.global_step
+        self.epoch = trainer.current_epoch
+        # log these values to pytorch lightning logger
+        if trainer.logger is not None:
+            trainer.logger.log_metrics(
+                {
+                    "kl_annealing_weight": compute_annealed_kl_weight(
+                        epoch=self.epoch,
+                        step=self.step,
+                        n_epochs_kl_warmup=self.kl_warmup_epochs,
+                        n_steps_kl_warmup=self.kl_warmup_steps,
+                        max_kl_weight=1.0,
+                        min_kl_weight=self.kl_annealing_start,
+                    )
+                },
+                step=trainer.global_step,
+            )
 
 
 def batch_index_to_batch_label(adata: AnnData, batch_keys: list[str]) -> pd.DataFrame:

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -463,7 +463,10 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
         batch_embedded: bool = False,
         batch_representation_sampled: bool = False,
         n_latent_batch: int | None = None,
-        batch_kl_weight: float = 0.0,
+        batch_kl_weight_max: float = 0.0,
+        z_kl_weight_max: float = 1.0,
+        kl_annealing_start: float = 0.0,
+        kl_warmup_epochs: int | None = 400,
         use_batch_norm: Literal["encoder", "decoder", "none", "both"] = "both",
         use_layer_norm: Literal["encoder", "decoder", "none", "both"] = "none",
         use_size_factor_key: bool = False,
@@ -484,8 +487,8 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin):
         self.batch_embedded = batch_embedded
         self.batch_representation_sampled = batch_representation_sampled
         self.n_latent_batch = n_latent_batch
-        assert batch_kl_weight >= 0.0, "batch_kl_weight must be non-negative"
-        self.batch_kl_weight = batch_kl_weight
+        assert batch_kl_weight_max >= 0.0, "batch_kl_weight must be non-negative"
+        self.batch_kl_weight = batch_kl_weight_max
 
         if n_continuous_cov > 0:
             raise NotImplementedError("Continuous covariates are not yet implemented")

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -468,6 +468,7 @@ n_epochs_kl_warmup: int = max_epochs
 max_z_kl_weight: float = 10.0  # this setting is not normal, but exaggerates problems
 batch_key: str = "batch_concat_cellxgene"
 log_variational: bool = True
+use_batchnorm: bool = False
 
 
 @pytest.fixture(scope="module")
@@ -501,10 +502,15 @@ def train_scvi_tools_model(
         n_latent=n_latent,
         n_layers=n_layers,
         n_hidden=n_hidden,
+        encode_covariates=True,
+        use_batch_norm="both" if use_batchnorm else "none",
         log_variational=log_variational,
         dispersion="gene",
         deeply_inject_covariates=True,
     )
+    print(model)
+    print(model.module.z_encoder)
+    print(model.module.decoder)
     model.train(
         max_epochs=max_epochs,
         train_size=1,
@@ -569,7 +575,7 @@ def train_cellarium_model(
                     "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
                     "init_args": {"out_features": n_hidden, "batch_to_bias_hidden_layers": []},
                     "dressing_init_args": {
-                        "use_batch_norm": True,
+                        "use_batch_norm": use_batchnorm,
                         "use_layer_norm": False,
                         "dropout_rate": 0.1,
                     },
@@ -584,7 +590,7 @@ def train_cellarium_model(
                     "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
                     "init_args": {"out_features": n_hidden, "batch_to_bias_hidden_layers": []},
                     "dressing_init_args": {
-                        "use_batch_norm": True,
+                        "use_batch_norm": use_batchnorm,
                         "use_layer_norm": False,
                         "dropout_rate": 0.0,
                     },


### PR DESCRIPTION
Important things:

- There was a bug where, during "predict()" and "reconstruct()", the value that was being used for `z_nk` was a _sample_ from the z distribution rather than the mean. This was a really big problem leading to bad outcomes when computing latent space metrics.
- Implemented KL annealing, which is really important for scvi-tools to get as nice of results as it gets
- Added tons of tests to show parity between cellarium and scvi-tools
    - losses and gradients now match exactly! (when computed using manual forward passes)
    - allowing the codebases themselves to train the respective models, they are on par when computing nearest-neighbors in the latent space using held-out test data