### PR TITLE
Output csv for `OnePassMeanVarStd` and `FileMultiLoader` for configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ else
 endif
 
 test-examples: FORCE
+	rm -r /tmp/test_examples || true
 	cellarium-ml onepass_mean_var_std fit --config examples/cli_workflow/onepass_train_config.yaml
 	cellarium-ml incremental_pca fit --config examples/cli_workflow/ipca_train_config.yaml
 	cellarium-ml logistic_regression fit --config examples/cli_workflow/lr_train_config.yaml

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -35,7 +35,7 @@ def _resolve_loader(loader_fn: Callable[[str], Any] | str) -> Callable[[str], An
     if isinstance(loader_fn, str):
         loader_fn = import_object(loader_fn)
     if loader_fn not in cached_loaders:
-        cached_loaders[loader_fn] = cache(loader_fn)
+        cached_loaders[loader_fn] = cache(loader_fn)  # type: ignore[arg-type]
     return cached_loaders[loader_fn]
 
 
@@ -52,7 +52,7 @@ def _resolve_value(
     if isinstance(convert_fn, str):
         convert_fn = import_object(convert_fn)
     if convert_fn is not None:
-        obj = convert_fn(obj)
+        obj = convert_fn(obj)  # type: ignore[operator]
     return obj
 
 

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -105,16 +105,17 @@ class FileMultiLoader:
         model:
           transforms:
             - class_path: cellarium.ml.transforms.ZScore
-              init_args: !FileMultiLoader
-                file_path: gs://dsp-cellarium-cas-public/test-data/onepass.csv
+              init_args:
+                !FileMultiLoader
+                file_path: /tmp/test_examples/onepass/onepass.csv
                 loader_fn: pandas.read_csv
                 fields:
                   mean_g:
-                    attr: mean_g
-                    convert_fn: torch.tensor
+                    attr: mean_g.values
+                    convert_fn: torch.FloatTensor
                   std_g:
-                    attr: std_g
-                    convert_fn: torch.tensor
+                    attr: std_g.values
+                    convert_fn: torch.FloatTensor
                   var_names_g:
                     attr: var_names_g
                     convert_fn: pandas.Series.to_numpy

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -90,6 +90,81 @@ class FileLoader:
 
 
 @dataclass
+class FileMultiLoader:
+    """
+    A YAML constructor for loading a file once and extracting multiple fields from it.
+
+    Applied to a ``init_args`` mapping, it returns a dict that is unpacked as keyword
+    arguments to the constructor, allowing all fields to be specified in a single block
+    instead of repeating the file path and loader for each argument.
+
+    Example:
+
+    .. code-block:: yaml
+
+        model:
+          transforms:
+            - class_path: cellarium.ml.transforms.ZScore
+              init_args: !FileMultiLoader
+                file_path: gs://dsp-cellarium-cas-public/test-data/onepass.csv
+                loader_fn: pandas.read_csv
+                fields:
+                  mean_g:
+                    attr: mean_g
+                    convert_fn: torch.tensor
+                  std_g:
+                    attr: std_g
+                    convert_fn: torch.tensor
+                  var_names_g:
+                    attr: var_names_g
+                    convert_fn: pandas.Series.to_numpy
+
+    Args:
+        file_path:
+            The file path to load the object from.
+        loader_fn:
+            A function to load the object from the file path.
+        fields:
+            A mapping from output key names to field specs. Each spec may contain:
+            ``attr`` (dotted attribute path), ``key`` (item key), and ``convert_fn``
+            (importable callable string or ``None``).
+    """
+
+    file_path: str
+    loader_fn: Callable[[str], Any] | str
+    fields: dict[str, dict]
+
+    def __new__(cls, file_path, loader_fn, fields):
+        if isinstance(loader_fn, str):
+            loader_fn = import_object(loader_fn)
+        if loader_fn not in cached_loaders:
+            cached_loaders[loader_fn] = cache(loader_fn)
+        loader_fn = cached_loaders[loader_fn]
+        obj = loader_fn(file_path)
+
+        result = {}
+        for name, spec in fields.items():
+            value = obj
+            attr = spec.get("attr")
+            key = spec.get("key")
+            convert_fn = spec.get("convert_fn")
+
+            if attr is not None:
+                value = attrgetter(attr)(value)
+            if key is not None:
+                value = value[key]
+
+            if isinstance(convert_fn, str):
+                convert_fn = import_object(convert_fn)
+            if convert_fn is not None:
+                value = convert_fn(value)
+
+            result[name] = value
+
+        return result
+
+
+@dataclass
 class CheckpointLoader(FileLoader):
     """
     A YAML constructor for loading a :class:`~cellarium.ml.core.CellariumModule` checkpoint and accessing its
@@ -132,6 +207,11 @@ def file_loader_constructor(loader: yaml.SafeLoader, node: yaml.nodes.MappingNod
     return FileLoader(**loader.construct_mapping(node))  # type: ignore[arg-type]
 
 
+def file_multi_loader_constructor(loader: yaml.SafeLoader, node: yaml.nodes.MappingNode) -> dict:
+    """Construct a dict of objects from a file."""
+    return FileMultiLoader(**loader.construct_mapping(node, deep=True))  # type: ignore[arg-type]
+
+
 def checkpoint_loader_constructor(loader: yaml.SafeLoader, node: yaml.nodes.MappingNode) -> CheckpointLoader:
     """Construct an object from a checkpoint."""
     return CheckpointLoader(**loader.construct_mapping(node))  # type: ignore[arg-type]
@@ -139,6 +219,7 @@ def checkpoint_loader_constructor(loader: yaml.SafeLoader, node: yaml.nodes.Mapp
 
 loader = DefaultLoader
 loader.add_constructor("!FileLoader", file_loader_constructor)
+loader.add_constructor("!FileMultiLoader", file_multi_loader_constructor)
 loader.add_constructor("!CheckpointLoader", checkpoint_loader_constructor)
 
 

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -31,6 +31,31 @@ from cellarium.ml.utilities.data import AnnDataField, collate_fn
 cached_loaders = {}
 
 
+def _resolve_loader(loader_fn: Callable[[str], Any] | str) -> Callable[[str], Any]:
+    if isinstance(loader_fn, str):
+        loader_fn = import_object(loader_fn)
+    if loader_fn not in cached_loaders:
+        cached_loaders[loader_fn] = cache(loader_fn)
+    return cached_loaders[loader_fn]
+
+
+def _resolve_value(
+    obj: Any,
+    attr: str | None = None,
+    key: Any = None,
+    convert_fn: Callable[[Any], Any] | str | None = None,
+) -> Any:
+    if attr is not None:
+        obj = attrgetter(attr)(obj)
+    if key is not None:
+        obj = obj[key]
+    if isinstance(convert_fn, str):
+        convert_fn = import_object(convert_fn)
+    if convert_fn is not None:
+        obj = convert_fn(obj)
+    return obj
+
+
 @dataclass
 class FileLoader:
     """
@@ -69,24 +94,8 @@ class FileLoader:
     convert_fn: Callable[[Any], Any] | str | None = None
 
     def __new__(cls, file_path, loader_fn, attr=None, key=None, convert_fn=None):
-        if isinstance(loader_fn, str):
-            loader_fn = import_object(loader_fn)
-        if loader_fn not in cached_loaders:
-            cached_loaders[loader_fn] = cache(loader_fn)
-        loader_fn = cached_loaders[loader_fn]
-        obj = loader_fn(file_path)
-
-        if attr is not None:
-            obj = attrgetter(attr)(obj)
-        if key is not None:
-            obj = obj[key]
-
-        if isinstance(convert_fn, str):
-            convert_fn = import_object(convert_fn)
-        if convert_fn is not None:
-            obj = convert_fn(obj)
-
-        return obj
+        obj = _resolve_loader(loader_fn)(file_path)
+        return _resolve_value(obj, attr=attr, key=key, convert_fn=convert_fn)
 
 
 @dataclass
@@ -136,33 +145,8 @@ class FileMultiLoader:
     fields: dict[str, dict]
 
     def __new__(cls, file_path, loader_fn, fields) -> dict:  # type: ignore[misc]
-        if isinstance(loader_fn, str):
-            loader_fn = import_object(loader_fn)
-        if loader_fn not in cached_loaders:
-            cached_loaders[loader_fn] = cache(loader_fn)
-        loader_fn = cached_loaders[loader_fn]
-        obj = loader_fn(file_path)
-
-        result = {}
-        for name, spec in fields.items():
-            value = obj
-            attr = spec.get("attr")
-            key = spec.get("key")
-            convert_fn = spec.get("convert_fn")
-
-            if attr is not None:
-                value = attrgetter(attr)(value)
-            if key is not None:
-                value = value[key]
-
-            if isinstance(convert_fn, str):
-                convert_fn = import_object(convert_fn)
-            if convert_fn is not None:
-                value = convert_fn(value)
-
-            result[name] = value
-
-        return result
+        obj = _resolve_loader(loader_fn)(file_path)
+        return {name: _resolve_value(obj, **spec) for name, spec in fields.items()}
 
 
 @dataclass

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -134,7 +134,7 @@ class FileMultiLoader:
     loader_fn: Callable[[str], Any] | str
     fields: dict[str, dict]
 
-    def __new__(cls, file_path, loader_fn, fields):
+    def __new__(cls, file_path, loader_fn, fields) -> dict:  # type: ignore[misc]
         if isinstance(loader_fn, str):
             loader_fn = import_object(loader_fn)
         if loader_fn not in cached_loaders:
@@ -209,7 +209,7 @@ def file_loader_constructor(loader: yaml.SafeLoader, node: yaml.nodes.MappingNod
 
 def file_multi_loader_constructor(loader: yaml.SafeLoader, node: yaml.nodes.MappingNode) -> dict:
     """Construct a dict of objects from a file."""
-    return FileMultiLoader(**loader.construct_mapping(node, deep=True))  # type: ignore[arg-type]
+    return FileMultiLoader(**loader.construct_mapping(node, deep=True))  # type: ignore[arg-type, return-value]
 
 
 def checkpoint_loader_constructor(loader: yaml.SafeLoader, node: yaml.nodes.MappingNode) -> CheckpointLoader:

--- a/cellarium/ml/core/module.py
+++ b/cellarium/ml/core/module.py
@@ -468,6 +468,14 @@ class CellariumModule(pl.LightningModule):
         if callable(on_train_batch_end):
             on_train_batch_end(self.trainer)
 
+    def on_train_end(self) -> None:
+        """
+        Calls the ``on_train_end`` method on the module.
+        """
+        on_train_end = getattr(self.model, "on_train_end", None)
+        if callable(on_train_end):
+            on_train_end(self.trainer)
+
     def move_cpu_transforms_to_dataloader(self) -> None:
         if not self._cpu_transforms_in_module_pipeline:
             warnings.warn(

--- a/cellarium/ml/models/onepass_mean_var_std.py
+++ b/cellarium/ml/models/onepass_mean_var_std.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 import lightning.pytorch as pl
 import numpy as np
+import pandas as pd
 import torch
 import torch.distributed as dist
 from lightning.pytorch.strategies import DDPStrategy
@@ -32,12 +33,11 @@ class OnePassMeanVarStd(CellariumModel):
        <https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance>`_.
 
     Args:
-        var_names_g:
-            The variable names schema for the input data validation.
-        algorithm:
-            ``"naive"`` (default) or ``"shifted_data"`` (numerically stable).
-        n_batch:
-            Number of batches. Use 1 to reproduce ``batch_key``=None behavior.
+        var_names_g: The variable names schema for the input data validation.
+        algorithm: ``"naive"`` (default) or ``"shifted_data"`` (numerically stable).
+        n_batch: Number of batches. Use 1 to reproduce ``batch_key``=None behavior.
+        output_path: Optional path to save a summary CSV at the end of training, containing
+            the mean and variance for each gene. If None, no CSV will be saved.
     """
 
     def __init__(
@@ -45,6 +45,7 @@ class OnePassMeanVarStd(CellariumModel):
         var_names_g: np.ndarray,
         algorithm: Literal["naive", "shifted_data"] = "naive",
         n_batch: int = 1,
+        output_path: str | None = "onepass_mean_var_std_output.csv",
     ) -> None:
         super().__init__()
         self.var_names_g = var_names_g
@@ -52,6 +53,9 @@ class OnePassMeanVarStd(CellariumModel):
         self.n_vars = n_vars
         self.algorithm = algorithm
         self.n_batch = n_batch
+        self.output_path = output_path
+        if (self.output_path is not None) and not self.output_path.endswith(".csv"):
+            raise ValueError("OnePassMeanVarStd output_path must end with .csv")
 
         self.x_shift: torch.Tensor | None
         if self.algorithm == "shifted_data":
@@ -180,3 +184,16 @@ class OnePassMeanVarStd(CellariumModel):
         """Per-batch population variance, shape ``(n_batch, n_genes)``."""
         mean_bg = self.x_sums_bg / self.x_size_b.unsqueeze(1)
         return self.x_squared_sums_bg / self.x_size_b.unsqueeze(1) - mean_bg**2
+
+    def on_train_end(self, trainer: pl.Trainer) -> None:
+        """Save a summary output CSV so we need not load the checkpoint downstream."""
+        if trainer.is_global_zero and (self.output_path is not None):
+            df = pd.DataFrame(
+                {
+                    "var_names_g": self.var_names_g,
+                    "mean_g": self.mean_g.detach().cpu().numpy(),
+                    "var_g": self.var_g.detach().cpu().numpy(),
+                    "std_g": self.std_g.detach().cpu().numpy(),
+                }
+            )
+            df.to_csv(self.output_path, index=False)

--- a/examples/cli_workflow/ipca_train_config.yaml
+++ b/examples/cli_workflow/ipca_train_config.yaml
@@ -63,22 +63,20 @@ model:
         target_count: 10_000
     - cellarium.ml.transforms.Log1p
     - class_path: cellarium.ml.transforms.ZScore
-      init_args:
-        mean_g:
-          !CheckpointLoader
-          file_path: /tmp/test_examples/onepass/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
-          attr: model.mean_g
-          convert_fn: null
-        std_g:
-          !CheckpointLoader
-          file_path: /tmp/test_examples/onepass/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
-          attr: model.std_g
-          convert_fn: null
-        var_names_g:
-          !CheckpointLoader
-          file_path: /tmp/test_examples/onepass/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
-          attr: model.var_names_g
-          convert_fn: null
+      init_args: 
+        !FileMultiLoader
+        file_path: /tmp/test_examples/onepass/onepass.csv
+        loader_fn: pandas.read_csv
+        fields:
+          mean_g:
+            attr: mean_g
+            convert_fn: torch.tensor
+          std_g:
+            attr: std_g
+            convert_fn: torch.tensor
+          var_names_g:
+            attr: var_names_g
+            convert_fn: pandas.Series.to_numpy
   model:
     class_path: cellarium.ml.models.IncrementalPCA
     init_args:

--- a/examples/cli_workflow/ipca_train_config.yaml
+++ b/examples/cli_workflow/ipca_train_config.yaml
@@ -69,11 +69,11 @@ model:
         loader_fn: pandas.read_csv
         fields:
           mean_g:
-            attr: mean_g
-            convert_fn: torch.tensor
+            attr: mean_g.values
+            convert_fn: torch.FloatTensor
           std_g:
-            attr: std_g
-            convert_fn: torch.tensor
+            attr: std_g.values
+            convert_fn: torch.FloatTensor
           var_names_g:
             attr: var_names_g
             convert_fn: pandas.Series.to_numpy

--- a/examples/cli_workflow/onepass_train_config.yaml
+++ b/examples/cli_workflow/onepass_train_config.yaml
@@ -66,6 +66,7 @@ model:
     class_path: cellarium.ml.models.OnePassMeanVarStd
     init_args:
       algorithm: shifted_data
+      output_path: /tmp/test_examples/onepass/onepass.csv
   optim_fn: null
   optim_kwargs: null
   scheduler_fn: null


### PR DESCRIPTION
The idea here was to have the onepass model output a simple CSV summary file, so downstream we never really need to load a checkpoint file unless we want to.

I make use of that CSV file in the `test-examples` pipeline.  Now the PCA training uses that output CSV from onepass (instead of the checkpoint).

This also seemed like a good opportunity to introduce a `FileMultiLoader` for the config files.  Instead of configs that look like this
```yaml
    - class_path: cellarium.ml.transforms.ZScore
      init_args:
        mean_g:
          !CheckpointLoader
          file_path: /tmp/test_examples/onepass/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
          attr: model.mean_g
          convert_fn: null
        std_g:
          !CheckpointLoader
          file_path: /tmp/test_examples/onepass/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
          attr: model.std_g
          convert_fn: null
        var_names_g:
          !CheckpointLoader
          file_path: /tmp/test_examples/onepass/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
          attr: model.var_names_g
          convert_fn: null
```
we can have (less error-prone) configs that look like this
```yaml
    - class_path: cellarium.ml.transforms.ZScore
      init_args: 
        !FileMultiLoader
        file_path: /tmp/test_examples/onepass/onepass.csv
        loader_fn: pandas.read_csv
        fields:
          mean_g:
            attr: mean_g.values
            convert_fn: torch.FloatTensor
          std_g:
            attr: std_g.values
            convert_fn: torch.FloatTensor
          var_names_g:
            attr: var_names_g
            convert_fn: pandas.Series.to_numpy
```

It's still not very concise, but at least we're not having to type the same filename 3 times.