### PR TITLE
allow n_top_genes list, fix precision and bessel, improve tests

### DIFF
--- a/cellarium/ml/models/hvg_seurat_v3.py
+++ b/cellarium/ml/models/hvg_seurat_v3.py
@@ -59,7 +59,7 @@ class HVGSeuratV3(CellariumModel):
     ``clip_val``, and accumulates clipped sums.
 
     After epoch 1 (``on_train_epoch_end``) — computes normalized variance per
-    batch, ranks genes, and writes ``self.hvg_df`` (and optionally a CSV/Parquet
+    batch, ranks genes, and writes ``self.hvg_dfs`` (and optionally a CSV
     file at ``output_path``).
 
     The ``flavor`` argument controls how genes are ranked across batches when
@@ -84,24 +84,21 @@ class HVGSeuratV3(CellariumModel):
         df = model.hvg_df  # pandas DataFrame, Scanpy-compatible columns
 
     Args:
-        var_names_g:
-            Array of gene names, length ``n_genes``.
-        n_top_genes:
-            Number of highly variable genes to select.
-        n_batch:
-            Number of batches (use 1 when no batch information is given).
-        flavor:
-            Multi-batch gene ranking strategy.  ``"seurat_v3_paper"`` (default)
+        var_names_g: Array of gene names, length ``n_genes``.
+        n_top_genes: Number of highly variable genes to select. Can be a list of ints
+            to produce multiple gene sets in a single training run.
+        n_batch: Number of batches (use 1 when no batch information is given).
+        flavor: Multi-batch gene ranking strategy.  ``"seurat_v3_paper"`` (default)
             prioritises batch consistency; ``"seurat_v3"`` prioritises median rank.
-        use_batch_key:
-            Whether to expect a ``batch_index_n`` batch key in the dataloader output.
-             If False, the model will ignore batch keys and treat all data as a single batch.
-        span:
-            LOESS span (fraction of data used per local fit).  Default 0.3.
-        output_path:
-            If given, the result DataFrame is written to this CSV filepath after training.
+        use_batch_key: Whether to expect a ``batch_index_n`` batch key in the dataloader output.
+            If False, the model will ignore batch keys and treat all data as a single batch.
+        span: LOESS span (fraction of data used per local fit).  Default 0.3.
+        output_path: If given, the result DataFrame is written to this CSV filepath after training.
             (Ends with ``.csv``). If ``None``, no file is written, but you really want to
             write this output, as it would require manually calling _compute_hvg_df() later.
+        batch_n_cell_minimum: Minimum number of cells required for a batch to be considered valid.
+        n_batch_minimum: Minimum number of batches in which the gene is in n_top_genes highly variable
+            for a gene to make the final list.
     """
 
     _VALID_FLAVORS = frozenset({"seurat_v3", "seurat_v3_paper"})
@@ -109,12 +106,14 @@ class HVGSeuratV3(CellariumModel):
     def __init__(
         self,
         var_names_g: np.ndarray,
-        n_top_genes: int,
+        n_top_genes: int | list[int],
         n_batch: int = 1,
         flavor: Literal["seurat_v3", "seurat_v3_paper"] = "seurat_v3",
         use_batch_key: bool = False,
         span: float = 0.3,
         output_path: str | None = "hvg_seurat_v3_output.csv",
+        batch_n_cell_minimum: int = 2,
+        n_batch_minimum: int = 1,
     ) -> None:
         super().__init__()
         if flavor not in self._VALID_FLAVORS:
@@ -122,7 +121,10 @@ class HVGSeuratV3(CellariumModel):
         self.var_names_g = var_names_g
         n_vars = len(var_names_g)
         self.n_vars = n_vars
-        self.n_top_genes = n_top_genes
+        if isinstance(n_top_genes, int):
+            self.n_top_genes_list = [n_top_genes]
+        else:
+            self.n_top_genes_list = sorted(set(n_top_genes))
         self.n_batch = n_batch
         self.flavor = flavor
         self.use_batch_key = use_batch_key
@@ -144,6 +146,10 @@ class HVGSeuratV3(CellariumModel):
         if (output_path is not None) and (not output_path.endswith(".csv")):
             raise ValueError("output_path must end with .csv")
         self.output_path = output_path
+        self.batch_n_cell_minimum = batch_n_cell_minimum
+        if n_batch_minimum > n_batch:
+            raise ValueError(f"n_batch_minimum ({n_batch_minimum}) cannot exceed n_batch ({n_batch}).")
+        self.n_batch_minimum = n_batch_minimum
 
         self._current_epoch: int = 0
 
@@ -151,27 +157,27 @@ class HVGSeuratV3(CellariumModel):
         self.x_sums_bg: torch.Tensor
         self.x_squared_sums_bg: torch.Tensor
         self.x_size_b: torch.Tensor
-        self.register_buffer("x_sums_bg", torch.zeros(n_batch, n_vars))
-        self.register_buffer("x_squared_sums_bg", torch.zeros(n_batch, n_vars))
+        self.register_buffer("x_sums_bg", torch.zeros(n_batch, n_vars, dtype=torch.float64))
+        self.register_buffer("x_squared_sums_bg", torch.zeros(n_batch, n_vars, dtype=torch.float64))
         self.register_buffer("x_size_b", torch.zeros(n_batch))
 
         # Set between epochs by on_train_epoch_end after epoch 0: shape (n_batch, n_vars)
         self.clip_val_bg: torch.Tensor
         self.reg_std_bg: torch.Tensor
-        self.register_buffer("clip_val_bg", torch.zeros(n_batch, n_vars))
-        self.register_buffer("reg_std_bg", torch.zeros(n_batch, n_vars))
+        self.register_buffer("clip_val_bg", torch.zeros(n_batch, n_vars, dtype=torch.float64))
+        self.register_buffer("reg_std_bg", torch.zeros(n_batch, n_vars, dtype=torch.float64))
 
         # Epoch-1 buffers: shape (n_batch, n_vars)
         self.counts_sum_bg: torch.Tensor
         self.sq_counts_sum_bg: torch.Tensor
-        self.register_buffer("counts_sum_bg", torch.zeros(n_batch, n_vars))
-        self.register_buffer("sq_counts_sum_bg", torch.zeros(n_batch, n_vars))
+        self.register_buffer("counts_sum_bg", torch.zeros(n_batch, n_vars, dtype=torch.float64))
+        self.register_buffer("sq_counts_sum_bg", torch.zeros(n_batch, n_vars, dtype=torch.float64))
 
         # Dummy parameter so Lightning treats this as a trainable module
         self._dummy_param = torch.nn.Parameter(torch.empty(()))
         self._dummy_param.data.zero_()
 
-        self.hvg_df: pd.DataFrame | None = None
+        self.hvg_dfs: dict[int, pd.DataFrame] | None = None
 
     def reset_parameters(self) -> None:
         self.x_sums_bg.zero_()
@@ -224,27 +230,29 @@ class HVGSeuratV3(CellariumModel):
 
     def _accumulate_epoch0(self, x_ng: torch.Tensor, batch_idx_n: torch.Tensor) -> None:
         n_cells = x_ng.shape[0]
-        idx_exp = batch_idx_n.unsqueeze(1).expand(n_cells, self.n_vars)
-        sums_contrib = torch.zeros(self.n_batch, self.n_vars, dtype=x_ng.dtype, device=x_ng.device)
-        sq_sums_contrib = torch.zeros(self.n_batch, self.n_vars, dtype=x_ng.dtype, device=x_ng.device)
-        sums_contrib.scatter_add_(0, idx_exp, x_ng)
-        sq_sums_contrib.scatter_add_(0, idx_exp, x_ng**2)
-        self.x_sums_bg = self.x_sums_bg + sums_contrib
-        self.x_squared_sums_bg = self.x_squared_sums_bg + sq_sums_contrib
+        x64_ng = x_ng.double()
+        idx_exp_ng = batch_idx_n.unsqueeze(1).expand(n_cells, self.n_vars)
+        sums_contrib_bg = torch.zeros(self.n_batch, self.n_vars, dtype=torch.float64, device=x_ng.device)
+        sq_sums_contrib_bg = torch.zeros(self.n_batch, self.n_vars, dtype=torch.float64, device=x_ng.device)
+        sums_contrib_bg.scatter_add_(0, idx_exp_ng, x64_ng)
+        sq_sums_contrib_bg.scatter_add_(0, idx_exp_ng, x64_ng**2)
+        self.x_sums_bg = self.x_sums_bg + sums_contrib_bg
+        self.x_squared_sums_bg = self.x_squared_sums_bg + sq_sums_contrib_bg
         self.x_size_b = self.x_size_b + torch.bincount(batch_idx_n, minlength=self.n_batch)
 
     def _accumulate_epoch1(self, x_ng: torch.Tensor, batch_idx_n: torch.Tensor) -> None:
         n_cells = x_ng.shape[0]
+        x64_ng = x_ng.double()
         # Per-cell clip value: shape (n_cells, n_vars)
-        per_cell_clip = self.clip_val_bg[batch_idx_n].to(x_ng.dtype)  # (n_cells, n_vars)
-        x_clipped = torch.minimum(x_ng, per_cell_clip)
-        idx_exp = batch_idx_n.unsqueeze(1).expand(n_cells, self.n_vars)
-        sums_contrib = torch.zeros(self.n_batch, self.n_vars, dtype=x_ng.dtype, device=x_ng.device)
-        sq_sums_contrib = torch.zeros(self.n_batch, self.n_vars, dtype=x_ng.dtype, device=x_ng.device)
-        sums_contrib.scatter_add_(0, idx_exp, x_clipped)
-        sq_sums_contrib.scatter_add_(0, idx_exp, x_clipped**2)
-        self.counts_sum_bg = self.counts_sum_bg + sums_contrib
-        self.sq_counts_sum_bg = self.sq_counts_sum_bg + sq_sums_contrib
+        per_cell_clip_ng = self.clip_val_bg[batch_idx_n]  # float64
+        x_clipped_ng = torch.minimum(x64_ng, per_cell_clip_ng)
+        idx_exp_ng = batch_idx_n.unsqueeze(1).expand(n_cells, self.n_vars)
+        sums_contrib_bg = torch.zeros(self.n_batch, self.n_vars, dtype=torch.float64, device=x_ng.device)
+        sq_sums_contrib_bg = torch.zeros(self.n_batch, self.n_vars, dtype=torch.float64, device=x_ng.device)
+        sums_contrib_bg.scatter_add_(0, idx_exp_ng, x_clipped_ng)
+        sq_sums_contrib_bg.scatter_add_(0, idx_exp_ng, x_clipped_ng**2)
+        self.counts_sum_bg = self.counts_sum_bg + sums_contrib_bg
+        self.sq_counts_sum_bg = self.sq_counts_sum_bg + sq_sums_contrib_bg
 
     def on_train_start(self, trainer: pl.Trainer) -> None:
         """Validation: if in a distributed setting, use DDP with broadcast_buffers=False."""
@@ -281,15 +289,18 @@ class HVGSeuratV3(CellariumModel):
             dist.broadcast(self.reg_std_bg, src=0)
 
     def _compute_clip_val(self) -> None:
-        # Default to +inf so any batch skipped below (N < 2) acts as a no-op clip.
+        # Default to +inf so any batch skipped below (N < batch_n_cell_minimum) acts as a no-op clip.
         self.clip_val_bg.fill_(float("inf"))
         n_vars = self.n_vars
         for b in range(self.n_batch):
             N = self.x_size_b[b].item()
-            if N < 2:
+            if N < self.batch_n_cell_minimum:
                 continue
-            mean_g = (self.x_sums_bg[b] / N).cpu().numpy().astype(np.float64)
-            var_g = (self.x_squared_sums_bg[b] / N - (self.x_sums_bg[b] / N) ** 2).cpu().numpy().astype(np.float64)
+            sums = self.x_sums_bg[b].cpu().numpy()
+            sq_sums = self.x_squared_sums_bg[b].cpu().numpy()
+            mean_g = sums / N
+            # Unbiased (sample) variance with Bessel's correction, matching Scanpy's correction=1
+            var_g = (sq_sums - sums**2 / N) / (N - 1)
 
             not_const = var_g > 0
             estimated_var = np.zeros(n_vars, dtype=np.float64)
@@ -302,8 +313,8 @@ class HVGSeuratV3(CellariumModel):
             reg_std = np.sqrt(10**estimated_var)  # shape (n_vars,)
             clip_val = reg_std * np.sqrt(N) + mean_g
 
-            self.reg_std_bg[b] = torch.tensor(reg_std, dtype=torch.float32)
-            self.clip_val_bg[b] = torch.tensor(clip_val, dtype=torch.float32)
+            self.reg_std_bg[b] = torch.tensor(reg_std)
+            self.clip_val_bg[b] = torch.tensor(clip_val)
 
     def _finish_epoch1(self, trainer: pl.Trainer) -> None:
         # 1. Reduce epoch-1 buffers to rank 0
@@ -325,66 +336,72 @@ class HVGSeuratV3(CellariumModel):
                     UserWarning,
                     stacklevel=2,
                 )
-            self.hvg_df = self._compute_hvg_df(var_df=var_df)
-            if self.output_path is not None:
-                self._save(df=self.hvg_df, output_path=self.output_path)
+            self.hvg_dfs = {}
+            for n in self.n_top_genes_list:
+                df = self._compute_hvg_df(n_top_genes=n, var_df=var_df)
+                self.hvg_dfs[n] = df
+                if self.output_path is not None:
+                    path = self.output_path.replace(".csv", f"__top{n}.csv")
+                    self._save(df=df, output_path=path)
 
-    def _compute_hvg_df(self, var_df: pd.DataFrame | None = None) -> pd.DataFrame:
+    def _compute_hvg_df(self, n_top_genes: int, var_df: pd.DataFrame | None = None) -> pd.DataFrame:
         n_vars = self.n_vars
-        norm_gene_vars = np.zeros((self.n_batch, n_vars), dtype=np.float64)
+        norm_gene_var_bg = np.zeros((self.n_batch, n_vars), dtype=np.float64)
 
         for b in range(self.n_batch):
             N = self.x_size_b[b].item()
-            if N < 2:
+            if N < self.batch_n_cell_minimum:
                 continue
-            mean_bg = (self.x_sums_bg[b] / N).cpu().numpy().astype(np.float64)
-            reg_std = self.reg_std_bg[b].cpu().numpy().astype(np.float64)
-            sum_bg = self.counts_sum_bg[b].cpu().numpy().astype(np.float64)
-            sq_sum_bg = self.sq_counts_sum_bg[b].cpu().numpy().astype(np.float64)
+            mean_g = (self.x_sums_bg[b] / N).cpu().numpy().astype(np.float64)
+            reg_std_g = self.reg_std_bg[b].cpu().numpy().astype(np.float64)
+            sum_g = self.counts_sum_bg[b].cpu().numpy().astype(np.float64)
+            sq_sum_g = self.sq_counts_sum_bg[b].cpu().numpy().astype(np.float64)
 
-            denom = (N - 1) * reg_std**2
+            denom_g = (N - 1) * reg_std_g**2
             with np.errstate(divide="ignore", invalid="ignore"):
-                nv = (N * mean_bg**2 + sq_sum_bg - 2 * mean_bg * sum_bg) / denom
-            nv[np.isnan(nv)] = 0.0
-            norm_gene_vars[b] = nv
+                norm_gene_var_g = (N * mean_g**2 + sq_sum_g - 2 * mean_g * sum_g) / denom_g
+            norm_gene_var_g[np.isnan(norm_gene_var_g)] = 0.0
+            norm_gene_var_bg[b] = norm_gene_var_g
 
-        # Only rank over batches with sufficient data (N >= 2); invalid batches
+        # Only rank over batches with sufficient data (N >= batch_n_cell_minimum); invalid batches
         # have norm_gene_vars == 0 and would otherwise pollute num_batches_high_var
         # and median_ranked with arbitrary rankings of equal values.
-        valid_b = np.array([self.x_size_b[b].item() >= 2 for b in range(self.n_batch)])
-        norm_gene_vars_valid = norm_gene_vars[valid_b]
+        valid_b = np.array([self.x_size_b[b].item() >= self.batch_n_cell_minimum for b in range(self.n_batch)])
+        norm_gene_vars_valid_vg = norm_gene_var_bg[valid_b]
 
-        # Rank genes within each valid batch
-        ranked = np.argsort(np.argsort(-norm_gene_vars_valid, axis=1), axis=1).astype(np.float32)
-        num_batches_high_var = (ranked < self.n_top_genes).sum(axis=0).astype(int)
-        ranked[ranked >= self.n_top_genes] = np.nan
-        ma = np.ma.masked_invalid(ranked)
-        median_ranked = np.ma.median(ma, axis=0).filled(np.nan)
+        # Rank genes within each valid batch v
+        hvg_rank_vg = np.argsort(np.argsort(-norm_gene_vars_valid_vg, axis=1), axis=1).astype(np.float32)
+        num_batches_high_var_v = (hvg_rank_vg < n_top_genes).sum(axis=0).astype(int)
+        hvg_rank_vg[hvg_rank_vg >= n_top_genes] = np.nan
+        masked_hvg_rank_vg = np.ma.masked_invalid(hvg_rank_vg)
+        median_hvg_rank_g = np.ma.median(masked_hvg_rank_vg, axis=0).filled(np.nan)
 
-        variances_norm = norm_gene_vars_valid.mean(axis=0)
+        variances_norm_g = norm_gene_vars_valid_vg.mean(axis=0)
 
         df = pd.DataFrame(
             index=pd.Index(self.var_names_g, name="gene"),
             data={
-                "highly_variable_nbatches": num_batches_high_var,
-                "highly_variable_rank": median_ranked,
-                "variances_norm": variances_norm,
+                "highly_variable_nbatches": num_batches_high_var_v,
+                "highly_variable_rank": median_hvg_rank_g,
+                "variances_norm": variances_norm_g,
             },
         )
 
         # Use integer-position sort so duplicate gene names don't cause
         # df.loc to mark more than n_top_genes rows as highly variable.
-        rank_vals = df["highly_variable_rank"].fillna(np.inf).values
-        nbatches_vals = df["highly_variable_nbatches"].values
+        rank_vals_g = df["highly_variable_rank"].fillna(np.inf).values
+        nbatches_vals_g = df["highly_variable_nbatches"].values
         # np.lexsort: LAST key = primary sort key.
         if self.flavor == "seurat_v3":
             # Primary: rank ascending; tiebreaker: nbatches descending.
-            sort_positions = np.lexsort((-nbatches_vals, rank_vals))
+            sort_positions_g = np.lexsort((-nbatches_vals_g, rank_vals_g))
         else:  # seurat_v3_paper
             # Primary: nbatches descending; tiebreaker: rank ascending.
-            sort_positions = np.lexsort((rank_vals, -nbatches_vals))
+            sort_positions_g = np.lexsort((rank_vals_g, -nbatches_vals_g))
+        eligible_g = df["highly_variable_nbatches"].values >= self.n_batch_minimum
+        eligible_in_sort_order_g = sort_positions_g[eligible_g[sort_positions_g]]
         hvg_flags = np.zeros(len(df), dtype=bool)
-        hvg_flags[sort_positions[: self.n_top_genes]] = True
+        hvg_flags[eligible_in_sort_order_g[:n_top_genes]] = True
         df["highly_variable"] = hvg_flags
 
         if self.n_batch == 1:
@@ -399,7 +416,7 @@ class HVGSeuratV3(CellariumModel):
             if len(extra_cols) > 0:
                 df = df.join(var_df[extra_cols], how="left")
 
-        df = df.iloc[sort_positions]  # reorder rows by rank
+        df = df.iloc[sort_positions_g]  # reorder rows by rank
         return df
 
     def _save(self, df: pd.DataFrame, output_path: str) -> None:

--- a/tests/test_hvg_seurat_v3.py
+++ b/tests/test_hvg_seurat_v3.py
@@ -377,7 +377,11 @@ def adata_and_batch_col():
     ids=["no_batch", "with_batch"],
 )
 def test_hvg_seurat_v3_matches_scanpy(
-    tmp_path, adata_and_batch_col, n_top_genes: int, flavor: str, use_batch_key: bool
+    tmp_path,
+    adata_and_batch_col,
+    n_top_genes: int,
+    flavor: Literal["seurat_v3", "seurat_v3_paper"],
+    use_batch_key: bool,
 ):
     """
     End-to-end test: run HVGSeuratV3 through pl.Trainer(max_epochs=2) and
@@ -440,7 +444,9 @@ def test_hvg_seurat_v3_matches_scanpy(
     )
 
     # ---- Assertions: HVG count ------------------------------------------
-    hvg_df = model.hvg_dfs[n_top_genes]
+    hvg_dfs = model.hvg_dfs
+    assert hvg_dfs is not None, "Model should have an hvg_dfs dict after fitting"  # mypy
+    hvg_df = hvg_dfs[n_top_genes]
     assert "highly_variable" in hvg_df.columns
     assert hvg_df["highly_variable"].sum() == n_top_genes, (
         f"Expected {n_top_genes} HVGs, got {hvg_df['highly_variable'].sum()}"

--- a/tests/test_hvg_seurat_v3.py
+++ b/tests/test_hvg_seurat_v3.py
@@ -17,6 +17,7 @@ from cellarium.ml.models.hvg_seurat_v3 import _fit_loess_with_jitter
 from cellarium.ml.utilities.data import collate_fn
 
 N_TOP_GENES = 200
+jaccard_threshold = 1.0  # exact match
 
 
 # ---------------------------------------------------------------------------
@@ -71,13 +72,14 @@ def _run_model(
     batch_idx: np.ndarray | None,
     batch_key: str | None,
     output_path: str,
+    n_top_genes: int = N_TOP_GENES,
     batch_size: int = 512,
     flavor: Literal["seurat_v3", "seurat_v3_paper"] = "seurat_v3",
 ) -> HVGSeuratV3:
     """Instantiate, fit (2 epochs), and return the HVGSeuratV3 model."""
     model = HVGSeuratV3(
         var_names_g=var_names,
-        n_top_genes=N_TOP_GENES,
+        n_top_genes=n_top_genes,
         n_batch=n_batch,
         use_batch_key=(batch_key is not None),
         flavor=flavor,
@@ -165,7 +167,7 @@ def test_hvg_seurat_v3_sort_order():
         ]
     )
 
-    df = model._compute_hvg_df()
+    df = model._compute_hvg_df(n_top_genes=n_top)
 
     assert df["highly_variable"].sum() == n_top
 
@@ -244,7 +246,7 @@ def test_hvg_seurat_v3_flavor_sort_order(flavor, expected_hvg, excluded_hvg):
         ]
     )
 
-    df = model._compute_hvg_df()
+    df = model._compute_hvg_df(n_top_genes=n_top)
 
     assert df["highly_variable"].sum() == n_top
     for gene in expected_hvg:
@@ -343,7 +345,7 @@ def test_hvg_seurat_v3_invalid_batch_excluded_from_ranking():
     nv_b0 = [100.0, 90.0, 80.0, 70.0, 60.0, 50.0]
     model.sq_counts_sum_bg[0] = torch.tensor([v * (N - 1) for v in nv_b0])
 
-    df = model._compute_hvg_df()
+    df = model._compute_hvg_df(n_top_genes=n_top)
 
     assert df["highly_variable"].sum() == n_top
     assert df["highly_variable_nbatches"].max() == 1, (
@@ -357,75 +359,31 @@ def test_hvg_seurat_v3_invalid_batch_excluded_from_ranking():
 # ---------------------------------------------------------------------------
 
 
-def _load_adata():
+@pytest.fixture(scope="session")
+def adata_and_batch_col():
     import scanpy as sc
 
-    adata, batch_column = sc.datasets.ebi_expression_atlas("E-MTAB-10137"), "Sample Characteristic[individual]"
+    adata = sc.datasets.ebi_expression_atlas("E-MTAB-10137")
+    batch_column = "Sample Characteristic[individual]"
     adata.obs[batch_column] = adata.obs[batch_column].astype("category")
     return adata, batch_column
 
 
-def test_hvg_seurat_v3_paper_matches_scanpy(tmp_path):
-    """
-    End-to-end test: compare HVGSeuratV3 (``flavor='seurat_v3_paper'``) against
-    Scanpy in multi-batch mode.
-
-    ``seurat_v3`` with batch_key is already covered by
-    ``test_hvg_seurat_v3_matches_scanpy[with_batch]``.  This test validates the
-    ``seurat_v3_paper`` sort order (nbatches-primary) against Scanpy's own
-    implementation of that flavor.
-    """
-    import scanpy as sc
-
-    flavor: Literal["seurat_v3", "seurat_v3_paper"] = "seurat_v3_paper"
-    adata, batch_col = _load_adata()
-    x = _to_dense(adata.X)
-    var_names = np.asarray(adata.var_names)
-
-    batch_cats = list(adata.obs[batch_col].cat.categories)
-    n_batch = len(batch_cats)
-    cat_to_idx = {c: i for i, c in enumerate(batch_cats)}
-    batch_idx = np.array([cat_to_idx[c] for c in adata.obs[batch_col]], dtype=np.int64)
-
-    sc_df = sc.pp.highly_variable_genes(
-        adata.copy(),
-        flavor=flavor,
-        n_top_genes=N_TOP_GENES,
-        batch_key=batch_col,
-        inplace=False,
-    )
-
-    output_file = str(tmp_path / f"hvg_{flavor}.csv")
-    model = _run_model(
-        x=x,
-        var_names=var_names,
-        n_batch=n_batch,
-        batch_idx=batch_idx,
-        batch_key="batch_index_n",
-        output_path=output_file,
-        flavor=flavor,
-    )
-
-    hvg_df = model.hvg_df
-    assert hvg_df is not None
-    assert hvg_df["highly_variable"].sum() == N_TOP_GENES
-
-    our_hvg = set(hvg_df[hvg_df["highly_variable"]].index)
-    sc_hvg = set(sc_df[sc_df["highly_variable"]].index)
-    jaccard = len(our_hvg & sc_hvg) / len(our_hvg | sc_hvg)
-    assert jaccard >= 0.98, f"Jaccard {jaccard:.4f} below 0.98 for flavor={flavor!r} with batch_key"
-
-
+@pytest.mark.parametrize("n_top_genes", [500, 2000])
+@pytest.mark.parametrize("flavor", ["seurat_v3", "seurat_v3_paper"])
 @pytest.mark.parametrize(
     "use_batch_key",
     [False, True],
     ids=["no_batch", "with_batch"],
 )
-def test_hvg_seurat_v3_matches_scanpy(tmp_path, use_batch_key: bool):
+def test_hvg_seurat_v3_matches_scanpy(
+    tmp_path, adata_and_batch_col, n_top_genes: int, flavor: str, use_batch_key: bool
+):
     """
     End-to-end test: run HVGSeuratV3 through pl.Trainer(max_epochs=2) and
-    compare the selected HVG set with scanpy.pp.highly_variable_genes
-    (flavor='seurat_v3').
+    compare the selected HVG set with scanpy.pp.highly_variable_genes for
+    both flavors (``seurat_v3`` and ``seurat_v3_paper``), with and without a
+    batch key, and for multiple values of ``n_top_genes``.
 
     seurat_v3 expects *raw counts* (no log-transform), so we feed the count
     matrix directly to both our model and Scanpy.
@@ -433,7 +391,7 @@ def test_hvg_seurat_v3_matches_scanpy(tmp_path, use_batch_key: bool):
     import pandas as pd
     import scanpy as sc
 
-    adata, batch_col = _load_adata()
+    adata, batch_col = adata_and_batch_col
     x = _to_dense(adata.X)
     var_names = np.asarray(adata.var_names)
 
@@ -450,11 +408,11 @@ def test_hvg_seurat_v3_matches_scanpy(tmp_path, use_batch_key: bool):
         sc_batch_key = None
         model_batch_key = None
 
-    # ---- Scanpy reference (seurat_v3 uses raw counts) --------------------
+    # ---- Scanpy reference -----------------------------------------------
     sc_df = sc.pp.highly_variable_genes(
         adata.copy(),
-        flavor="seurat_v3",
-        n_top_genes=N_TOP_GENES,
+        flavor=flavor,
+        n_top_genes=n_top_genes,
         batch_key=sc_batch_key,
         inplace=False,
     )
@@ -468,23 +426,24 @@ def test_hvg_seurat_v3_matches_scanpy(tmp_path, use_batch_key: bool):
         batch_idx=batch_idx,
         batch_key=model_batch_key,
         output_path=output_file,
+        n_top_genes=n_top_genes,
+        flavor=flavor,
     )
 
     # ---- Assertions: output artefacts ------------------------------------
-    hvg_df = model.hvg_df
-    assert hvg_df is not None, "HVGSeuratV3.hvg_df was not populated after training"
-    assert os.path.exists(output_file), "on_train_epoch_end did not write the output CSV"
+    actual_output_file = output_file.replace(".csv", f"__top{n_top_genes}.csv")
+    assert os.path.exists(actual_output_file), "on_train_epoch_end did not write the output CSV"
 
-    # The saved file should round-trip cleanly
-    saved_df = pd.read_csv(output_file, index_col=0)
+    saved_df = pd.read_csv(actual_output_file, index_col=0)
     assert set(saved_df.columns).issuperset({"highly_variable"}), (
         f"Saved CSV is missing expected columns; got {list(saved_df.columns)}"
     )
 
     # ---- Assertions: HVG count ------------------------------------------
+    hvg_df = model.hvg_dfs[n_top_genes]
     assert "highly_variable" in hvg_df.columns
-    assert hvg_df["highly_variable"].sum() == N_TOP_GENES, (
-        f"Expected {N_TOP_GENES} HVGs, got {hvg_df['highly_variable'].sum()}"
+    assert hvg_df["highly_variable"].sum() == n_top_genes, (
+        f"Expected {n_top_genes} HVGs, got {hvg_df['highly_variable'].sum()}"
     )
 
     # ---- Assertions: overlap with Scanpy --------------------------------
@@ -493,11 +452,10 @@ def test_hvg_seurat_v3_matches_scanpy(tmp_path, use_batch_key: bool):
     union = our_hvg | sc_hvg
     jaccard = len(our_hvg & sc_hvg) / len(union)
 
-    # Jaccard threshold
-    threshold = 0.98
+    threshold = jaccard_threshold
     assert jaccard >= threshold, (
-        f"Jaccard similarity {jaccard:.4f} is below {threshold} for seurat_v3 "
-        f"{'with' if use_batch_key else 'without'} batch_key"
+        f"Jaccard similarity {jaccard:.4f} is below {threshold} for {flavor=!r} "
+        f"{'with' if use_batch_key else 'without'} batch_key, {n_top_genes=}"
     )
 
     # ---- Assertions: batch-specific columns ------------------------------
@@ -510,7 +468,7 @@ def test_hvg_seurat_v3_matches_scanpy(tmp_path, use_batch_key: bool):
         )
 
 
-def test_hvg_seurat_v3_cli_matches_scanpy(tmp_path):
+def test_hvg_seurat_v3_cli_matches_scanpy(tmp_path, adata_and_batch_col):
     """
     End-to-end CLI integration test: run HVGSeuratV3 via the Lightning CLI
     (``main()``) backed by a :class:`~cellarium.ml.CellariumAnnDataDataModule`
@@ -524,7 +482,7 @@ def test_hvg_seurat_v3_cli_matches_scanpy(tmp_path):
     import pandas as pd
     import scanpy as sc
 
-    adata, batch_col = _load_adata()
+    adata, batch_col = adata_and_batch_col
     adata_path = tmp_path / "test.h5ad"
     adata.write_h5ad(adata_path)
     batch_cats = list(adata.obs[batch_col].cat.categories)
@@ -591,8 +549,9 @@ def test_hvg_seurat_v3_cli_matches_scanpy(tmp_path):
     main(config)
 
     # ---- Output file was written by on_train_epoch_end -------------------
-    assert os.path.exists(output_file), "CLI did not write the HVG output CSV"
-    hvg_df = pd.read_csv(output_file, index_col=0)
+    output_filename = output_file.replace(".csv", f"__top{N_TOP_GENES}.csv")
+    assert os.path.exists(output_filename), "CLI did not write the HVG output CSV"
+    hvg_df = pd.read_csv(output_filename, index_col=0)
 
     # ---- Basic structural checks ----------------------------------------
     assert "highly_variable" in hvg_df.columns
@@ -614,4 +573,6 @@ def test_hvg_seurat_v3_cli_matches_scanpy(tmp_path):
     our_hvg = set(hvg_df[hvg_df["highly_variable"]].index)
     sc_hvg = set(sc_df[sc_df["highly_variable"]].index)
     jaccard = len(our_hvg & sc_hvg) / len(our_hvg | sc_hvg)
-    assert jaccard >= 0.98, f"CLI Jaccard similarity {jaccard:.4f} is below 0.98 for seurat_v3 with batch_key"
+    assert jaccard >= jaccard_threshold, (
+        f"CLI Jaccard similarity {jaccard:.4f} is below {jaccard_threshold} for seurat_v3 with batch_key"
+    )


### PR DESCRIPTION
Modifications for `HVGSeuratV3`:
 - allow `n_top_genes` to be a list so you only need to do the training once and can get results at various HVG numbers
     - I previously thought you could just take the top of a longer list but this is not true at all
 - add two args beyond what scanpy does:
     - `batch_n_cell_minimum`: exclude batches with fewer than this many cells from the computation entirely (useful for a large dataset where some batches are really small and crappy)
     - `n_batch_minimum`: exclude genes that are highly variable in fewer batches than this from being "highly variable" in the output (this can be used to exclude genes "highly variable" in only one batch, for example)

Improve tests and made them more stringent.  Found a discrepancy due to bessel correction and also the use of float64.  Now matches scanpy results exactly in tests.