### PR TITLE
add google-cloud-cli for nextflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,13 @@ ENV DOCKER=true \
 ARG VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv python-is-python3 git \
+    python3 python3-pip python3-venv python-is-python3 git curl gnupg \
+ && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+ && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \
+    https://packages.cloud.google.com/apt cloud-sdk main" \
+    > /etc/apt/sources.list.d/google-cloud-sdk.list \
+ && apt-get update && apt-get install -y --no-install-recommends google-cloud-cli \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && python3 -m venv /opt/venv \


### PR DESCRIPTION
Add google-cloud-cli to docker image

I didn't want to do this, but for nextflow workflows, it's pretty much totally necessary.  Using the native nextflow file staging just won't work for us here.  We need to download as fast as possible upfront, and we need `gsutil -m cp` or `gcloud storage cp` to do it.

Docker image is a bit larger, but at least I can now do the nextflow stuff, which seems useful