### PR TITLE
mypy update fix

### DIFF
--- a/cellarium/ml/models/probabilistic_pca.py
+++ b/cellarium/ml/models/probabilistic_pca.py
@@ -134,7 +134,7 @@ class ProbabilisticPCA(CellariumModel, PredictMixin):
                 )
                 pyro.sample(
                     "counts",
-                    dist.Normal(self.mean_g + z_nk @ self.W_kg, self.sigma).to_event(1),
+                    dist.Normal(self.mean_g + z_nk @ self.W_kg, self.sigma).to_event(1),  # type: ignore[arg-type]
                     obs=x_ng,
                 )
 


### PR DESCRIPTION
Just ignoring this complaint from `mypy` caused by a pytorch update:

```python
dist.Normal(self.mean_g + z_nk @ self.W_kg, self.sigma).to_event(1)
```
gives
```pytb
cellarium/ml/models/probabilistic_pca.py:137: error: Argument 2 to "Normal" has incompatible type "PyroParam"; expected "Tensor | float"  [arg-type]
```