### PR TITLE
use a patched version of anndata and python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Machine learning library for single-cell data analysis"
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE.md"}
 classifiers = [
   "Intended Audience :: Developers",
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "anndata",
+  "git+https://github.com/sjfleming/anndata.git@sf-backed-hdf5-fancy-indexing",
   "boltons",
   "braceexpand",
   "crick>=0.0.4",


### PR DESCRIPTION
This enables us to bypass https://github.com/scverse/anndata/issues/2064 by manually using https://github.com/scverse/anndata/pull/2066

New anndata also requires python 3.11 minimum