### PR TITLE
PyArrow data fomat for speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __pycache__/
-data/
 runs/
 .ipynb_checkpoints
 .mypy_cache/

--- a/cellarium/ml/__init__.py
+++ b/cellarium/ml/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from cellarium.ml.core import CellariumAnnDataDataModule, CellariumModule, CellariumPipeline
+from cellarium.ml.core import CellariumAnnDataDataModule, CellariumDataModule, CellariumModule, CellariumPipeline
 
-__all__ = ["CellariumAnnDataDataModule", "CellariumModule", "CellariumPipeline"]
+__all__ = ["CellariumAnnDataDataModule", "CellariumDataModule", "CellariumModule", "CellariumPipeline"]

--- a/cellarium/ml/callbacks/__init__.py
+++ b/cellarium/ml/callbacks/__init__.py
@@ -5,6 +5,14 @@ from cellarium.ml.callbacks.compute_norm import ComputeNorm
 from cellarium.ml.callbacks.get_coord_data import GetCoordData
 from cellarium.ml.callbacks.loss_scale_monitor import LossScaleMonitor
 from cellarium.ml.callbacks.prediction_writer import PredictionWriter
+from cellarium.ml.callbacks.prediction_writer_arrow import PredictionWriterArrow
 from cellarium.ml.callbacks.variance_monitor import VarianceMonitor
 
-__all__ = ["ComputeNorm", "GetCoordData", "LossScaleMonitor", "PredictionWriter", "VarianceMonitor"]
+__all__ = [
+    "ComputeNorm",
+    "GetCoordData",
+    "LossScaleMonitor",
+    "PredictionWriter",
+    "PredictionWriterArrow",
+    "VarianceMonitor",
+]

--- a/cellarium/ml/callbacks/prediction_writer_arrow.py
+++ b/cellarium/ml/callbacks/prediction_writer_arrow.py
@@ -3,6 +3,8 @@
 
 import json
 import os
+import threading
+import warnings
 from collections.abc import Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from queue import Queue
@@ -54,8 +56,8 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
 
     **Per-cell column encoding:**
 
-    * 2-D numeric arrays (e.g. ``x_ng``) → ``FixedSizeBinary(n_cols × 2)``,
-      each row packed as ``float16``.
+    * 2-D numeric arrays (e.g. ``x_ng``) → ``FixedSizeBinary(n_cols × itemsize)``,
+      each row packed as the dtype given by *matrix_dtype*.
     * String / object arrays → ``large_utf8``.
     * Integer arrays → ``int32``.
     * All other numerics → ``float32``.
@@ -87,8 +89,16 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
         num_write_workers:
             Number of threads encoding and writing Arrow shards in parallel.
             Submission blocks when all workers are busy, bounding peak extra
-            memory to roughly ``num_write_workers × shard_size × n_genes × 2``
-            bytes.
+            memory to roughly
+            ``num_write_workers × shard_size × n_genes × itemsize`` bytes.
+        matrix_dtype:
+            NumPy dtype name for storing 2-D matrix fields (e.g. ``x_ng``).
+            ``"float32"`` (default) preserves full single-precision range.
+            ``"float16"`` halves file size but has a maximum representable
+            value of 65504 — values outside ``[−65504, 65504]`` are silently
+            **clamped** to ``±65504`` and a :class:`RuntimeWarning` with
+            per-gene overflow counts is emitted by :meth:`flush` at the end
+            of prediction.
     """
 
     def __init__(
@@ -96,16 +106,26 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
         output_dir: str,
         compression: str | None = "zstd",
         num_write_workers: int = 8,
+        matrix_dtype: str = "float32",
     ) -> None:
         super().__init__(write_interval="batch")
+        _allowed_dtypes = {"float32", "float16"}
+        if matrix_dtype not in _allowed_dtypes:
+            raise ValueError(f"matrix_dtype must be one of {sorted(_allowed_dtypes)!r}, got {matrix_dtype!r}")
         self.output_dir = output_dir
         self.compression = compression
         self.num_write_workers = num_write_workers
+        self.matrix_dtype = matrix_dtype
+        self._matrix_np_dtype = np.dtype(matrix_dtype)
         self._shard_counter: int = 0
         self._executor: _BoundedThreadPoolExecutor = _BoundedThreadPoolExecutor(
             max_workers=num_write_workers, max_queue_size=num_write_workers
         )
         self._futures: list[Future] = []
+        # Overflow tracking — only populated when matrix_dtype="float16"
+        self._overflow_lock = threading.Lock()
+        self._overflow_counts: dict[str, np.ndarray] = {}  # field → per-gene int64 overflow count
+        self._var_names_g: np.ndarray | None = None  # captured for overflow reporting
 
     def __del__(self) -> None:
         """Ensure the executor shuts down on object deletion."""
@@ -180,12 +200,28 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
 
         for key, val in per_row.items():
             if val.ndim == 2:
-                # Matrix field (e.g., x_ng): pack each row as float16 bytes
-                val_f16 = val.astype(np.float16)
-                n, d = val_f16.shape
-                byte_width = d * 2
+                n, d = val.shape
+                if self._matrix_np_dtype == np.dtype("float16"):
+                    with np.errstate(over="ignore"):
+                        val_cast = val.astype(np.float16)
+                    overflow_mask = np.isinf(val_cast)  # True where overflow occurred
+                    if np.any(overflow_mask):
+                        f16_max = np.finfo(np.float16).max
+                        val_cast = val_cast.copy()
+                        val_cast[val_cast == np.float16(np.inf)] = np.float16(f16_max)
+                        val_cast[val_cast == np.float16(-np.inf)] = np.float16(-f16_max)
+                        per_gene_counts = overflow_mask.sum(axis=0).astype(np.int64)
+                        with self._overflow_lock:
+                            if key not in self._overflow_counts:
+                                self._overflow_counts[key] = np.zeros(d, dtype=np.int64)
+                            self._overflow_counts[key] += per_gene_counts
+                            if self._var_names_g is None and "var_names_g" in metadata_arrays:
+                                self._var_names_g = metadata_arrays["var_names_g"].copy()
+                else:
+                    val_cast = val.astype(self._matrix_np_dtype)
+                byte_width = d * self._matrix_np_dtype.itemsize
                 col = pa.array(
-                    [val_f16[i].tobytes() for i in range(n)],
+                    [val_cast[i].tobytes() for i in range(n)],
                     type=pa.binary(byte_width),
                 )
                 arrow_fields.append(pa.field(key, pa.binary(byte_width)))
@@ -204,6 +240,7 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
         schema_meta: dict[bytes, bytes] = {
             b"cellarium_arrow_version": b"1",
             b"n_obs": str(n_obs).encode(),
+            b"matrix_dtype": self._matrix_np_dtype.name.encode(),
         }
         for key, val in metadata_arrays.items():
             if key == "var_names_g" or (key.endswith("_g") and val.dtype.kind in ("U", "O")):
@@ -245,11 +282,39 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
         self._futures = live
 
     def flush(self) -> None:
-        """Drain all pending write threads and re-raise any write exceptions."""
+        """Drain all pending write threads, report float16 overflow warnings, and re-raise write errors."""
         self._executor.shutdown(wait=True)
         for f in self._futures:
             f.result()
         self._futures.clear()
+
+        # Collect overflow state and reset under lock so worker threads see a clean slate next run.
+        with self._overflow_lock:
+            overflow_snapshot = {k: v.copy() for k, v in self._overflow_counts.items()}
+            var_names = self._var_names_g.copy() if self._var_names_g is not None else None
+            self._overflow_counts.clear()
+            self._var_names_g = None
+
+        for field, counts in overflow_snapshot.items():
+            total = int(counts.sum())
+            if total == 0:
+                continue
+            affected_indices = np.where(counts > 0)[0]
+            n_affected = len(affected_indices)
+            top_idx = affected_indices[np.argsort(counts[affected_indices])[::-1][:10]]
+            if var_names is not None and len(var_names) == len(counts):
+                gene_str = ", ".join(f"{var_names[i]} ({counts[i]})" for i in top_idx)
+            else:
+                gene_str = ", ".join(f"idx={i} ({counts[i]})" for i in top_idx)
+            warnings.warn(
+                f"PredictionWriterArrow: {total} value(s) in field '{field}' overflowed float16 "
+                f"and were clamped to \u00b1{np.finfo(np.float16).max}. "
+                f"Affected genes: {n_affected}. Top genes (up to 10): {gene_str}. "
+                f"Consider using matrix_dtype='float32' to avoid precision loss.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
         # Recreate the executor so the callback can be reused across multiple predict runs.
         self._executor = _BoundedThreadPoolExecutor(
             max_workers=self.num_write_workers, max_queue_size=self.num_write_workers

--- a/cellarium/ml/callbacks/prediction_writer_arrow.py
+++ b/cellarium/ml/callbacks/prediction_writer_arrow.py
@@ -89,8 +89,10 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
         num_write_workers:
             Number of threads encoding and writing Arrow shards in parallel.
             Submission blocks when all workers are busy, bounding peak extra
-            memory to roughly
-            ``num_write_workers × shard_size × n_genes × itemsize`` bytes.
+            memory to roughly ``num_write_workers × shard_size × n_genes ×
+            itemsize`` bytes.  Defaults to ``2``; Arrow writes are I/O-bound
+            so additional threads rarely improve throughput but do increase
+            peak memory proportionally.
         matrix_dtype:
             NumPy dtype name for storing 2-D matrix fields (e.g. ``x_ng``).
             ``"float32"`` (default) preserves full single-precision range.
@@ -105,7 +107,7 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
         self,
         output_dir: str,
         compression: str | None = "zstd",
-        num_write_workers: int = 8,
+        num_write_workers: int = 2,
         matrix_dtype: str = "float32",
     ) -> None:
         super().__init__(write_interval="batch")
@@ -172,6 +174,11 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
             if arr is not None:
                 np_batch[key] = arr
 
+        # Release the original batch reference now that all arrays are in np_batch.
+        # The work-queue entry has already been dropped by the executor at this point,
+        # so this is the last external reference to the prediction dict.
+        del batch
+
         if not np_batch:
             return
 
@@ -229,10 +236,10 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
                 col = pa.array(val.tolist(), type=pa.large_utf8())
                 arrow_fields.append(pa.field(key, pa.large_utf8()))
             elif val.dtype.kind in ("i", "u"):
-                col = pa.array(val.astype(np.int32), type=pa.int32())
+                col = pa.array(val.astype(np.int32, copy=False), type=pa.int32())
                 arrow_fields.append(pa.field(key, pa.int32()))
             else:
-                col = pa.array(val.astype(np.float32), type=pa.float32())
+                col = pa.array(val.astype(np.float32, copy=False), type=pa.float32())
                 arrow_fields.append(pa.field(key, pa.float32()))
             arrow_columns.append(col)
 
@@ -340,3 +347,19 @@ class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
     def on_predict_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """Drain the write pool and re-raise any write exceptions."""
         self.flush()
+
+    def on_exception(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        exception: BaseException,
+    ) -> None:
+        """On any exception, shut down the write pool immediately without waiting.
+
+        Running writes are allowed to finish (they cannot be cancelled), but no
+        new writes will be accepted and pending batch references are released as
+        soon as each thread completes.  This prevents the thread pool from
+        holding large batch tensors alive after prediction has already failed.
+        """
+        self._executor.shutdown(wait=False)
+        self._futures.clear()

--- a/cellarium/ml/callbacks/prediction_writer_arrow.py
+++ b/cellarium/ml/callbacks/prediction_writer_arrow.py
@@ -1,0 +1,277 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+import os
+from collections.abc import Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from queue import Queue
+from typing import Any
+
+import lightning.pytorch as pl
+import numpy as np
+import pyarrow as pa
+import torch
+
+
+class _BoundedThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor with a bounded submission queue.
+
+    Blocks on :meth:`submit` when *max_queue_size* tasks are already in flight,
+    preventing the caller from queuing an unbounded number of batches in memory.
+    """
+
+    def __init__(self, max_workers: int, max_queue_size: int) -> None:
+        self._bound_queue: Queue = Queue(max_queue_size)
+        super().__init__(max_workers=max_workers)
+
+    def submit(self, fn, /, *args, **kwargs):  # type: ignore[override]
+        self._bound_queue.put(None)  # blocks when all slots are occupied
+        future = super().submit(fn, *args, **kwargs)
+
+        def _done(_: Future) -> None:
+            self._bound_queue.get()
+
+        future.add_done_callback(_done)
+        return future
+
+
+class PredictionWriterArrow(pl.callbacks.BasePredictionWriter):
+    r"""
+    Write prediction batches to Arrow IPC (Feather v2) files in parallel.
+
+    Intended to be paired with :class:`~cellarium.ml.models.DataPreformatter` (or
+    any other :class:`~cellarium.ml.models.PredictMixin` model) in a ``predict``
+    CLI run.  After all ``cpu_transforms`` and ``transforms`` in the pipeline have
+    been applied, the accumulated post-transform batch is received via
+    ``write_on_batch_end`` and written asynchronously to disk.
+
+    **Field classification** (same conventions as the old ``DataPreformatter``):
+
+    * Keys ending in ``_g`` (but **not** ``_ng``) or ``_categories`` → Arrow
+      **schema metadata** (written once per shard, not per row).
+    * All other array keys → Arrow **columns** (one value per cell).
+
+    **Per-cell column encoding:**
+
+    * 2-D numeric arrays (e.g. ``x_ng``) → ``FixedSizeBinary(n_cols × 2)``,
+      each row packed as ``float16``.
+    * String / object arrays → ``large_utf8``.
+    * Integer arrays → ``int32``.
+    * All other numerics → ``float32``.
+
+    **Output file naming:**
+
+    ``<output_dir>/rank<rank:02d>_shard<counter:06d>.arrow``
+
+    .. note::
+
+        Set ``return_predictions: false`` in the top-level trainer config to
+        prevent Lightning from accumulating all predictions in memory::
+
+            return_predictions: false
+
+    .. note::
+
+        When running with multiple distributed ranks each rank writes its own
+        series of files starting from counter 0.
+
+    Args:
+        output_dir:
+            Directory in which Arrow IPC files will be written. Created
+            automatically if it does not exist.
+        compression:
+            Compression codec for Arrow IPC files. ``"zstd"`` (default) gives
+            the best ratio for sparse integer count data; ``"lz4"`` is faster
+            to decompress; ``None`` disables compression.
+        num_write_workers:
+            Number of threads encoding and writing Arrow shards in parallel.
+            Submission blocks when all workers are busy, bounding peak extra
+            memory to roughly ``num_write_workers × shard_size × n_genes × 2``
+            bytes.
+    """
+
+    def __init__(
+        self,
+        output_dir: str,
+        compression: str | None = "zstd",
+        num_write_workers: int = 8,
+    ) -> None:
+        super().__init__(write_interval="batch")
+        self.output_dir = output_dir
+        self.compression = compression
+        self.num_write_workers = num_write_workers
+        self._shard_counter: int = 0
+        self._executor: _BoundedThreadPoolExecutor = _BoundedThreadPoolExecutor(
+            max_workers=num_write_workers, max_queue_size=num_write_workers
+        )
+        self._futures: list[Future] = []
+
+    def __del__(self) -> None:
+        """Ensure the executor shuts down on object deletion."""
+        self._executor.shutdown(wait=True)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_numpy(val: Any) -> np.ndarray | None:
+        if isinstance(val, torch.Tensor):
+            return val.detach().cpu().numpy()
+        if isinstance(val, np.ndarray):
+            return val
+        return None
+
+    @staticmethod
+    def _get_rank() -> int:
+        try:
+            import torch.distributed as dist
+
+            if dist.is_available() and dist.is_initialized():
+                return dist.get_rank()
+        except Exception:
+            pass
+        return 0
+
+    def _write_arrow(self, batch: dict[str, Any], filename: str | None = None) -> None:
+        """Classify batch fields and write one Arrow IPC shard.
+
+        When *filename* is ``None`` (synchronous / direct-call path) the filename
+        is computed here and ``_shard_counter`` is incremented. When *filename*
+        is provided (async path from :meth:`_submit_write`) the caller has already
+        assigned the name and incremented the counter in the main thread to
+        guarantee sequential ordering.
+        """
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        # Convert tensors → numpy; skip non-array scalars
+        np_batch: dict[str, np.ndarray] = {}
+        for key, val in batch.items():
+            arr = self._to_numpy(val)
+            if arr is not None:
+                np_batch[key] = arr
+
+        if not np_batch:
+            return
+
+        # Infer n_obs from the first array with ndim >= 1
+        n_obs: int | None = None
+        for val in np_batch.values():
+            if val.ndim >= 1:
+                n_obs = val.shape[0]
+                break
+        if n_obs is None:
+            return
+
+        # Classify: schema metadata vs per-row columns
+        # Rule: keys ending in `_g` (but not `_ng`) or `_categories` → metadata
+        per_row: dict[str, np.ndarray] = {}
+        metadata_arrays: dict[str, np.ndarray] = {}
+        for key, val in np_batch.items():
+            if key.endswith("_categories") or (key.endswith("_g") and not key.endswith("_ng")):
+                metadata_arrays[key] = val
+            else:
+                per_row[key] = val
+
+        # Build Arrow columns for per-row fields
+        arrow_columns: list[pa.Array] = []
+        arrow_fields: list[pa.Field] = []
+
+        for key, val in per_row.items():
+            if val.ndim == 2:
+                # Matrix field (e.g., x_ng): pack each row as float16 bytes
+                val_f16 = val.astype(np.float16)
+                n, d = val_f16.shape
+                byte_width = d * 2
+                col = pa.array(
+                    [val_f16[i].tobytes() for i in range(n)],
+                    type=pa.binary(byte_width),
+                )
+                arrow_fields.append(pa.field(key, pa.binary(byte_width)))
+            elif val.dtype.kind in ("U", "O", "S"):
+                col = pa.array(val.tolist(), type=pa.large_utf8())
+                arrow_fields.append(pa.field(key, pa.large_utf8()))
+            elif val.dtype.kind in ("i", "u"):
+                col = pa.array(val.astype(np.int32), type=pa.int32())
+                arrow_fields.append(pa.field(key, pa.int32()))
+            else:
+                col = pa.array(val.astype(np.float32), type=pa.float32())
+                arrow_fields.append(pa.field(key, pa.float32()))
+            arrow_columns.append(col)
+
+        # Build schema metadata
+        schema_meta: dict[bytes, bytes] = {
+            b"cellarium_arrow_version": b"1",
+            b"n_obs": str(n_obs).encode(),
+        }
+        for key, val in metadata_arrays.items():
+            if key == "var_names_g" or (key.endswith("_g") and val.dtype.kind in ("U", "O")):
+                schema_meta[key.encode()] = "\n".join(val.tolist()).encode()
+                if key == "var_names_g":
+                    schema_meta[b"n_genes"] = str(len(val)).encode()
+            else:
+                schema_meta[key.encode()] = json.dumps(val.tolist()).encode()
+
+        schema = pa.schema(arrow_fields, metadata=schema_meta)
+        record_batch = pa.record_batch(arrow_columns, schema=schema)
+
+        if filename is None:
+            # Synchronous path: compute filename and advance counter here.
+            rank = self._get_rank()
+            filename = os.path.join(self.output_dir, f"rank{rank:02d}_shard{self._shard_counter:06d}.arrow")
+            self._shard_counter += 1
+
+        options = pa.ipc.IpcWriteOptions(compression=self.compression)
+        with pa.OSFile(filename, "wb") as sink:
+            with pa.ipc.new_file(sink, schema, options=options) as writer:
+                writer.write_batch(record_batch)
+
+    def _submit_write(self, batch: dict[str, Any]) -> None:
+        """Assign filename in the main thread then submit encoding + write to the thread pool."""
+        rank = self._get_rank()
+        os.makedirs(self.output_dir, exist_ok=True)
+        filename = os.path.join(self.output_dir, f"rank{rank:02d}_shard{self._shard_counter:06d}.arrow")
+        self._shard_counter += 1
+        future: Future = self._executor.submit(self._write_arrow, batch, filename)
+        self._futures.append(future)
+        # Opportunistically prune completed futures and surface any write errors.
+        live: list[Future] = []
+        for f in self._futures:
+            if f.done():
+                f.result()  # re-raises if the thread threw an exception
+            else:
+                live.append(f)
+        self._futures = live
+
+    def flush(self) -> None:
+        """Drain all pending write threads and re-raise any write exceptions."""
+        self._executor.shutdown(wait=True)
+        for f in self._futures:
+            f.result()
+        self._futures.clear()
+        # Recreate the executor so the callback can be reused across multiple predict runs.
+        self._executor = _BoundedThreadPoolExecutor(
+            max_workers=self.num_write_workers, max_queue_size=self.num_write_workers
+        )
+
+    # ------------------------------------------------------------------
+    # BasePredictionWriter interface
+    # ------------------------------------------------------------------
+
+    def write_on_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        prediction: dict[str, Any],
+        batch_indices: Sequence[int] | None,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int,
+    ) -> None:
+        """Submit the post-transform batch to the async write pool."""
+        self._submit_write(prediction)
+
+    def on_predict_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Drain the write pool and re-raise any write exceptions."""
+        self.flush()

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -26,7 +26,7 @@ from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
 from torch.utils._pytree import tree_map
 
 from cellarium.ml import CellariumAnnDataDataModule, CellariumModule, CellariumPipeline
-from cellarium.ml.data.distributed_arrow_data import DistributedArrowDataCollection
+from cellarium.ml.data import DistributedArrowDataCollection
 from cellarium.ml.utilities.data import AnnDataField, collate_fn
 
 cached_loaders: dict[Callable[[str], Any] | str, Callable[[str], Any]] = {}

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -854,17 +854,20 @@ def contrastive_mlp(args: ArgsType = None) -> None:
 @register_model
 def data_preformatter(args: ArgsType = None) -> None:
     r"""
-    CLI for converting AnnData h5ad shards to Arrow IPC (Feather v2) shards via
-    :class:`~cellarium.ml.models.DataPreformatter`.
+    CLI for converting AnnData h5ad shards to Arrow IPC (Feather v2) shards.
 
-    Runs in ``predict`` mode: each batch produced by the dataloader (after all
-    ``cpu_transforms`` and ``transforms`` have been applied) is written as one Arrow
-    IPC file to ``output_dir``.
+    Uses :class:`~cellarium.ml.models.DataPreformatter` (a pass-through model)
+    together with the :class:`~cellarium.ml.callbacks.PredictionWriterArrow`
+    callback.  Each batch produced by the dataloader (after all
+    ``cpu_transforms`` and ``transforms`` have been applied) is written as one
+    Arrow IPC file to ``output_dir`` by the callback.
+
+    ``return_predictions: false`` must be included so that Lightning does not
+    accumulate predictions in memory.
 
     Example run::
 
         cellarium-ml data_preformatter predict \\
-            --model.model.init_args.output_dir ./arrow_output \\
             --data.dadc.class_path cellarium.ml.data.DistributedAnnDataCollection \\
             --data.dadc.init_args.filenames "gs://bucket/adata_{0..3}.h5ad" \\
             --data.dadc.init_args.shard_size 1800 \\
@@ -876,6 +879,8 @@ def data_preformatter(args: ArgsType = None) -> None:
             --data.num_workers 4 \\
             --trainer.accelerator cpu \\
             --trainer.devices 1 \\
+            --trainer.callbacks=[{\"class_path\":\"cellarium.ml.callbacks.PredictionWriterArrow\",
+            \"init_args\":{\"output_dir\":\"./arrow_output\"}}] \\
             --return_predictions false
 
     Args:

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -26,6 +26,7 @@ from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
 from torch.utils._pytree import tree_map
 
 from cellarium.ml import CellariumAnnDataDataModule, CellariumModule, CellariumPipeline
+from cellarium.ml.data.distributed_arrow_data import DistributedArrowDataCollection
 from cellarium.ml.utilities.data import AnnDataField, collate_fn
 
 cached_loaders: dict[Callable[[str], Any] | str, Callable[[str], Any]] = {}
@@ -276,13 +277,19 @@ def compute_y_categories(data: CellariumAnnDataDataModule) -> np.ndarray:
 
         >>> np.asarray(data.dadc[0].obs["cell_type"].cat.categories)
 
+    For Arrow-format data the categories are read directly from the Arrow schema
+    metadata (written by :class:`~cellarium.ml.models.DataPreformatter`).
+
     Args:
         data: A :class:`CellariumAnnDataDataModule` instance.
 
     Returns:
         The categories in the target variable.
     """
+    if isinstance(data.dadc, DistributedArrowDataCollection):
+        return data.dadc.get_schema_metadata()["y_categories"]
     adata = data.dadc[0]
+    assert data.batch_keys is not None
     field = data.batch_keys["y_categories"]
     assert isinstance(field, AnnDataField)
     return field(adata)
@@ -296,6 +303,10 @@ def compute_var_names_g(
     """
     Compute variable names from the data by applying the transforms.
 
+    For Arrow-format data (:class:`~cellarium.ml.data.DistributedArrowDataCollection`),
+    ``var_names_g`` is read directly from the Arrow schema metadata (already post-filter)
+    and the FakeTensor pipeline simulation is skipped.
+
     Args:
         cpu_transforms:
             A list of of CPU transforms applied by the dataloader.
@@ -307,6 +318,8 @@ def compute_var_names_g(
     Returns:
         The variable names.
     """
+    if isinstance(data.dadc, DistributedArrowDataCollection):
+        return data.dadc.get_schema_metadata()["var_names_g"]
     adata = data.dadc[0]
     batch = tree_map(lambda field: field(adata), data.batch_keys)
     pipeline = CellariumPipeline(cpu_transforms) + CellariumPipeline(transforms)
@@ -327,13 +340,25 @@ def compute_batch_index_n_categories(data: CellariumAnnDataDataModule) -> int:
             If batch_index_n is comprised of multiple keys, the number of categories is computed
             as the product of the number of categories in each key.
 
+    For Arrow-format data the category counts are read from the Arrow schema metadata
+    (keys matching ``batch_index_n*_categories``).
+
     Args:
         data: A :class:`CellariumAnnDataDataModule` instance.
 
     Returns:
         The number of categories in batch_index_n.
     """
-    if "batch_index_n" not in data.batch_keys:
+    if isinstance(data.dadc, DistributedArrowDataCollection):
+        import math
+
+        meta = data.dadc.get_schema_metadata()
+        result = 1
+        for k, v in meta.items():
+            if k.startswith("batch_index_n") and k.endswith("_categories"):
+                result = math.prod([result, len(v)])
+        return result if result > 1 else 1
+    if not data.batch_keys or "batch_index_n" not in data.batch_keys:
         return 1  # for hvg selection when no batch key is given, treat all cells as a single batch
     field = data.batch_keys["batch_index_n"]
     assert isinstance(field, AnnDataField)
@@ -823,6 +848,40 @@ def contrastive_mlp(args: ArgsType = None) -> None:
             "max_epochs": 20,
         },
     )
+    cli(args=args)
+
+
+@register_model
+def data_preformatter(args: ArgsType = None) -> None:
+    r"""
+    CLI for converting AnnData h5ad shards to Arrow IPC (Feather v2) shards via
+    :class:`~cellarium.ml.models.DataPreformatter`.
+
+    Runs in ``predict`` mode: each batch produced by the dataloader (after all
+    ``cpu_transforms`` and ``transforms`` have been applied) is written as one Arrow
+    IPC file to ``output_dir``.
+
+    Example run::
+
+        cellarium-ml data_preformatter predict \\
+            --model.model.init_args.output_dir ./arrow_output \\
+            --data.dadc.class_path cellarium.ml.data.DistributedAnnDataCollection \\
+            --data.dadc.init_args.filenames "gs://bucket/adata_{0..3}.h5ad" \\
+            --data.dadc.init_args.shard_size 1800 \\
+            --data.batch_keys.x_ng.attr X \\
+            --data.batch_keys.x_ng.convert_fn cellarium.ml.utilities.data.densify \\
+            --data.batch_keys.var_names_g.attr var_names \\
+            --data.batch_keys.obs_names_n.attr obs_names \\
+            --data.batch_size 1800 \\
+            --data.num_workers 4 \\
+            --trainer.accelerator cpu \\
+            --trainer.devices 1 \\
+            --return_predictions false
+
+    Args:
+        args: Arguments to parse. If ``None`` the arguments are taken from ``sys.argv``.
+    """
+    cli = lightning_cli_factory("cellarium.ml.models.DataPreformatter")
     cli(args=args)
 
 

--- a/cellarium/ml/core/__init__.py
+++ b/cellarium/ml/core/__init__.py
@@ -1,8 +1,8 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from cellarium.ml.core.datamodule import CellariumAnnDataDataModule
+from cellarium.ml.core.datamodule import CellariumAnnDataDataModule, CellariumDataModule
 from cellarium.ml.core.module import CellariumModule
 from cellarium.ml.core.pipeline import CellariumPipeline
 
-__all__ = ["CellariumAnnDataDataModule", "CellariumModule", "CellariumPipeline"]
+__all__ = ["CellariumAnnDataDataModule", "CellariumDataModule", "CellariumModule", "CellariumPipeline"]

--- a/cellarium/ml/core/datamodule.py
+++ b/cellarium/ml/core/datamodule.py
@@ -9,8 +9,11 @@ import lightning.pytorch as pl
 import torch
 from anndata import AnnData
 
-from cellarium.ml.data import DistributedAnnDataCollection, IterableDistributedAnnDataCollectionDataset
-from cellarium.ml.data.distributed_arrow_data import DistributedArrowDataCollection
+from cellarium.ml.data import (
+    DistributedAnnDataCollection,
+    DistributedArrowDataCollection,
+    IterableDistributedAnnDataCollectionDataset,
+)
 from cellarium.ml.utilities.core import train_val_split
 from cellarium.ml.utilities.data import AnnDataField, collate_fn
 

--- a/cellarium/ml/core/datamodule.py
+++ b/cellarium/ml/core/datamodule.py
@@ -10,6 +10,7 @@ import torch
 from anndata import AnnData
 
 from cellarium.ml.data import DistributedAnnDataCollection, IterableDistributedAnnDataCollectionDataset
+from cellarium.ml.data.distributed_arrow_data import DistributedArrowDataCollection
 from cellarium.ml.utilities.core import train_val_split
 from cellarium.ml.utilities.data import AnnDataField, collate_fn
 
@@ -102,7 +103,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        dadc: DistributedAnnDataCollection | AnnData,
+        dadc: DistributedAnnDataCollection | DistributedArrowDataCollection | AnnData,
         # IterableDistributedAnnDataCollectionDataset args
         batch_keys: dict[str, dict[str, AnnDataField] | AnnDataField] | None = None,
         batch_size: int = 1,
@@ -120,6 +121,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
         num_workers: int = 0,
         prefetch_factor: int | None = None,
         persistent_workers: bool = False,
+        pin_memory: bool = False,
     ) -> None:
         super().__init__()
         self.save_hyperparameters(logger=False)
@@ -128,7 +130,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
 
         self.dadc = dadc
         # IterableDistributedAnnDataCollectionDataset args
-        self.batch_keys = batch_keys or {}
+        self.batch_keys = batch_keys
         self.batch_size = batch_size
         self.iteration_strategy = iteration_strategy
         self.shuffle = shuffle
@@ -147,6 +149,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
         self.drop_incomplete_batch = drop_incomplete_batch
         self.prefetch_factor = prefetch_factor
         self.persistent_workers = persistent_workers
+        self.pin_memory = pin_memory
 
     def setup(self, stage: str | None = None) -> None:
         """
@@ -227,6 +230,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             collate_fn=self.collate_fn,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
+            pin_memory=self.pin_memory,
         )
 
     def val_dataloader(self) -> torch.utils.data.DataLoader:
@@ -237,6 +241,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             collate_fn=self.collate_fn,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
+            pin_memory=self.pin_memory,
         )
 
     def predict_dataloader(self) -> torch.utils.data.DataLoader:
@@ -247,6 +252,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             collate_fn=self.collate_fn,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
+            pin_memory=self.pin_memory,
         )
 
     def test_dataloader(self) -> torch.utils.data.DataLoader:
@@ -257,6 +263,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
             collate_fn=self.collate_fn,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
+            pin_memory=self.pin_memory,
         )
 
     def state_dict(self) -> dict[str, Any]:
@@ -344,3 +351,7 @@ class CellariumAnnDataDataModule(pl.LightningDataModule):
                 )
 
             self.train_dataset.load_state_dict(state_dict)
+
+
+#: Alias for :class:`CellariumAnnDataDataModule` that also accepts Arrow shards.
+CellariumDataModule = CellariumAnnDataDataModule

--- a/cellarium/ml/data/__init__.py
+++ b/cellarium/ml/data/__init__.py
@@ -1,23 +1,28 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from cellarium.ml.data.dadc_dataset import IterableDistributedAnnDataCollectionDataset
+from cellarium.ml.data.dadc_dataset import IterableDistributedAnnDataCollectionDataset, IterableDistributedDataset
 from cellarium.ml.data.distributed_anndata import (
     DistributedAnnDataCollection,
     DistributedAnnDataCollectionView,
     LazyAnnData,
 )
+from cellarium.ml.data.distributed_arrow_data import DistributedArrowDataCollection
 from cellarium.ml.data.fileio import read_h5ad_file, read_h5ad_gcs, read_h5ad_local, read_h5ad_url
 from cellarium.ml.data.pytree_dataset import PyTreeDataset
 from cellarium.ml.data.schema import AnnDataSchema
+from cellarium.ml.data.shard_collection import ShardCollection
 
 __all__ = [
     "AnnDataSchema",
     "DistributedAnnDataCollection",
     "DistributedAnnDataCollectionView",
+    "DistributedArrowDataCollection",
     "IterableDistributedAnnDataCollectionDataset",
+    "IterableDistributedDataset",
     "LazyAnnData",
     "PyTreeDataset",
+    "ShardCollection",
     "read_h5ad_file",
     "read_h5ad_gcs",
     "read_h5ad_local",

--- a/cellarium/ml/data/dadc_dataset.py
+++ b/cellarium/ml/data/dadc_dataset.py
@@ -14,6 +14,7 @@ from torch.utils._pytree import tree_map
 from torch.utils.data import IterableDataset
 
 from cellarium.ml.data.distributed_anndata import DistributedAnnDataCollection
+from cellarium.ml.data.distributed_arrow_data import DistributedArrowDataCollection
 from cellarium.ml.utilities.data import AnnDataField
 from cellarium.ml.utilities.distributed import get_rank_and_num_replicas, get_worker_info
 
@@ -102,8 +103,8 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
 
     def __init__(
         self,
-        dadc: DistributedAnnDataCollection | AnnData,
-        batch_keys: dict[str, dict[str, AnnDataField] | AnnDataField],
+        dadc: DistributedAnnDataCollection | DistributedArrowDataCollection | AnnData,
+        batch_keys: dict[str, dict[str, AnnDataField] | AnnDataField] | None = None,
         batch_size: int = 1,
         iteration_strategy: Literal["same_order", "cache_efficient"] = "cache_efficient",
         shuffle: bool = False,
@@ -169,13 +170,19 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
 
     def __getitem__(self, idx: int | list[int] | slice) -> dict[str, dict[str, np.ndarray] | np.ndarray]:
         r"""
-        Returns a dictionary containing the data from the :attr:`dadc` with keys specified by the :attr:`batch_keys`
-        at the given index ``idx``.
-        """
+        Returns a dictionary containing the data from the :attr:`dadc` at the given index ``idx``.
 
-        data = {}
-        adata = self.dadc[idx]
-        data = tree_map(lambda field: field(adata), self.batch_keys)
+        When :attr:`batch_keys` is ``None`` (Arrow mode), :attr:`dadc` is called directly and
+        is expected to return a ``dict``.  When :attr:`batch_keys` is provided (AnnData mode),
+        each :class:`~cellarium.ml.utilities.data.AnnDataField` is applied to the materialised
+        AnnData shard.
+        """
+        if self.batch_keys is not None:
+            adata = self.dadc[idx]
+            data = tree_map(lambda field: field(adata), self.batch_keys)
+        else:
+            # Arrow mode: dadc.__getitem__ returns a dict directly
+            data = self.dadc[idx]
 
         # for testing purposes
         if self.test_mode:
@@ -568,3 +575,7 @@ class IterableDistributedAnnDataCollectionDataset(IterableDataset):
         self.resume_step = state_dict["resume_step"]
         # trainer.accumulate_grad_batches
         self.accumulate_grad_batches = state_dict["accumulate_grad_batches"]
+
+
+# Backward-compatible alias
+IterableDistributedDataset = IterableDistributedAnnDataCollectionDataset

--- a/cellarium/ml/data/distributed_anndata.py
+++ b/cellarium/ml/data/distributed_anndata.py
@@ -268,6 +268,35 @@ class DistributedAnnDataCollection(AnnCollection):
                 adatas[i] = self.adatas[adata_idx].adata[oidx, vidx]
         return adatas
 
+    def get_schema_metadata(self) -> dict:
+        """
+        Return schema-level metadata without loading any cell data.
+
+        Reads from :attr:`schema` which is populated at construction time from the
+        first shard.
+
+        Returns:
+            A dict containing:
+
+            * ``"n_obs"`` – total observation count (:class:`int`)
+            * ``"n_vars"`` – number of variables (:class:`int`)
+            * ``"var_names_g"`` – :class:`numpy.ndarray` of variable names
+            * ``"<col>_categories"`` – :class:`numpy.ndarray` of category strings for
+              every categorical ``obs`` column in the schema
+        """
+        import numpy as np
+
+        result: dict = {
+            "n_obs": self.n_obs,
+            "n_vars": self.n_vars,
+            "var_names_g": np.asarray(self.schema.attr_values["var_names"]),
+        }
+        obs_df = self.schema.attr_values["obs"]
+        for col in obs_df.columns:
+            if hasattr(obs_df[col], "cat"):
+                result[f"{col}_categories"] = np.asarray(obs_df[col].cat.categories)
+        return result
+
     def __repr__(self) -> str:
         n_obs, n_vars = self.shape
         descr = f"DistributedAnnDataCollection object with n_obs × n_vars = {self.n_obs} × {self.n_vars}"

--- a/cellarium/ml/data/distributed_arrow_data.py
+++ b/cellarium/ml/data/distributed_arrow_data.py
@@ -230,18 +230,23 @@ class DistributedArrowDataCollection:
             local_idx = (global_idx - shard_start).tolist()
 
             part: dict[str, np.ndarray] = {}
+
+            # Read matrix dtype from schema metadata; default to float16 for backward compat.
+            shard_meta = batch.schema.metadata or {}
+            _mat_dtype = np.dtype(shard_meta.get(b"matrix_dtype", b"float16").decode())
+
             for col_name in batch.schema.names:
                 col_taken = batch.column(col_name).take(local_idx)
                 col_type = col_taken.type
 
                 if pa.types.is_fixed_size_binary(col_type):
-                    # x_ng: packed float16 – one fixed-size binary row per cell
+                    # Matrix field: packed as matrix_dtype bytes, one fixed-size binary row per cell.
                     byte_width: int = col_type.byte_width
-                    n_genes = byte_width // 2
+                    n_genes = byte_width // _mat_dtype.itemsize
                     offset = col_taken.offset
                     values_buf = col_taken.buffers()[1]
                     arr_bytes = values_buf[offset * byte_width : (offset + len(col_taken)) * byte_width]
-                    part[col_name] = np.frombuffer(arr_bytes, dtype=np.float16).reshape(len(local_idx), n_genes).copy()
+                    part[col_name] = np.frombuffer(arr_bytes, dtype=_mat_dtype).reshape(len(local_idx), n_genes).copy()
                 elif pa.types.is_dictionary(col_type):
                     part[col_name] = np.array(col_taken.to_pylist())
                 elif pa.types.is_large_string(col_type) or pa.types.is_string(col_type):

--- a/cellarium/ml/data/distributed_arrow_data.py
+++ b/cellarium/ml/data/distributed_arrow_data.py
@@ -1,0 +1,303 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+from boltons.cacheutils import LRU
+from braceexpand import braceexpand
+
+
+class DistributedArrowDataCollection:
+    r"""
+    Distributed collection of pre-formatted Arrow IPC shards.
+
+    Each shard is an Arrow IPC file (Feather v2 layout) written by
+    :class:`~cellarium.ml.models.DataPreformatter`.  Per-cell fields are stored as
+    Arrow columns; per-gene and global category fields are stored in the Arrow
+    schema metadata so they are read once per shard rather than once per cell.
+
+    The :meth:`__getitem__` method returns a ``dict[str, numpy.ndarray]`` directly
+    (no :class:`~cellarium.ml.utilities.data.AnnDataField` mapping is required),
+    so ``batch_keys`` must be set to ``None`` in the corresponding
+    :class:`~cellarium.ml.core.CellariumDataModule`.
+
+    Schema metadata keys written by :class:`~cellarium.ml.models.DataPreformatter`:
+
+    * ``b"cellarium_arrow_version"`` – format version string (``"1"``)
+    * ``b"n_obs"`` – number of cells in the shard
+    * ``b"n_genes"`` – number of genes / features
+    * ``b"var_names_g"`` – newline-joined gene name string
+    * ``b"<key>_categories"`` – JSON-encoded list of category strings for each
+      categorical field
+
+    Example::
+
+        >>> dadc = DistributedArrowDataCollection(
+        ...     "output/rank00_shard{000000..000999}.arrow",
+        ...     shard_size=1800,
+        ...     max_cache_size=2,
+        ... )
+        >>> batch = dadc[0:1800]   # returns dict[str, np.ndarray]
+
+    Args:
+        filenames:
+            Names of Arrow IPC files.  May be a brace-expanded glob string or an
+            explicit sequence of paths.
+        limits:
+            Cumulative cell counts (upper exclusive bound) for each shard.
+            If ``None``, inferred from ``shard_size`` and ``last_shard_size``.
+        shard_size:
+            Number of cells in each shard.  Required when ``limits`` is ``None``.
+        last_shard_size:
+            Cell count of the final shard when it differs from ``shard_size``.
+            Only meaningful when ``shard_size`` is also set.
+        max_cache_size:
+            Maximum number of Arrow record batches to keep in the LRU cache.
+        cache_size_strictly_enforced:
+            If ``True``, raise an error when a single ``__getitem__`` call would
+            require more shards than ``max_cache_size``.
+    """
+
+    def __init__(
+        self,
+        filenames: Sequence[str] | str,
+        limits: list[int] | None = None,
+        shard_size: int | None = None,
+        last_shard_size: int | None = None,
+        max_cache_size: int = 1,
+        cache_size_strictly_enforced: bool = True,
+    ) -> None:
+        self.filenames = list(braceexpand(filenames) if isinstance(filenames, str) else filenames)
+
+        if shard_size is None and last_shard_size is not None:
+            raise ValueError("If `last_shard_size` is specified then `shard_size` must also be specified.")
+        if limits is None:
+            if shard_size is None:
+                raise ValueError("If `limits` is `None` then `shard_size` must be specified.")
+            limits = [shard_size * (i + 1) for i in range(len(self.filenames))]
+            if last_shard_size is not None:
+                limits[-1] = limits[-1] - shard_size + last_shard_size
+        else:
+            limits = list(limits)
+
+        if len(limits) != len(self.filenames):
+            raise ValueError(
+                f"The number of limits ({len(limits)}) must match the number of filenames ({len(self.filenames)})."
+            )
+
+        self.limits = limits
+        self.max_cache_size = max_cache_size
+        self.cache_size_strictly_enforced = cache_size_strictly_enforced
+        self.cache: LRU = LRU(max_cache_size)
+
+    # ------------------------------------------------------------------
+    # Core properties
+    # ------------------------------------------------------------------
+
+    @property
+    def n_obs(self) -> int:
+        """Total number of observations (cells) across all shards."""
+        return self.limits[-1]
+
+    @property
+    def n_vars(self) -> int:
+        """Number of variables (genes/features)."""
+        meta = self._read_schema_metadata(self.filenames[0])
+        return int(meta.get(b"n_genes", b"0"))
+
+    def __len__(self) -> int:
+        return self.n_obs
+
+    # ------------------------------------------------------------------
+    # Schema metadata helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _read_schema_metadata(filename: str) -> dict[bytes, bytes]:
+        """Read Arrow schema metadata from a file without loading cell data."""
+        with pa.memory_map(filename, "r") as source:
+            # open_file reads only the footer (schema + batch offsets) up front
+            meta = dict(pa.ipc.open_file(source).schema.metadata or {})
+        return meta
+
+    def get_schema_metadata(self) -> dict[str, Any]:
+        """
+        Return schema-level metadata without reading any cell data.
+
+        Reads the Arrow schema footer from the first shard only.
+
+        Returns:
+            A dict containing:
+
+            * ``"n_obs"`` – total observation count (:class:`int`)
+            * ``"n_vars"`` – number of genes (:class:`int`)
+            * ``"var_names_g"`` – :class:`numpy.ndarray` of gene names
+            * ``"<key>_categories"`` – :class:`numpy.ndarray` of category strings for
+              every categorical batch field stored in the Arrow metadata
+        """
+        meta = self._read_schema_metadata(self.filenames[0])
+
+        result: dict[str, Any] = {
+            "n_obs": self.n_obs,
+            "n_vars": int(meta.get(b"n_genes", b"0")),
+        }
+
+        if b"var_names_g" in meta:
+            raw = meta[b"var_names_g"].decode()
+            result["var_names_g"] = np.array(raw.split("\n")) if raw else np.array([], dtype=str)
+
+        for k, v in meta.items():
+            k_str = k.decode()
+            if k_str.endswith("_categories"):
+                result[k_str] = np.array(json.loads(v.decode()))
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Shard loading
+    # ------------------------------------------------------------------
+
+    def _get_shard(self, shard_idx: int) -> pa.RecordBatch:
+        """Load a shard into the LRU cache and return it."""
+        filename = self.filenames[shard_idx]
+        if filename in self.cache:
+            return self.cache[filename]
+
+        with pa.memory_map(filename, "r") as source:
+            batch = pa.ipc.open_file(source).get_batch(0)
+
+        if len(self.cache) < self.cache.max_size:
+            self.cache[filename] = batch
+
+        return batch
+
+    # ------------------------------------------------------------------
+    # Data access
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, idx: int | list[int] | slice) -> dict[str, np.ndarray]:
+        """
+        Return a dict of numpy arrays for the requested cell indices.
+
+        Per-row columns are concatenated across shards if the request spans multiple
+        shards.  Schema-level fields (``var_names_g``, ``*_categories``) are read
+        from the first touched shard and added to the returned dict.
+
+        Args:
+            idx: A single cell index, a list of cell indices, or a slice.
+
+        Returns:
+            ``dict[str, numpy.ndarray]`` with one entry per Arrow column plus one
+            entry per schema-metadata field.
+        """
+        if isinstance(idx, int):
+            idx = [idx]
+        elif isinstance(idx, slice):
+            idx = list(range(*idx.indices(self.n_obs)))
+
+        idx_arr = np.asarray(idx, dtype=np.intp)
+        limits_arr = np.asarray(self.limits, dtype=np.intp)
+        # shard_indices[i] = which shard cell idx_arr[i] belongs to
+        shard_indices = np.searchsorted(limits_arr, idx_arr, side="right")
+
+        unique_shards = np.unique(shard_indices)
+        if self.cache_size_strictly_enforced and len(unique_shards) > self.max_cache_size:
+            raise ValueError(
+                f"Expected the number of Arrow shards ({len(unique_shards)}) to be "
+                f"no more than the max cache size ({self.max_cache_size})."
+            )
+
+        parts: list[dict[str, np.ndarray]] = []
+        metadata_dict: dict[str, np.ndarray] | None = None
+        # perm[flat_i] = original request position of the i-th cell in shard-sorted order.
+        # Used to restore the caller's requested ordering after concatenating parts.
+        perm = np.empty(len(idx_arr), dtype=np.intp)
+        flat_offset = 0
+
+        for shard_idx in unique_shards:
+            orig_positions = np.where(shard_indices == shard_idx)[0]
+            perm[flat_offset : flat_offset + len(orig_positions)] = orig_positions
+            flat_offset += len(orig_positions)
+
+            global_idx = idx_arr[orig_positions]
+
+            batch = self._get_shard(int(shard_idx))
+            shard_start = int(self.limits[shard_idx - 1]) if shard_idx > 0 else 0
+            local_idx = (global_idx - shard_start).tolist()
+
+            part: dict[str, np.ndarray] = {}
+            for col_name in batch.schema.names:
+                col_taken = batch.column(col_name).take(local_idx)
+                col_type = col_taken.type
+
+                if pa.types.is_fixed_size_binary(col_type):
+                    # x_ng: packed float16 – one fixed-size binary row per cell
+                    byte_width: int = col_type.byte_width
+                    n_genes = byte_width // 2
+                    offset = col_taken.offset
+                    values_buf = col_taken.buffers()[1]
+                    arr_bytes = values_buf[offset * byte_width : (offset + len(col_taken)) * byte_width]
+                    part[col_name] = np.frombuffer(arr_bytes, dtype=np.float16).reshape(len(local_idx), n_genes).copy()
+                elif pa.types.is_dictionary(col_type):
+                    part[col_name] = np.array(col_taken.to_pylist())
+                elif pa.types.is_large_string(col_type) or pa.types.is_string(col_type):
+                    part[col_name] = np.array(col_taken.to_pylist(), dtype=object)
+                else:
+                    part[col_name] = col_taken.to_numpy(zero_copy_only=False)
+
+            # Read schema metadata once from the first shard we touch
+            if metadata_dict is None:
+                metadata_dict = {}
+                meta = batch.schema.metadata or {}
+                if b"var_names_g" in meta:
+                    raw = meta[b"var_names_g"].decode()
+                    metadata_dict["var_names_g"] = np.array(raw.split("\n")) if raw else np.array([], dtype=str)
+                for k, v in meta.items():
+                    k_str = k.decode()
+                    if k_str.endswith("_categories"):
+                        metadata_dict[k_str] = np.array(json.loads(v.decode()))
+
+            parts.append(part)
+
+        # Concatenate per-row fields across shards (result is in shard-sorted order)
+        if len(parts) == 1:
+            per_row: dict[str, np.ndarray] = parts[0]
+        else:
+            per_row = {}
+            for key in parts[0]:
+                per_row[key] = np.concatenate([p[key] for p in parts], axis=0)
+
+        # Restore the caller's original request order via inverse permutation
+        inv_perm = np.argsort(perm, kind="stable")
+        result = {key: val[inv_perm] for key, val in per_row.items()}
+
+        # Merge schema-level fields (constant, not per-row)
+        if metadata_dict:
+            result.update(metadata_dict)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Pickling (worker handoff)
+    # ------------------------------------------------------------------
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        del state["cache"]
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        # Rebuild an EMPTY cache – no file I/O on worker init
+        self.cache = LRU(self.max_cache_size)
+
+    # ------------------------------------------------------------------
+    # Repr
+    # ------------------------------------------------------------------
+
+    def __repr__(self) -> str:
+        return f"DistributedArrowDataCollection with n_obs={self.n_obs}, n_shards={len(self.filenames)}"

--- a/cellarium/ml/data/distributed_arrow_data.py
+++ b/cellarium/ml/data/distributed_arrow_data.py
@@ -60,6 +60,13 @@ class DistributedArrowDataCollection:
         cache_size_strictly_enforced:
             If ``True``, raise an error when a single ``__getitem__`` call would
             require more shards than ``max_cache_size``.
+        include_fields:
+            Optional list of per-row Arrow column names to include in the dict
+            returned by :meth:`__getitem__`.  Schema-metadata fields
+            (``var_names_g``, ``*_categories``) are **always** returned and are
+            not affected by this parameter.  ``None`` (default) returns every
+            per-row column.  A :class:`ValueError` is raised on the first read
+            if any requested field is absent from the shard schema.
     """
 
     def __init__(
@@ -70,6 +77,7 @@ class DistributedArrowDataCollection:
         last_shard_size: int | None = None,
         max_cache_size: int = 1,
         cache_size_strictly_enforced: bool = True,
+        include_fields: list[str] | None = None,
     ) -> None:
         self.filenames = list(braceexpand(filenames) if isinstance(filenames, str) else filenames)
 
@@ -92,6 +100,7 @@ class DistributedArrowDataCollection:
         self.limits = limits
         self.max_cache_size = max_cache_size
         self.cache_size_strictly_enforced = cache_size_strictly_enforced
+        self.include_fields = include_fields
         self.cache: LRU = LRU(max_cache_size)
 
     # ------------------------------------------------------------------
@@ -276,6 +285,19 @@ class DistributedArrowDataCollection:
             for key in parts[0]:
                 per_row[key] = np.concatenate([p[key] for p in parts], axis=0)
 
+        # Validate and apply include_fields filter
+        if self.include_fields is not None:
+            available_columns = set(per_row.keys())
+            requested = set(self.include_fields)
+            missing = requested - available_columns
+            if missing:
+                raise ValueError(
+                    f"include_fields contains column(s) not found in the Arrow shard schema: "
+                    f"{sorted(missing)}. "
+                    f"Available per-row columns are: {sorted(available_columns)}."
+                )
+            per_row = {k: v for k, v in per_row.items() if k in requested}
+
         # Restore the caller's original request order via inverse permutation
         inv_perm = np.argsort(perm, kind="stable")
         result = {key: val[inv_perm] for key, val in per_row.items()}
@@ -305,4 +327,7 @@ class DistributedArrowDataCollection:
     # ------------------------------------------------------------------
 
     def __repr__(self) -> str:
-        return f"DistributedArrowDataCollection with n_obs={self.n_obs}, n_shards={len(self.filenames)}"
+        base = f"DistributedArrowDataCollection with n_obs={self.n_obs}, n_shards={len(self.filenames)}"
+        if self.include_fields is not None:
+            base += f", include_fields={self.include_fields!r}"
+        return base

--- a/cellarium/ml/data/shard_collection.py
+++ b/cellarium/ml/data/shard_collection.py
@@ -1,0 +1,49 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ShardCollection(Protocol):
+    """
+    Protocol satisfied by both :class:`~cellarium.ml.data.DistributedAnnDataCollection` and
+    :class:`~cellarium.ml.data.DistributedArrowDataCollection`.
+
+    Implementations must expose ``n_obs``, ``n_vars``, ``limits``, ``__getitem__``, ``__len__``,
+    and :meth:`get_schema_metadata`.
+    """
+
+    limits: list[int]
+
+    @property
+    def n_obs(self) -> int:
+        """Total number of observations across all shards."""
+        ...
+
+    @property
+    def n_vars(self) -> int:
+        """Number of variables (features)."""
+        ...
+
+    def __getitem__(self, idx: int | list[int]) -> Any:
+        """Return data at the given index (or indices)."""
+        ...
+
+    def __len__(self) -> int:
+        """Return the total number of observations."""
+        ...
+
+    def get_schema_metadata(self) -> dict[str, Any]:
+        """
+        Return schema-level metadata without loading any cell data.
+
+        The returned dict contains at minimum:
+
+        * ``"n_obs"`` – total number of observations (:class:`int`)
+        * ``"n_vars"`` – number of variables (:class:`int`)
+        * ``"var_names_g"`` – 1-D :class:`numpy.ndarray` of variable names (str)
+        * ``"<key>_categories"`` – 1-D :class:`numpy.ndarray` of category strings for
+          each categorical field present in the collection
+        """
+        ...

--- a/cellarium/ml/models/__init__.py
+++ b/cellarium/ml/models/__init__.py
@@ -3,6 +3,7 @@
 
 from cellarium.ml.models.cellarium_gpt import CellariumGPT
 from cellarium.ml.models.contrastive_mlp import ContrastiveMLP
+from cellarium.ml.models.data_preformatter import DataPreformatter
 from cellarium.ml.models.geneformer import Geneformer
 from cellarium.ml.models.hvg_seurat_v3 import HVGSeuratV3
 from cellarium.ml.models.incremental_pca import IncrementalPCA
@@ -16,6 +17,7 @@ __all__ = [
     "CellariumGPT",
     "CellariumModel",
     "ContrastiveMLP",
+    "DataPreformatter",
     "Geneformer",
     "HVGSeuratV3",
     "IncrementalPCA",

--- a/cellarium/ml/models/data_preformatter.py
+++ b/cellarium/ml/models/data_preformatter.py
@@ -1,0 +1,199 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+import os
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import torch
+
+from cellarium.ml.models.model import CellariumModel, PredictMixin
+
+
+class DataPreformatter(CellariumModel, PredictMixin):
+    r"""
+    Writes processed batches to Arrow IPC (Feather v2) files.
+
+    Intended to be used as the model in a ``predict`` CLI run, converting h5ad
+    shards (with all ``cpu_transforms`` and ``transforms`` already applied) into
+    fast Arrow shards that can be loaded without any AnnData / HDF5 overhead.
+
+    **Naming conventions used when classifying batch fields:**
+
+    * Fields whose key ends in ``_g`` (e.g. ``var_names_g``, ``mean_g``) but
+      **not** ``_ng`` are per-gene constants → stored in Arrow **schema metadata**.
+    * Fields whose key ends in ``_categories`` are global category arrays →
+      stored in Arrow **schema metadata** as JSON-encoded string lists.
+    * All other fields are per-cell → stored as Arrow **columns**.
+
+    **Per-cell column encoding:**
+
+    * 2-D numeric arrays (e.g. ``x_ng``) → ``FixedSizeBinary(n_cols × 2)``, each
+      row packed as ``float16``.
+    * String / object arrays → ``large_utf8``.
+    * Integer arrays → ``int32``.
+    * All other numerics → ``float32``.
+
+    **Output file naming:**
+
+    ``<output_dir>/rank<rank:02d>_shard<counter:06d>.arrow``
+
+    where *rank* is the PyTorch distributed rank (0 for single-process runs).
+
+    .. note::
+
+        When running with multiple distributed ranks each rank writes its own
+        series of files starting from counter 0.  After preformatting you can
+        renumber the files into a single flat sequence if desired.
+
+    Args:
+        output_dir:
+            Directory in which Arrow IPC files will be written.  Created
+            automatically if it does not exist.
+    """
+
+    def __init__(self, output_dir: str) -> None:
+        super().__init__()
+        self.output_dir = output_dir
+        self._shard_counter: int = 0
+
+    def reset_parameters(self) -> None:
+        # No parameters or buffers to reset.
+        pass
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_numpy(val: Any) -> np.ndarray | None:
+        if isinstance(val, torch.Tensor):
+            return val.detach().cpu().numpy()
+        if isinstance(val, np.ndarray):
+            return val
+        return None
+
+    @staticmethod
+    def _get_rank() -> int:
+        try:
+            import torch.distributed as dist
+
+            if dist.is_available() and dist.is_initialized():
+                return dist.get_rank()
+        except Exception:
+            pass
+        return 0
+
+    def _write_arrow(self, batch: dict[str, Any]) -> None:
+        """Classify batch fields and write one Arrow IPC shard."""
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        # Convert tensors → numpy; skip non-array scalars
+        np_batch: dict[str, np.ndarray] = {}
+        for key, val in batch.items():
+            arr = self._to_numpy(val)
+            if arr is not None:
+                np_batch[key] = arr
+
+        if not np_batch:
+            return
+
+        # Infer n_obs from the first array with ndim >= 1
+        n_obs: int | None = None
+        for val in np_batch.values():
+            if val.ndim >= 1:
+                n_obs = val.shape[0]
+                break
+        if n_obs is None:
+            return
+
+        # Classify: schema metadata vs per-row columns
+        # Rule: keys ending in `_g` (but not `_ng`) or `_categories` → metadata
+        per_row: dict[str, np.ndarray] = {}
+        metadata_arrays: dict[str, np.ndarray] = {}
+        for key, val in np_batch.items():
+            if key.endswith("_categories") or (key.endswith("_g") and not key.endswith("_ng")):
+                metadata_arrays[key] = val
+            else:
+                per_row[key] = val
+
+        # Build Arrow columns for per-row fields
+        arrow_columns: list[pa.Array] = []
+        arrow_fields: list[pa.Field] = []
+
+        for key, val in per_row.items():
+            if val.ndim == 2:
+                # Matrix field (e.g., x_ng): pack each row as float16 bytes
+                val_f16 = val.astype(np.float16)
+                n, d = val_f16.shape
+                byte_width = d * 2
+                col = pa.array(
+                    [val_f16[i].tobytes() for i in range(n)],
+                    type=pa.binary(byte_width),
+                )
+                arrow_fields.append(pa.field(key, pa.binary(byte_width)))
+            elif val.dtype.kind in ("U", "O", "S"):
+                col = pa.array(val.tolist(), type=pa.large_utf8())
+                arrow_fields.append(pa.field(key, pa.large_utf8()))
+            elif val.dtype.kind in ("i", "u"):
+                col = pa.array(val.astype(np.int32), type=pa.int32())
+                arrow_fields.append(pa.field(key, pa.int32()))
+            else:
+                col = pa.array(val.astype(np.float32), type=pa.float32())
+                arrow_fields.append(pa.field(key, pa.float32()))
+            arrow_columns.append(col)
+
+        # Build schema metadata
+        schema_meta: dict[bytes, bytes] = {
+            b"cellarium_arrow_version": b"1",
+            b"n_obs": str(n_obs).encode(),
+        }
+        for key, val in metadata_arrays.items():
+            if key == "var_names_g" or (key.endswith("_g") and val.dtype.kind in ("U", "O")):
+                schema_meta[key.encode()] = "\n".join(val.tolist()).encode()
+                if key == "var_names_g":
+                    schema_meta[b"n_genes"] = str(len(val)).encode()
+            else:
+                schema_meta[key.encode()] = json.dumps(val.tolist()).encode()
+
+        schema = pa.schema(arrow_fields, metadata=schema_meta)
+        record_batch = pa.record_batch(arrow_columns, schema=schema)
+
+        rank = self._get_rank()
+        filename = os.path.join(self.output_dir, f"rank{rank:02d}_shard{self._shard_counter:06d}.arrow")
+        with pa.OSFile(filename, "wb") as sink:
+            with pa.ipc.new_file(sink, schema) as writer:
+                writer.write_batch(record_batch)
+
+        self._shard_counter += 1
+
+    # ------------------------------------------------------------------
+    # CellariumModel interface
+    # ------------------------------------------------------------------
+
+    def forward(self, **kwargs: Any) -> dict:
+        """
+        Write one Arrow IPC shard from the batch and return an empty dict
+        (no loss is produced).
+
+        The ``**kwargs`` annotation causes :func:`~cellarium.ml.utilities.core.call_func_with_batch`
+        to pass all batch keys to this method.
+        """
+        self._write_arrow(kwargs)
+        return {}
+
+    # ------------------------------------------------------------------
+    # PredictMixin interface
+    # ------------------------------------------------------------------
+
+    def predict(self, **kwargs: Any) -> dict[str, np.ndarray | torch.Tensor]:
+        """
+        Write one Arrow IPC shard from the batch during predict mode.
+
+        The ``**kwargs`` annotation causes :func:`~cellarium.ml.utilities.core.call_func_with_batch`
+        to pass all batch keys to this method.
+        """
+        self._write_arrow(kwargs)
+        return {}

--- a/cellarium/ml/models/data_preformatter.py
+++ b/cellarium/ml/models/data_preformatter.py
@@ -1,12 +1,9 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import json
-import os
 from typing import Any
 
 import numpy as np
-import pyarrow as pa
 import torch
 
 from cellarium.ml.models.model import CellariumModel, PredictMixin
@@ -14,203 +11,30 @@ from cellarium.ml.models.model import CellariumModel, PredictMixin
 
 class DataPreformatter(CellariumModel, PredictMixin):
     r"""
-    Writes processed batches to Arrow IPC (Feather v2) files.
+    Minimal pass-through model for the ``data_preformatter`` CLI workflow.
 
-    Intended to be used as the model in a ``predict`` CLI run, converting h5ad
-    shards (with all ``cpu_transforms`` and ``transforms`` already applied) into
-    fast Arrow shards that can be loaded without any AnnData / HDF5 overhead.
+    Intended to be combined with
+    :class:`~cellarium.ml.callbacks.PredictionWriterArrow` in a ``predict`` CLI
+    run.  This model itself performs no transformations and writes nothing to
+    disk.  All ``cpu_transforms`` and ``transforms`` upstream in the pipeline are
+    applied by the dataloader / pipeline as usual, and
+    :class:`~cellarium.ml.callbacks.PredictionWriterArrow` receives the fully
+    accumulated post-transform batch via ``write_on_batch_end`` and writes it to
+    Arrow IPC files.
 
-    **Naming conventions used when classifying batch fields:**
-
-    * Fields whose key ends in ``_g`` (e.g. ``var_names_g``, ``mean_g``) but
-      **not** ``_ng`` are per-gene constants → stored in Arrow **schema metadata**.
-    * Fields whose key ends in ``_categories`` are global category arrays →
-      stored in Arrow **schema metadata** as JSON-encoded string lists.
-    * All other fields are per-cell → stored as Arrow **columns**.
-
-    **Per-cell column encoding:**
-
-    * 2-D numeric arrays (e.g. ``x_ng``) → ``FixedSizeBinary(n_cols × 2)``, each
-      row packed as ``float16``.
-    * String / object arrays → ``large_utf8``.
-    * Integer arrays → ``int32``.
-    * All other numerics → ``float32``.
-
-    **Output file naming:**
-
-    ``<output_dir>/rank<rank:02d>_shard<counter:06d>.arrow``
-
-    where *rank* is the PyTorch distributed rank (0 for single-process runs).
-
-    .. note::
-
-        When running with multiple distributed ranks each rank writes its own
-        series of files starting from counter 0.  After preformatting you can
-        renumber the files into a single flat sequence if desired.
-
-    Args:
-        output_dir:
-            Directory in which Arrow IPC files will be written.  Created
-            automatically if it does not exist.
-        compression:
-            Compression codec to use when writing Arrow IPC files.  Accepted
-            values:
-
-            * ``"zstd"`` *(default)* — best compression ratio; recommended for
-              raw integer count data (sparse) where 5–20× size reduction is
-              typical.  Decompresses at ~2 GB/s.
-            * ``"lz4"`` — lower compression ratio than ZSTD but decompresses at
-              ~4 GB/s; useful when CPU is the bottleneck.
-            * ``None`` — no compression; useful for local NVMe storage where I/O
-              bandwidth exceeds decompression throughput.
-
-            Decompression is handled automatically by
-            :class:`~cellarium.ml.data.DistributedArrowDataCollection` — no
-            reader-side configuration is required.
+    Both :meth:`predict` and :meth:`forward` return an empty dict so that
+    :class:`~cellarium.ml.core.CellariumPipeline` accumulates all transform
+    outputs into the final ``prediction`` dict, which the callback then receives.
     """
-
-    def __init__(self, output_dir: str, compression: str | None = "zstd") -> None:
-        super().__init__()
-        self.output_dir = output_dir
-        self.compression = compression
-        self._shard_counter: int = 0
 
     def reset_parameters(self) -> None:
         # No parameters or buffers to reset.
         pass
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _to_numpy(val: Any) -> np.ndarray | None:
-        if isinstance(val, torch.Tensor):
-            return val.detach().cpu().numpy()
-        if isinstance(val, np.ndarray):
-            return val
-        return None
-
-    @staticmethod
-    def _get_rank() -> int:
-        try:
-            import torch.distributed as dist
-
-            if dist.is_available() and dist.is_initialized():
-                return dist.get_rank()
-        except Exception:
-            pass
-        return 0
-
-    def _write_arrow(self, batch: dict[str, Any]) -> None:
-        """Classify batch fields and write one Arrow IPC shard."""
-        os.makedirs(self.output_dir, exist_ok=True)
-
-        # Convert tensors → numpy; skip non-array scalars
-        np_batch: dict[str, np.ndarray] = {}
-        for key, val in batch.items():
-            arr = self._to_numpy(val)
-            if arr is not None:
-                np_batch[key] = arr
-
-        if not np_batch:
-            return
-
-        # Infer n_obs from the first array with ndim >= 1
-        n_obs: int | None = None
-        for val in np_batch.values():
-            if val.ndim >= 1:
-                n_obs = val.shape[0]
-                break
-        if n_obs is None:
-            return
-
-        # Classify: schema metadata vs per-row columns
-        # Rule: keys ending in `_g` (but not `_ng`) or `_categories` → metadata
-        per_row: dict[str, np.ndarray] = {}
-        metadata_arrays: dict[str, np.ndarray] = {}
-        for key, val in np_batch.items():
-            if key.endswith("_categories") or (key.endswith("_g") and not key.endswith("_ng")):
-                metadata_arrays[key] = val
-            else:
-                per_row[key] = val
-
-        # Build Arrow columns for per-row fields
-        arrow_columns: list[pa.Array] = []
-        arrow_fields: list[pa.Field] = []
-
-        for key, val in per_row.items():
-            if val.ndim == 2:
-                # Matrix field (e.g., x_ng): pack each row as float16 bytes
-                val_f16 = val.astype(np.float16)
-                n, d = val_f16.shape
-                byte_width = d * 2
-                col = pa.array(
-                    [val_f16[i].tobytes() for i in range(n)],
-                    type=pa.binary(byte_width),
-                )
-                arrow_fields.append(pa.field(key, pa.binary(byte_width)))
-            elif val.dtype.kind in ("U", "O", "S"):
-                col = pa.array(val.tolist(), type=pa.large_utf8())
-                arrow_fields.append(pa.field(key, pa.large_utf8()))
-            elif val.dtype.kind in ("i", "u"):
-                col = pa.array(val.astype(np.int32), type=pa.int32())
-                arrow_fields.append(pa.field(key, pa.int32()))
-            else:
-                col = pa.array(val.astype(np.float32), type=pa.float32())
-                arrow_fields.append(pa.field(key, pa.float32()))
-            arrow_columns.append(col)
-
-        # Build schema metadata
-        schema_meta: dict[bytes, bytes] = {
-            b"cellarium_arrow_version": b"1",
-            b"n_obs": str(n_obs).encode(),
-        }
-        for key, val in metadata_arrays.items():
-            if key == "var_names_g" or (key.endswith("_g") and val.dtype.kind in ("U", "O")):
-                schema_meta[key.encode()] = "\n".join(val.tolist()).encode()
-                if key == "var_names_g":
-                    schema_meta[b"n_genes"] = str(len(val)).encode()
-            else:
-                schema_meta[key.encode()] = json.dumps(val.tolist()).encode()
-
-        schema = pa.schema(arrow_fields, metadata=schema_meta)
-        record_batch = pa.record_batch(arrow_columns, schema=schema)
-
-        rank = self._get_rank()
-        filename = os.path.join(self.output_dir, f"rank{rank:02d}_shard{self._shard_counter:06d}.arrow")
-        options = pa.ipc.IpcWriteOptions(compression=self.compression)
-        with pa.OSFile(filename, "wb") as sink:
-            with pa.ipc.new_file(sink, schema, options=options) as writer:
-                writer.write_batch(record_batch)
-
-        self._shard_counter += 1
-
-    # ------------------------------------------------------------------
-    # CellariumModel interface
-    # ------------------------------------------------------------------
-
     def forward(self, **kwargs: Any) -> dict:
-        """
-        Write one Arrow IPC shard from the batch and return an empty dict
-        (no loss is produced).
-
-        The ``**kwargs`` annotation causes :func:`~cellarium.ml.utilities.core.call_func_with_batch`
-        to pass all batch keys to this method.
-        """
-        self._write_arrow(kwargs)
+        """Return ``{}``; the pipeline accumulates all transform outputs."""
         return {}
 
-    # ------------------------------------------------------------------
-    # PredictMixin interface
-    # ------------------------------------------------------------------
-
     def predict(self, **kwargs: Any) -> dict[str, np.ndarray | torch.Tensor]:
-        """
-        Write one Arrow IPC shard from the batch during predict mode.
-
-        The ``**kwargs`` annotation causes :func:`~cellarium.ml.utilities.core.call_func_with_batch`
-        to pass all batch keys to this method.
-        """
-        self._write_arrow(kwargs)
+        """Return ``{}``; the pipeline accumulates all transform outputs."""
         return {}

--- a/cellarium/ml/models/data_preformatter.py
+++ b/cellarium/ml/models/data_preformatter.py
@@ -52,11 +52,27 @@ class DataPreformatter(CellariumModel, PredictMixin):
         output_dir:
             Directory in which Arrow IPC files will be written.  Created
             automatically if it does not exist.
+        compression:
+            Compression codec to use when writing Arrow IPC files.  Accepted
+            values:
+
+            * ``"zstd"`` *(default)* — best compression ratio; recommended for
+              raw integer count data (sparse) where 5–20× size reduction is
+              typical.  Decompresses at ~2 GB/s.
+            * ``"lz4"`` — lower compression ratio than ZSTD but decompresses at
+              ~4 GB/s; useful when CPU is the bottleneck.
+            * ``None`` — no compression; useful for local NVMe storage where I/O
+              bandwidth exceeds decompression throughput.
+
+            Decompression is handled automatically by
+            :class:`~cellarium.ml.data.DistributedArrowDataCollection` — no
+            reader-side configuration is required.
     """
 
-    def __init__(self, output_dir: str) -> None:
+    def __init__(self, output_dir: str, compression: str | None = "zstd") -> None:
         super().__init__()
         self.output_dir = output_dir
+        self.compression = compression
         self._shard_counter: int = 0
 
     def reset_parameters(self) -> None:
@@ -163,8 +179,9 @@ class DataPreformatter(CellariumModel, PredictMixin):
 
         rank = self._get_rank()
         filename = os.path.join(self.output_dir, f"rank{rank:02d}_shard{self._shard_counter:06d}.arrow")
+        options = pa.ipc.IpcWriteOptions(compression=self.compression)
         with pa.OSFile(filename, "wb") as sink:
-            with pa.ipc.new_file(sink, schema) as writer:
+            with pa.ipc.new_file(sink, schema, options=options) as writer:
                 writer.write_batch(record_batch)
 
         self._shard_counter += 1

--- a/cellarium/ml/models/hvg_seurat_v3.py
+++ b/cellarium/ml/models/hvg_seurat_v3.py
@@ -15,6 +15,7 @@ import torch.distributed as dist
 from lightning.pytorch.strategies import DDPStrategy
 
 from cellarium.ml.core.datamodule import CellariumAnnDataDataModule
+from cellarium.ml.data.distributed_anndata import DistributedAnnDataCollection
 from cellarium.ml.models.model import CellariumModel
 from cellarium.ml.utilities.testing import (
     assert_arrays_equal,
@@ -327,7 +328,9 @@ class HVGSeuratV3(CellariumModel):
             # Retrieve adata.var annotation columns to enrich the output DataFrame.
             var_df: pd.DataFrame | None = None
             datamodule = getattr(trainer, "datamodule", None)
-            if isinstance(datamodule, CellariumAnnDataDataModule):
+            if isinstance(datamodule, CellariumAnnDataDataModule) and isinstance(
+                datamodule.dadc, DistributedAnnDataCollection
+            ):
                 var_df = datamodule.dadc.schema.attr_values["var"]
             else:
                 warnings.warn(

--- a/cellarium/ml/models/onepass_mean_var_std.py
+++ b/cellarium/ml/models/onepass_mean_var_std.py
@@ -103,6 +103,19 @@ class OnePassMeanVarStd(CellariumModel):
             batch_index_n = torch.zeros(x_ng.shape[0], dtype=torch.long, device=x_ng.device)
         else:
             batch_index_n = batch_index_n.long()  # needed for scatter_add_
+            if batch_index_n.numel() > 0:
+                lo = int(batch_index_n.min())
+                hi = int(batch_index_n.max())
+                if lo < 0 or hi >= self.n_batch:
+                    raise ValueError(
+                        f"batch_index_n values were supplied to model, and must be in [0, n_batch={self.n_batch}), "
+                        f"but got min={lo}, max={hi}. "
+                        f"If the data contains more unique batches than n_batch, set n_batch "
+                        f"to the correct number of unique batch labels. "
+                        f"If batch_index_n should not be used (e.g. computing global statistics "
+                        f"with n_batch=1), exclude it from the batch dict before it reaches this "
+                        f"model (e.g. via DistributedArrowDataCollection(include_fields=[...]))."
+                    )
 
         if self.algorithm == "naive":
             x_for_sum = x_ng

--- a/examples/cli_workflow/arrow_converter.yaml
+++ b/examples/cli_workflow/arrow_converter.yaml
@@ -1,0 +1,38 @@
+model:
+  transforms:
+    - class_path: cellarium.ml.transforms.NormalizeTotal
+      init_args:
+        target_count: 10_000
+    - cellarium.ml.transforms.Log1p
+  model:
+    class_path: cellarium.ml.models.DataPreformatter
+
+data:
+  dadc:
+    class_path: cellarium.ml.data.DistributedAnnDataCollection
+    init_args:
+      filenames: gs://bucket/adata_{0..99}.h5ad
+      shard_size: 1800
+      max_cache_size: 2
+  batch_keys:
+    x_ng:
+      attr: X
+      convert_fn: cellarium.ml.utilities.data.densify
+    var_names_g:
+      attr: var_names
+    obs_names_n:
+      attr: obs_names
+  batch_size: 10000
+  num_workers: 4
+
+trainer:
+  accelerator: cpu
+  devices: 1
+  callbacks:
+    - class_path: cellarium.ml.callbacks.PredictionWriterArrow
+      init_args:
+        output_dir: ./arrow_output
+        compression: lz4
+        num_write_workers: 8
+
+return_predictions: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "jsonargparse[signatures]==4.27.7",
   "lightning>=2.2.0,<=2.5.2",
   "numpy<=1.26.4",
+  "pyarrow",
   "pyro-ppl>=1.9.1",
   "pytest",
   "scikit-misc==0.5.1",

--- a/tests/dataloader/test_datamodule.py
+++ b/tests/dataloader/test_datamodule.py
@@ -193,6 +193,7 @@ def test_datamodule(tmp_path: Path, batch_size: int | None, accelerator: str) ->
     trainer.fit(module, datamodule)
 
     ckpt_path = str(tmp_path / "lightning_logs/version_0/checkpoints/epoch=0-step=1.ckpt")
+    assert isinstance(datamodule.dadc, DistributedAnnDataCollection)
     adata = datamodule.dadc.adatas[0].adata
     kwargs = {"dadc": adata}
     if batch_size is not None:

--- a/tests/dataloader/test_distributed_arrow.py
+++ b/tests/dataloader/test_distributed_arrow.py
@@ -566,3 +566,85 @@ def test_pickle_dataset(dat: DistributedArrowDataCollection, source_arrays: dict
         atol=1e-6,
     )
     np.testing.assert_array_equal(obs_names_n, source_arrays["obs_names"][:2])
+
+
+# ---------------------------------------------------------------------------
+# DistributedArrowDataCollection: include_fields
+# ---------------------------------------------------------------------------
+
+
+def test_include_fields_filters_per_row_columns(tmp_path: Path, source_arrays: dict) -> None:
+    """include_fields=["x_ng"] keeps x_ng, drops other per-row columns, keeps metadata."""
+    # Write a shard that includes x_ng, obs_names_n, and a batch_index_n column.
+    batch_index = np.arange(N_CELL, dtype=np.int32)
+    dp = PredictionWriterArrow(output_dir=str(tmp_path))
+    dp._write_arrow(
+        {
+            "x_ng": source_arrays["x"],
+            "obs_names_n": source_arrays["obs_names"],
+            "batch_index_n": batch_index,
+            "var_names_g": VAR_NAMES,
+        }
+    )
+
+    dadc = DistributedArrowDataCollection(
+        [str(tmp_path / "rank00_shard000000.arrow")],
+        shard_size=N_CELL,
+        include_fields=["x_ng"],
+    )
+    result = dadc[list(range(N_CELL))]
+
+    assert "x_ng" in result, "x_ng must be present when included in include_fields"
+    assert "batch_index_n" not in result, "batch_index_n must be filtered out"
+    assert "obs_names_n" not in result, "obs_names_n must be filtered out"
+    # Schema metadata fields are never filtered
+    assert "var_names_g" in result, "var_names_g (schema metadata) must always be present"
+
+
+def test_include_fields_none_returns_all_columns(tmp_path: Path, source_arrays: dict) -> None:
+    """include_fields=None (default) returns every per-row column — backward compatible."""
+    batch_index = np.arange(N_CELL, dtype=np.int32)
+    dp = PredictionWriterArrow(output_dir=str(tmp_path))
+    dp._write_arrow(
+        {
+            "x_ng": source_arrays["x"],
+            "obs_names_n": source_arrays["obs_names"],
+            "batch_index_n": batch_index,
+            "var_names_g": VAR_NAMES,
+        }
+    )
+
+    dadc = DistributedArrowDataCollection(
+        [str(tmp_path / "rank00_shard000000.arrow")],
+        shard_size=N_CELL,
+        include_fields=None,
+    )
+    result = dadc[list(range(N_CELL))]
+
+    for col in ("x_ng", "obs_names_n", "batch_index_n", "var_names_g"):
+        assert col in result, f"{col} should be present when include_fields is None"
+
+
+def test_include_fields_missing_column_raises(tmp_path: Path, source_arrays: dict) -> None:
+    """Requesting a column that doesn't exist raises ValueError with a clear message."""
+    dp = PredictionWriterArrow(output_dir=str(tmp_path))
+    dp._write_arrow(
+        {
+            "x_ng": source_arrays["x"],
+            "obs_names_n": source_arrays["obs_names"],
+            "var_names_g": VAR_NAMES,
+        }
+    )
+
+    dadc = DistributedArrowDataCollection(
+        [str(tmp_path / "rank00_shard000000.arrow")],
+        shard_size=N_CELL,
+        include_fields=["x_ng", "nonexistent_column_n"],
+    )
+
+    with pytest.raises(ValueError, match="nonexistent_column_n") as exc_info:
+        dadc[list(range(N_CELL))]
+
+    msg = str(exc_info.value)
+    assert "not found in the Arrow shard schema" in msg
+    assert "Available per-row columns" in msg

--- a/tests/dataloader/test_distributed_arrow.py
+++ b/tests/dataloader/test_distributed_arrow.py
@@ -10,11 +10,11 @@ import numpy as np
 import pytest
 import torch
 
+from cellarium.ml.callbacks.prediction_writer_arrow import PredictionWriterArrow
 from cellarium.ml.data import (
     DistributedArrowDataCollection,
     IterableDistributedAnnDataCollectionDataset,
 )
-from cellarium.ml.models.data_preformatter import DataPreformatter
 
 # ---------------------------------------------------------------------------
 # Shared data dimensions
@@ -29,11 +29,11 @@ Y_CATEGORIES = np.array(["type_a", "type_b", "type_c"])
 
 
 # ---------------------------------------------------------------------------
-# Helper: write a single Arrow shard via DataPreformatter._write_arrow
+# Helper: write a single Arrow shard via PredictionWriterArrow._write_arrow
 # ---------------------------------------------------------------------------
 
 
-def _write_shard(dp: DataPreformatter, x: np.ndarray, obs_names: np.ndarray, y: np.ndarray) -> None:
+def _write_shard(dp: PredictionWriterArrow, x: np.ndarray, obs_names: np.ndarray, y: np.ndarray) -> None:
     """Write one shard for the given slice of cells."""
     dp._write_arrow(
         {
@@ -66,7 +66,7 @@ def source_arrays() -> dict:
 def arrows_path(tmp_path_factory: pytest.TempPathFactory, source_arrays: dict) -> Path:
     """Write three Arrow shards matching SHARD_LIMITS to a temp directory."""
     tmp_path = tmp_path_factory.mktemp("arrows")
-    dp = DataPreformatter(output_dir=str(tmp_path))
+    dp = PredictionWriterArrow(output_dir=str(tmp_path))
     starts = [0] + SHARD_LIMITS[:-1]
     for start, end in zip(starts, SHARD_LIMITS):
         _write_shard(
@@ -92,7 +92,7 @@ def dat(arrows_path: Path, request: pytest.FixtureRequest) -> DistributedArrowDa
 
 
 # ---------------------------------------------------------------------------
-# DataPreformatter: field classification and file writing
+# PredictionWriterArrow: field classification and file writing
 # ---------------------------------------------------------------------------
 
 
@@ -100,7 +100,7 @@ def test_preformatter_field_classification(tmp_path: Path) -> None:
     """Check that the right fields land in columns vs schema metadata."""
     import pyarrow as pa
 
-    dp = DataPreformatter(output_dir=str(tmp_path))
+    dp = PredictionWriterArrow(output_dir=str(tmp_path))
     rng = np.random.default_rng(0)
     x = rng.standard_normal((4, N_GENE)).astype(np.float32)
     obs_names = np.array([f"c{i}" for i in range(4)], dtype=object)
@@ -152,7 +152,7 @@ def test_preformatter_field_classification(tmp_path: Path) -> None:
 
 def test_preformatter_shard_counter(tmp_path: Path) -> None:
     """Counter increments and files are named correctly."""
-    dp = DataPreformatter(output_dir=str(tmp_path))
+    dp = PredictionWriterArrow(output_dir=str(tmp_path))
     rng = np.random.default_rng(1)
     x = rng.standard_normal((2, N_GENE)).astype(np.float32)
     obs = np.array(["a", "b"], dtype=object)
@@ -165,8 +165,8 @@ def test_preformatter_shard_counter(tmp_path: Path) -> None:
 
 
 def test_preformatter_tensor_input(tmp_path: Path) -> None:
-    """DataPreformatter accepts torch.Tensor inputs via _to_numpy."""
-    dp = DataPreformatter(output_dir=str(tmp_path))
+    """PredictionWriterArrow accepts torch.Tensor inputs via _to_numpy."""
+    dp = PredictionWriterArrow(output_dir=str(tmp_path))
     x_tensor = torch.randn(3, N_GENE)
     obs = np.array([f"c{i}" for i in range(3)], dtype=object)
     y = np.array([0, 0, 1], dtype=np.int32)
@@ -209,8 +209,8 @@ def test_preformatter_compression(tmp_path: Path, compression: str | None) -> No
     compressed_dir = tmp_path / f"compressed_{compression}"
     uncompressed_dir = tmp_path / "uncompressed"
 
-    dp_compressed = DataPreformatter(output_dir=str(compressed_dir), compression=compression)
-    dp_uncompressed = DataPreformatter(output_dir=str(uncompressed_dir), compression=None)
+    dp_compressed = PredictionWriterArrow(output_dir=str(compressed_dir), compression=compression)
+    dp_uncompressed = PredictionWriterArrow(output_dir=str(uncompressed_dir), compression=None)
 
     batch = {"x_ng": x, "obs_names_n": obs, "y_n": y, "var_names_g": var_names}
     dp_compressed._write_arrow(batch)
@@ -241,6 +241,44 @@ def test_preformatter_compression(tmp_path: Path, compression: str | None) -> No
     np.testing.assert_array_equal(obs_names_n, obs)
 
 
+def test_preformatter_async_writes(tmp_path: Path) -> None:
+    """predict() offloads writes to the thread pool; on_predict_end() flushes and all files are readable."""
+    rng = np.random.default_rng(99)
+    n_cells, n_genes = 20, 10
+    var_names = np.array([f"gene{i:04d}" for i in range(n_genes)])
+
+    # Use 3 workers so we exercise the bounded-queue backpressure path with 12 batches.
+    dp = PredictionWriterArrow(output_dir=str(tmp_path), compression=None, num_write_workers=3)
+
+    n_batches = 12
+    batches = []
+    for i in range(n_batches):
+        x = rng.standard_normal((n_cells, n_genes)).astype(np.float32)
+        obs = np.array([f"b{i}c{j:03d}" for j in range(n_cells)], dtype=object)
+        y = np.zeros(n_cells, dtype=np.int32)
+        batches.append({"x_ng": x, "obs_names_n": obs, "y_n": y, "var_names_g": var_names})
+        # _submit_write is async — files may not exist yet
+        dp._submit_write(batches[-1])
+
+    assert dp._shard_counter == n_batches, "counter must be incremented synchronously in main thread"
+
+    # Flush — blocks until all worker threads finish
+    dp.flush()
+
+    for i in range(n_batches):
+        path = tmp_path / f"rank00_shard{i:06d}.arrow"
+        assert path.exists(), f"shard {i} not written after flush"
+
+    # Verify one shard round-trips correctly
+    dadc = DistributedArrowDataCollection([str(tmp_path / "rank00_shard000000.arrow")], shard_size=n_cells)
+    result = dadc[list(range(n_cells))]
+    np.testing.assert_allclose(
+        result["x_ng"].astype(np.float32),
+        batches[0]["x_ng"].astype(np.float16).astype(np.float32),
+        atol=1e-3,
+    )
+
+
 # ---------------------------------------------------------------------------
 # DistributedArrowDataCollection: init
 # ---------------------------------------------------------------------------
@@ -266,7 +304,7 @@ def test_init_shard_size(tmp_path: Path, num_shards: int, last_shard_size: int |
     shard_size = 3
     rng = np.random.default_rng(99)
     out_dir = tmp_path / f"shards_{num_shards}_{last_shard_size}"
-    dp = DataPreformatter(output_dir=str(out_dir))
+    dp = PredictionWriterArrow(output_dir=str(out_dir))
     filenames = []
     for i in range(num_shards):
         n = last_shard_size if (last_shard_size is not None and i == num_shards - 1) else shard_size

--- a/tests/dataloader/test_distributed_arrow.py
+++ b/tests/dataloader/test_distributed_arrow.py
@@ -194,6 +194,53 @@ def test_preformatter_tensor_input(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("compression", ["zstd", "lz4", None])
+def test_preformatter_compression(tmp_path: Path, compression: str | None) -> None:
+    """Compressed shards are smaller than uncompressed and round-trip values identically."""
+    rng = np.random.default_rng(77)
+    # Use sparse-ish integer counts (realistic UMI data) so compression has something to work with
+    n_cells, n_genes = 50, 200
+    x = rng.integers(0, 5, size=(n_cells, n_genes)).astype(np.float32)
+    x[x < 3] = 0  # ~60 % sparsity
+    obs = np.array([f"c{i:03d}" for i in range(n_cells)], dtype=object)
+    y = np.zeros(n_cells, dtype=np.int32)
+    var_names = np.array([f"gene{i:04d}" for i in range(n_genes)])
+
+    compressed_dir = tmp_path / f"compressed_{compression}"
+    uncompressed_dir = tmp_path / "uncompressed"
+
+    dp_compressed = DataPreformatter(output_dir=str(compressed_dir), compression=compression)
+    dp_uncompressed = DataPreformatter(output_dir=str(uncompressed_dir), compression=None)
+
+    batch = {"x_ng": x, "obs_names_n": obs, "y_n": y, "var_names_g": var_names}
+    dp_compressed._write_arrow(batch)
+    dp_uncompressed._write_arrow(batch)
+
+    compressed_file = compressed_dir / "rank00_shard000000.arrow"
+    uncompressed_file = uncompressed_dir / "rank00_shard000000.arrow"
+    assert compressed_file.exists()
+    assert uncompressed_file.exists()
+
+    if compression is not None:
+        assert compressed_file.stat().st_size < uncompressed_file.stat().st_size, (
+            f"{compression} compressed file should be smaller than uncompressed"
+        )
+
+    # Values must be identical regardless of compression
+    dadc = DistributedArrowDataCollection([str(compressed_file)], shard_size=n_cells)
+    result = dadc[list(range(n_cells))]
+    x_ng = result["x_ng"]
+    obs_names_n = result["obs_names_n"]
+    assert isinstance(x_ng, np.ndarray)
+    assert isinstance(obs_names_n, np.ndarray)
+    np.testing.assert_allclose(
+        x_ng.astype(np.float32),
+        x.astype(np.float16).astype(np.float32),
+        atol=1e-3,
+    )
+    np.testing.assert_array_equal(obs_names_n, obs)
+
+
 # ---------------------------------------------------------------------------
 # DistributedArrowDataCollection: init
 # ---------------------------------------------------------------------------

--- a/tests/dataloader/test_distributed_arrow.py
+++ b/tests/dataloader/test_distributed_arrow.py
@@ -1,0 +1,406 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+import os
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from cellarium.ml.data import (
+    DistributedArrowDataCollection,
+    IterableDistributedAnnDataCollectionDataset,
+)
+from cellarium.ml.models.data_preformatter import DataPreformatter
+
+# ---------------------------------------------------------------------------
+# Shared data dimensions
+# ---------------------------------------------------------------------------
+
+N_CELL = 10
+N_GENE = 5
+# Three shards: 2 cells, 3 cells, 5 cells
+SHARD_LIMITS = [2, 5, 10]
+VAR_NAMES = np.array([f"gene{i:03d}" for i in range(N_GENE)])
+Y_CATEGORIES = np.array(["type_a", "type_b", "type_c"])
+
+
+# ---------------------------------------------------------------------------
+# Helper: write a single Arrow shard via DataPreformatter._write_arrow
+# ---------------------------------------------------------------------------
+
+
+def _write_shard(dp: DataPreformatter, x: np.ndarray, obs_names: np.ndarray, y: np.ndarray) -> None:
+    """Write one shard for the given slice of cells."""
+    dp._write_arrow(
+        {
+            "x_ng": x,
+            "obs_names_n": obs_names,
+            "y_n": y.astype(np.int32),
+            "total_mrna_umis_n": x.sum(axis=1).astype(np.float32),
+            "var_names_g": VAR_NAMES,
+            "y_categories": Y_CATEGORIES,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def source_arrays() -> dict:
+    """Ground-truth numpy arrays for all N_CELL cells."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((N_CELL, N_GENE)).astype(np.float32)
+    obs_names = np.array([f"cell{i:03d}" for i in range(N_CELL)], dtype=object)
+    y = rng.integers(0, len(Y_CATEGORIES), N_CELL).astype(np.int32)
+    return {"x": x, "obs_names": obs_names, "y": y}
+
+
+@pytest.fixture(scope="module")
+def arrows_path(tmp_path_factory: pytest.TempPathFactory, source_arrays: dict) -> Path:
+    """Write three Arrow shards matching SHARD_LIMITS to a temp directory."""
+    tmp_path = tmp_path_factory.mktemp("arrows")
+    dp = DataPreformatter(output_dir=str(tmp_path))
+    starts = [0] + SHARD_LIMITS[:-1]
+    for start, end in zip(starts, SHARD_LIMITS):
+        _write_shard(
+            dp,
+            source_arrays["x"][start:end],
+            source_arrays["obs_names"][start:end],
+            source_arrays["y"][start:end],
+        )
+    return tmp_path
+
+
+@pytest.fixture(params=[(i, j) for i in (1, 2, 3) for j in (True, False)])
+def dat(arrows_path: Path, request: pytest.FixtureRequest) -> DistributedArrowDataCollection:
+    """Parametrized DistributedArrowDataCollection over the three test shards."""
+    max_cache_size, cache_size_strictly_enforced = request.param
+    filenames = [str(arrows_path / f"rank00_shard{i:06d}.arrow") for i in range(3)]
+    return DistributedArrowDataCollection(
+        filenames,
+        limits=SHARD_LIMITS,
+        max_cache_size=max_cache_size,
+        cache_size_strictly_enforced=cache_size_strictly_enforced,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DataPreformatter: field classification and file writing
+# ---------------------------------------------------------------------------
+
+
+def test_preformatter_field_classification(tmp_path: Path) -> None:
+    """Check that the right fields land in columns vs schema metadata."""
+    import pyarrow as pa
+
+    dp = DataPreformatter(output_dir=str(tmp_path))
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((4, N_GENE)).astype(np.float32)
+    obs_names = np.array([f"c{i}" for i in range(4)], dtype=object)
+    y = np.array([0, 1, 0, 2], dtype=np.int32)
+
+    dp._write_arrow(
+        {
+            "x_ng": x,
+            "obs_names_n": obs_names,
+            "y_n": y,
+            "total_mrna_umis_n": x.sum(axis=1).astype(np.float32),
+            "var_names_g": VAR_NAMES,
+            "y_categories": Y_CATEGORIES,
+        }
+    )
+
+    arrow_file = str(tmp_path / "rank00_shard000000.arrow")
+    with pa.memory_map(arrow_file, "r") as src:
+        reader = pa.ipc.open_file(src)
+        batch = reader.get_batch(0)
+        meta = reader.schema.metadata
+
+    # --- Per-row columns ---
+    assert "x_ng" in batch.schema.names
+    assert pa.types.is_fixed_size_binary(batch.schema.field("x_ng").type)
+    assert batch.schema.field("x_ng").type.byte_width == N_GENE * 2
+
+    assert "obs_names_n" in batch.schema.names
+    assert pa.types.is_large_string(batch.schema.field("obs_names_n").type)
+
+    assert "y_n" in batch.schema.names
+    assert pa.types.is_int32(batch.schema.field("y_n").type)
+
+    assert "total_mrna_umis_n" in batch.schema.names
+    assert pa.types.is_float32(batch.schema.field("total_mrna_umis_n").type)
+
+    # --- Schema metadata ---
+    assert "var_names_g" not in batch.schema.names
+    assert b"var_names_g" in meta
+    assert "y_categories" not in batch.schema.names
+    assert b"y_categories" in meta
+
+    # Check metadata contents
+    assert meta[b"cellarium_arrow_version"] == b"1"
+    assert int(meta[b"n_genes"]) == N_GENE
+    assert meta[b"var_names_g"].decode().split("\n") == list(VAR_NAMES)
+    assert json.loads(meta[b"y_categories"].decode()) == list(Y_CATEGORIES)
+
+
+def test_preformatter_shard_counter(tmp_path: Path) -> None:
+    """Counter increments and files are named correctly."""
+    dp = DataPreformatter(output_dir=str(tmp_path))
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((2, N_GENE)).astype(np.float32)
+    obs = np.array(["a", "b"], dtype=object)
+    y = np.array([0, 1], dtype=np.int32)
+
+    for i in range(4):
+        _write_shard(dp, x, obs, y)
+        assert dp._shard_counter == i + 1
+        assert os.path.exists(str(tmp_path / f"rank00_shard{i:06d}.arrow"))
+
+
+def test_preformatter_tensor_input(tmp_path: Path) -> None:
+    """DataPreformatter accepts torch.Tensor inputs via _to_numpy."""
+    dp = DataPreformatter(output_dir=str(tmp_path))
+    x_tensor = torch.randn(3, N_GENE)
+    obs = np.array([f"c{i}" for i in range(3)], dtype=object)
+    y = np.array([0, 0, 1], dtype=np.int32)
+
+    dp._write_arrow(
+        {
+            "x_ng": x_tensor,
+            "obs_names_n": obs,
+            "y_n": y,
+            "var_names_g": VAR_NAMES,
+            "y_categories": Y_CATEGORIES,
+        }
+    )
+
+    dadc = DistributedArrowDataCollection(
+        [str(tmp_path / "rank00_shard000000.arrow")],
+        shard_size=3,
+    )
+    batch = dadc[list(range(3))]
+    # float16 round-trip; compare with float32-cast original
+    np.testing.assert_allclose(
+        batch["x_ng"].astype(np.float32),
+        x_tensor.numpy().astype(np.float16).astype(np.float32),
+        atol=1e-3,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DistributedArrowDataCollection: init
+# ---------------------------------------------------------------------------
+
+
+def test_init_empty_cache(dat: DistributedArrowDataCollection) -> None:
+    """Cache starts empty — unlike AnnData, no shard is read on __init__."""
+    assert len(dat.cache) == 0
+
+
+def test_init_properties(dat: DistributedArrowDataCollection) -> None:
+    assert dat.n_obs == N_CELL
+    assert len(dat) == N_CELL
+    assert dat.limits == SHARD_LIMITS
+    # n_vars requires reading the schema footer of shard 0
+    assert dat.n_vars == N_GENE
+
+
+@pytest.mark.parametrize("num_shards", [1, 3, 5])
+@pytest.mark.parametrize("last_shard_size", [1, 2, None])
+def test_init_shard_size(tmp_path: Path, num_shards: int, last_shard_size: int | None) -> None:
+    """limits are computed correctly from shard_size / last_shard_size."""
+    shard_size = 3
+    rng = np.random.default_rng(99)
+    out_dir = tmp_path / f"shards_{num_shards}_{last_shard_size}"
+    dp = DataPreformatter(output_dir=str(out_dir))
+    filenames = []
+    for i in range(num_shards):
+        n = last_shard_size if (last_shard_size is not None and i == num_shards - 1) else shard_size
+        x = rng.standard_normal((n, N_GENE)).astype(np.float32)
+        obs = np.array([f"c{j}" for j in range(n)], dtype=object)
+        y = np.zeros(n, dtype=np.int32)
+        dp._write_arrow({"x_ng": x, "obs_names_n": obs, "y_n": y, "var_names_g": VAR_NAMES})
+        filenames.append(str(out_dir / f"rank00_shard{i:06d}.arrow"))
+
+    dadc = DistributedArrowDataCollection(
+        filenames,
+        shard_size=shard_size,
+        last_shard_size=last_shard_size,
+    )
+
+    expected = num_shards * shard_size
+    if last_shard_size is not None:
+        expected = expected - shard_size + last_shard_size
+    assert len(dadc) == expected
+
+
+# ---------------------------------------------------------------------------
+# DistributedArrowDataCollection: schema metadata
+# ---------------------------------------------------------------------------
+
+
+def test_schema_metadata(dat: DistributedArrowDataCollection) -> None:
+    meta = dat.get_schema_metadata()
+
+    assert meta["n_obs"] == N_CELL
+    assert meta["n_vars"] == N_GENE
+    np.testing.assert_array_equal(meta["var_names_g"], VAR_NAMES)
+    np.testing.assert_array_equal(meta["y_categories"], Y_CATEGORIES)
+
+
+# ---------------------------------------------------------------------------
+# DistributedArrowDataCollection: indexing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "row_select",
+    [(slice(0, 2), 1), (slice(1, 4), 2), ([1, 2, 4, 4], 2), ([6, 1, 3], 3)],
+    ids=["one shard", "two shards", "sorted two shards", "unsorted three shards"],
+)
+def test_indexing(
+    dat: DistributedArrowDataCollection,
+    source_arrays: dict,
+    row_select: tuple,
+) -> None:
+    oidx, n_shards = row_select
+    max_cache_size = dat.max_cache_size
+    cache_size_strictly_enforced = dat.cache_size_strictly_enforced
+
+    if cache_size_strictly_enforced and n_shards > max_cache_size:
+        with pytest.raises(ValueError, match="Expected the number of Arrow shards"):
+            dat[oidx]
+        return
+
+    result = dat[oidx]
+
+    # Determine integer indices for comparison against source_arrays
+    if isinstance(oidx, slice):
+        idx_list = list(range(*oidx.indices(N_CELL)))
+    else:
+        idx_list = list(oidx)
+
+    # x_ng: float16 round-trip tolerance
+    np.testing.assert_allclose(
+        result["x_ng"].astype(np.float32),
+        source_arrays["x"][idx_list].astype(np.float16).astype(np.float32),
+        atol=1e-3,
+    )
+    # obs_names_n: exact
+    np.testing.assert_array_equal(result["obs_names_n"], source_arrays["obs_names"][idx_list])
+    # y_n: exact integer codes
+    np.testing.assert_array_equal(result["y_n"], source_arrays["y"][idx_list])
+    # total_mrna_umis_n: derived from float16 x, so compare to recomputed value
+    np.testing.assert_allclose(
+        result["total_mrna_umis_n"],
+        source_arrays["x"][idx_list].astype(np.float16).sum(axis=1).astype(np.float32),
+        atol=1e-2,
+    )
+    # Metadata fields present in every response
+    np.testing.assert_array_equal(result["var_names_g"], VAR_NAMES)
+    np.testing.assert_array_equal(result["y_categories"], Y_CATEGORIES)
+
+
+def test_indexing_single_int(dat: DistributedArrowDataCollection, source_arrays: dict) -> None:
+    """Single integer index is converted to a list-of-one internally."""
+    result = dat[0]
+    assert result["x_ng"].shape == (1, N_GENE)
+    np.testing.assert_array_equal(result["obs_names_n"], source_arrays["obs_names"][[0]])
+
+
+# ---------------------------------------------------------------------------
+# DistributedArrowDataCollection: pickle (worker handoff)
+# ---------------------------------------------------------------------------
+
+
+def test_pickle_empty_cache_after_unpickle(dat: DistributedArrowDataCollection) -> None:
+    """__setstate__ rebuilds an empty LRU — no file I/O on worker init."""
+    new_dat: DistributedArrowDataCollection = pickle.loads(pickle.dumps(dat))
+    # Key difference from AnnData: cache is EMPTY after unpickling
+    assert len(new_dat.cache) == 0
+
+
+def test_pickle_reads_correctly_after_unpickle(dat: DistributedArrowDataCollection, source_arrays: dict) -> None:
+    new_dat: DistributedArrowDataCollection = pickle.loads(pickle.dumps(dat))
+
+    result = new_dat[list(range(2))]
+    np.testing.assert_allclose(
+        result["x_ng"].astype(np.float32),
+        source_arrays["x"][:2].astype(np.float16).astype(np.float32),
+        atol=1e-3,
+    )
+    np.testing.assert_array_equal(result["obs_names_n"], source_arrays["obs_names"][:2])
+
+
+# ---------------------------------------------------------------------------
+# IterableDistributedAnnDataCollectionDataset with batch_keys=None (Arrow mode)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "row_select",
+    [(slice(0, 2), 1), (slice(1, 4), 2), ([1, 2, 4, 4], 2), ([6, 1, 3], 3)],
+    ids=["one shard", "two shards", "sorted two shards", "unsorted three shards"],
+)
+def test_indexing_dataset(
+    dat: DistributedArrowDataCollection,
+    source_arrays: dict,
+    row_select: tuple,
+) -> None:
+    """Dataset with batch_keys=None passes __getitem__ through to dadc directly."""
+    oidx, n_shards = row_select
+    max_cache_size = dat.max_cache_size
+    cache_size_strictly_enforced = dat.cache_size_strictly_enforced
+
+    dataset = IterableDistributedAnnDataCollectionDataset(dat, batch_keys=None)
+
+    if cache_size_strictly_enforced and n_shards > max_cache_size:
+        with pytest.raises(ValueError, match="Expected the number of Arrow shards"):
+            dataset[oidx]
+        return
+
+    result = dataset[oidx]
+
+    if isinstance(oidx, slice):
+        idx_list = list(range(*oidx.indices(N_CELL)))
+    else:
+        idx_list = list(oidx)
+
+    x_ng = result["x_ng"]
+    obs_names_n = result["obs_names_n"]
+    assert isinstance(x_ng, np.ndarray)
+    assert isinstance(obs_names_n, np.ndarray)
+    assert x_ng.shape == (len(idx_list), N_GENE)
+    np.testing.assert_allclose(
+        x_ng.astype(np.float32),
+        source_arrays["x"][idx_list].astype(np.float16).astype(np.float32),
+        atol=1e-3,
+    )
+    np.testing.assert_array_equal(obs_names_n, source_arrays["obs_names"][idx_list])
+
+
+def test_pickle_dataset(dat: DistributedArrowDataCollection, source_arrays: dict) -> None:
+    dataset = IterableDistributedAnnDataCollectionDataset(dat, batch_keys=None)
+    new_dataset: IterableDistributedAnnDataCollectionDataset = pickle.loads(pickle.dumps(dataset))
+
+    # Cache inside the dadc should still be empty after unpickling
+    assert len(new_dataset.dadc.cache) == 0  # type: ignore[union-attr]
+
+    result = new_dataset[list(range(2))]
+    x_ng = result["x_ng"]
+    obs_names_n = result["obs_names_n"]
+    assert isinstance(x_ng, np.ndarray)
+    assert isinstance(obs_names_n, np.ndarray)
+    np.testing.assert_allclose(
+        x_ng.astype(np.float32),
+        source_arrays["x"][:2].astype(np.float16).astype(np.float32),
+        atol=1e-3,
+    )
+    np.testing.assert_array_equal(obs_names_n, source_arrays["obs_names"][:2])

--- a/tests/dataloader/test_distributed_arrow.py
+++ b/tests/dataloader/test_distributed_arrow.py
@@ -126,7 +126,7 @@ def test_preformatter_field_classification(tmp_path: Path) -> None:
     # --- Per-row columns ---
     assert "x_ng" in batch.schema.names
     assert pa.types.is_fixed_size_binary(batch.schema.field("x_ng").type)
-    assert batch.schema.field("x_ng").type.byte_width == N_GENE * 2
+    assert batch.schema.field("x_ng").type.byte_width == N_GENE * 4  # float32 default
 
     assert "obs_names_n" in batch.schema.names
     assert pa.types.is_large_string(batch.schema.field("obs_names_n").type)
@@ -145,6 +145,7 @@ def test_preformatter_field_classification(tmp_path: Path) -> None:
 
     # Check metadata contents
     assert meta[b"cellarium_arrow_version"] == b"1"
+    assert meta[b"matrix_dtype"] == b"float32"
     assert int(meta[b"n_genes"]) == N_GENE
     assert meta[b"var_names_g"].decode().split("\n") == list(VAR_NAMES)
     assert json.loads(meta[b"y_categories"].decode()) == list(Y_CATEGORIES)
@@ -186,11 +187,11 @@ def test_preformatter_tensor_input(tmp_path: Path) -> None:
         shard_size=3,
     )
     batch = dadc[list(range(3))]
-    # float16 round-trip; compare with float32-cast original
+    # float32 round-trip: exact to float32 precision
     np.testing.assert_allclose(
-        batch["x_ng"].astype(np.float32),
-        x_tensor.numpy().astype(np.float16).astype(np.float32),
-        atol=1e-3,
+        batch["x_ng"],
+        x_tensor.numpy().astype(np.float32),
+        atol=1e-6,
     )
 
 
@@ -234,9 +235,9 @@ def test_preformatter_compression(tmp_path: Path, compression: str | None) -> No
     assert isinstance(x_ng, np.ndarray)
     assert isinstance(obs_names_n, np.ndarray)
     np.testing.assert_allclose(
-        x_ng.astype(np.float32),
-        x.astype(np.float16).astype(np.float32),
-        atol=1e-3,
+        x_ng,
+        x.astype(np.float32),
+        atol=1e-6,
     )
     np.testing.assert_array_equal(obs_names_n, obs)
 
@@ -273,10 +274,86 @@ def test_preformatter_async_writes(tmp_path: Path) -> None:
     dadc = DistributedArrowDataCollection([str(tmp_path / "rank00_shard000000.arrow")], shard_size=n_cells)
     result = dadc[list(range(n_cells))]
     np.testing.assert_allclose(
+        result["x_ng"],
+        batches[0]["x_ng"].astype(np.float32),
+        atol=1e-6,
+    )
+
+
+def test_preformatter_matrix_dtype_float16(tmp_path: Path) -> None:
+    """Explicit matrix_dtype='float16' stores float16 and round-trips with float16 tolerance."""
+    import pyarrow as pa
+
+    dp = PredictionWriterArrow(output_dir=str(tmp_path), matrix_dtype="float16")
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((3, N_GENE)).astype(np.float32)
+    obs = np.array(["a", "b", "c"], dtype=object)
+    y = np.array([0, 1, 2], dtype=np.int32)
+    dp._write_arrow({"x_ng": x, "obs_names_n": obs, "y_n": y, "var_names_g": VAR_NAMES})
+
+    # Schema metadata should record float16
+    arrow_file = str(tmp_path / "rank00_shard000000.arrow")
+    with pa.memory_map(arrow_file, "r") as src:
+        schema_meta = pa.ipc.open_file(src).schema.metadata
+    assert schema_meta[b"matrix_dtype"] == b"float16"
+    assert schema_meta.get(b"matrix_dtype") != b"float32"
+    # byte_width should be N_GENE * 2 for float16
+    with pa.memory_map(arrow_file, "r") as src:
+        batch = pa.ipc.open_file(src).get_batch(0)
+    assert batch.schema.field("x_ng").type.byte_width == N_GENE * 2
+
+    dadc = DistributedArrowDataCollection([arrow_file], shard_size=3)
+    result = dadc[list(range(3))]
+    assert result["x_ng"].dtype == np.float16
+    np.testing.assert_allclose(
         result["x_ng"].astype(np.float32),
-        batches[0]["x_ng"].astype(np.float16).astype(np.float32),
+        x.astype(np.float16).astype(np.float32),
         atol=1e-3,
     )
+
+
+def test_preformatter_float16_overflow(tmp_path: Path) -> None:
+    """Overflow values are clamped to ±65504, counts are tracked, and flush() warns."""
+    import warnings
+
+    dp = PredictionWriterArrow(output_dir=str(tmp_path), matrix_dtype="float16")
+    n_cells = 4
+    x = np.zeros((n_cells, N_GENE), dtype=np.float32)
+    # Gene index 1: all cells overflow (positive)
+    x[:, 1] = 70000.0
+    # Gene index 3: one cell overflows (negative)
+    x[0, 3] = -70000.0
+
+    obs = np.array([f"c{i}" for i in range(n_cells)], dtype=object)
+    y = np.zeros(n_cells, dtype=np.int32)
+
+    dp._write_arrow({"x_ng": x, "obs_names_n": obs, "y_n": y, "var_names_g": VAR_NAMES})
+
+    # Overflow counts are populated before flush clears them
+    assert "x_ng" in dp._overflow_counts
+    assert dp._overflow_counts["x_ng"][1] == n_cells  # all 4 cells at gene 1
+    assert dp._overflow_counts["x_ng"][3] == 1  # 1 cell at gene 3
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        dp.flush()
+
+    overflow_warnings = [warning for warning in w if issubclass(warning.category, RuntimeWarning)]
+    assert len(overflow_warnings) == 1
+    msg = str(overflow_warnings[0].message)
+    assert "overflow" in msg.lower()
+    assert "x_ng" in msg
+
+    # After flush, counts are reset
+    assert len(dp._overflow_counts) == 0
+
+    # Read back: all values must be finite and clamped
+    f16_max = np.finfo(np.float16).max
+    dadc = DistributedArrowDataCollection([str(tmp_path / "rank00_shard000000.arrow")], shard_size=n_cells)
+    result = dadc[list(range(n_cells))]
+    assert np.all(np.isfinite(result["x_ng"])), "No infinities should remain after clamping"
+    assert np.all(result["x_ng"][:, 1] == np.float16(f16_max)), "Positive overflow clamped to +max"
+    assert result["x_ng"][0, 3] == np.float16(-f16_max), "Negative overflow clamped to -max"
 
 
 # ---------------------------------------------------------------------------
@@ -372,21 +449,21 @@ def test_indexing(
     else:
         idx_list = list(oidx)
 
-    # x_ng: float16 round-trip tolerance
+    # x_ng: float32 round-trip is exact
     np.testing.assert_allclose(
-        result["x_ng"].astype(np.float32),
-        source_arrays["x"][idx_list].astype(np.float16).astype(np.float32),
-        atol=1e-3,
+        result["x_ng"],
+        source_arrays["x"][idx_list].astype(np.float32),
+        atol=1e-6,
     )
     # obs_names_n: exact
     np.testing.assert_array_equal(result["obs_names_n"], source_arrays["obs_names"][idx_list])
     # y_n: exact integer codes
     np.testing.assert_array_equal(result["y_n"], source_arrays["y"][idx_list])
-    # total_mrna_umis_n: derived from float16 x, so compare to recomputed value
+    # total_mrna_umis_n: stored as float32 from float32 source, exact
     np.testing.assert_allclose(
         result["total_mrna_umis_n"],
-        source_arrays["x"][idx_list].astype(np.float16).sum(axis=1).astype(np.float32),
-        atol=1e-2,
+        source_arrays["x"][idx_list].sum(axis=1).astype(np.float32),
+        atol=1e-5,
     )
     # Metadata fields present in every response
     np.testing.assert_array_equal(result["var_names_g"], VAR_NAMES)
@@ -417,9 +494,9 @@ def test_pickle_reads_correctly_after_unpickle(dat: DistributedArrowDataCollecti
 
     result = new_dat[list(range(2))]
     np.testing.assert_allclose(
-        result["x_ng"].astype(np.float32),
-        source_arrays["x"][:2].astype(np.float16).astype(np.float32),
-        atol=1e-3,
+        result["x_ng"],
+        source_arrays["x"][:2].astype(np.float32),
+        atol=1e-6,
     )
     np.testing.assert_array_equal(result["obs_names_n"], source_arrays["obs_names"][:2])
 
@@ -465,8 +542,8 @@ def test_indexing_dataset(
     assert x_ng.shape == (len(idx_list), N_GENE)
     np.testing.assert_allclose(
         x_ng.astype(np.float32),
-        source_arrays["x"][idx_list].astype(np.float16).astype(np.float32),
-        atol=1e-3,
+        source_arrays["x"][idx_list].astype(np.float32),
+        atol=1e-6,
     )
     np.testing.assert_array_equal(obs_names_n, source_arrays["obs_names"][idx_list])
 
@@ -485,7 +562,7 @@ def test_pickle_dataset(dat: DistributedArrowDataCollection, source_arrays: dict
     assert isinstance(obs_names_n, np.ndarray)
     np.testing.assert_allclose(
         x_ng.astype(np.float32),
-        source_arrays["x"][:2].astype(np.float16).astype(np.float32),
-        atol=1e-3,
+        source_arrays["x"][:2].astype(np.float32),
+        atol=1e-6,
     )
     np.testing.assert_array_equal(obs_names_n, source_arrays["obs_names"][:2])

--- a/tests/dataloader/test_parity_anndata_arrow.py
+++ b/tests/dataloader/test_parity_anndata_arrow.py
@@ -1,0 +1,302 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Parity test: verify that an AnnData dataloader and an Arrow dataloader built from the
+same source data (with the same NormalizeTotal → Log1p transforms applied) yield
+identical cells across a full epoch for every batch_size / num_workers combination.
+"""
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse
+import torch
+from anndata import AnnData
+from torch.utils.data import DataLoader
+
+from cellarium.ml.data import (
+    DistributedAnnDataCollection,
+    DistributedArrowDataCollection,
+    IterableDistributedAnnDataCollectionDataset,
+)
+from cellarium.ml.models.data_preformatter import DataPreformatter
+from cellarium.ml.transforms import Log1p, NormalizeTotal
+from cellarium.ml.utilities.data import (
+    AnnDataField,
+    categories_to_codes,
+    collate_fn,
+    get_categories,
+)
+
+# Required for multi-worker DataLoaders on macOS / Linux with limited open-file descriptors.
+torch.multiprocessing.set_sharing_strategy("file_system")
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+N_CELL = 10
+N_GENE = 5
+LIMITS = [2, 5, 10]
+CELL_TYPE_CATS = np.array(["B", "NK", "T"])
+
+# ---------------------------------------------------------------------------
+# Module-level helper — must be picklable for num_workers > 0
+# ---------------------------------------------------------------------------
+
+
+def _to_float32(x: np.ndarray | scipy.sparse.spmatrix) -> np.ndarray:
+    """Convert sparse or dense X to float32 numpy array."""
+    if isinstance(x, scipy.sparse.spmatrix):
+        return x.toarray().astype(np.float32)
+    return np.asarray(x, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def h5ads_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Write 3 h5ad shards (limits=[2, 5, 10]) to a temp directory."""
+    tmp_path = tmp_path_factory.mktemp("h5ads")
+
+    rng = np.random.default_rng(2024)
+    # Use positive integers so NormalizeTotal is well-defined (eps guards against zeros)
+    X = rng.integers(1, 50, size=(N_CELL, N_GENE)).astype(np.int32)
+    rng_ct = rng.integers(0, len(CELL_TYPE_CATS), N_CELL)
+    obs = pd.DataFrame(
+        {
+            "cell_type": pd.Categorical(
+                CELL_TYPE_CATS[rng_ct],
+                categories=list(CELL_TYPE_CATS),
+            ),
+        },
+        index=[f"ref_cell{i:03d}" for i in range(N_CELL)],
+    )
+    var = pd.DataFrame(index=[f"gene{i:03d}" for i in range(N_GENE)])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        adata = AnnData(X=X, obs=obs, var=var)
+        for i, (start, end) in enumerate(zip([0] + LIMITS, LIMITS)):
+            sliced = adata[start:end].copy()
+            # Preserve global category list in every shard
+            sliced.obs["cell_type"] = sliced.obs["cell_type"].cat.set_categories(list(CELL_TYPE_CATS))
+            sliced.write(str(tmp_path / f"adata.{i:03d}.h5ad"))
+
+    return tmp_path
+
+
+@pytest.fixture(scope="module")
+def dadc_anndata(h5ads_dir: Path) -> DistributedAnnDataCollection:
+    """DistributedAnnDataCollection over the 3 test shards."""
+    filenames = str(h5ads_dir / "adata.{000..002}.h5ad")
+    return DistributedAnnDataCollection(
+        filenames,
+        limits=LIMITS,
+        max_cache_size=3,
+        cache_size_strictly_enforced=False,
+    )
+
+
+@pytest.fixture(scope="module")
+def dadc_arrow(
+    dadc_anndata: DistributedAnnDataCollection,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> DistributedArrowDataCollection:
+    """
+    Write a single Arrow shard from the pre-transformed AnnData cells, then return
+    a DistributedArrowDataCollection pointing at that shard.
+
+    The NormalizeTotal → Log1p transform pipeline is applied here (same as in the
+    test), so the Arrow shard stores the final transformed float values.
+    """
+    arrow_dir = tmp_path_factory.mktemp("arrows")
+
+    # Load all cells from the AnnData collection
+    adata_all = dadc_anndata[list(range(N_CELL))]
+
+    # Build float32 expression matrix and apply transforms
+    x_tensor = torch.tensor(_to_float32(adata_all.X))
+    normalize = NormalizeTotal(target_count=10_000)
+    log1p = Log1p()
+    x_tensor = normalize(x_ng=x_tensor)["x_ng"]
+    x_tensor = log1p(x_ng=x_tensor)["x_ng"]
+    x_ng = x_tensor.numpy()  # shape (N_CELL, N_GENE), float32
+
+    # Extract obs fields
+    obs_names = np.asarray(adata_all.obs_names)
+    cell_type_codes = categories_to_codes(adata_all.obs["cell_type"])  # int32
+    cell_type_cats = get_categories(adata_all.obs["cell_type"])  # string array
+    var_names = np.asarray(adata_all.var_names)
+
+    # Write Arrow shard — classification rules:
+    #   var_names_g        → schema metadata (ends with _g, not _ng)
+    #   cell_type_categories → schema metadata (ends with _categories)
+    #   x_ng               → per-row FixedSizeBinary float16
+    #   obs_names_n        → per-row large_utf8
+    #   cell_type_n        → per-row int32
+    dp = DataPreformatter(output_dir=str(arrow_dir))
+    dp._write_arrow(
+        {
+            "x_ng": x_ng,
+            "obs_names_n": obs_names,
+            "cell_type_n": cell_type_codes,
+            "var_names_g": var_names,
+            "cell_type_categories": cell_type_cats,
+        }
+    )
+
+    arrow_file = str(arrow_dir / "rank00_shard000000.arrow")
+    return DistributedArrowDataCollection(
+        [arrow_file],
+        shard_size=N_CELL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 5, 10])
+@pytest.mark.parametrize("num_workers", [0, 2])
+def test_no_shuffle_parity(
+    dadc_anndata: DistributedAnnDataCollection,
+    dadc_arrow: DistributedArrowDataCollection,
+    batch_size: int,
+    num_workers: int,
+) -> None:
+    """
+    AnnData and Arrow dataloaders must yield the same cells (same data values,
+    same obs_names, same category codes) across a full epoch.
+
+    Comparison is done after sorting by obs_names to be robust to any difference
+    in batch-delivery ordering across workers.
+    """
+    normalize = NormalizeTotal(target_count=10_000)
+    log1p = Log1p()
+
+    # --- AnnData dataset ---
+    adata_ds = IterableDistributedAnnDataCollectionDataset(
+        dadc_anndata,
+        batch_keys={
+            "x_ng": AnnDataField(attr="X", convert_fn=_to_float32),
+            "obs_names_n": AnnDataField(attr="obs_names"),
+            "var_names_g": AnnDataField(attr="var_names"),
+            "cell_type_n": AnnDataField(attr="obs", key="cell_type", convert_fn=categories_to_codes),
+            "cell_type_categories": AnnDataField(attr="obs", key="cell_type", convert_fn=get_categories),
+        },
+        batch_size=batch_size,
+        shuffle=False,
+        iteration_strategy="same_order",
+    )
+
+    # --- Arrow dataset ---
+    arrow_ds = IterableDistributedAnnDataCollectionDataset(
+        dadc_arrow,
+        batch_keys=None,
+        batch_size=batch_size,
+        shuffle=False,
+        iteration_strategy="same_order",
+    )
+
+    adata_loader = DataLoader(adata_ds, num_workers=num_workers, collate_fn=collate_fn)
+    arrow_loader = DataLoader(arrow_ds, num_workers=num_workers, collate_fn=collate_fn)
+
+    # --- Collect all batches ---
+    adata_x_parts: list[np.ndarray] = []
+    adata_obs_parts: list[np.ndarray] = []
+    adata_ct_parts: list[np.ndarray] = []
+    adata_var_names: np.ndarray | None = None
+    adata_ct_cats: np.ndarray | None = None
+
+    for batch in adata_loader:
+        # Apply NormalizeTotal → Log1p (both transforms take/return x_ng as torch.Tensor)
+        x_ng = normalize(x_ng=batch["x_ng"])["x_ng"]
+        x_ng = log1p(x_ng=x_ng)["x_ng"]
+        adata_x_parts.append(x_ng.numpy())
+        adata_obs_parts.append(np.asarray(batch["obs_names_n"]))
+        adata_ct_parts.append(batch["cell_type_n"].numpy())
+        if adata_var_names is None:
+            adata_var_names = np.asarray(batch["var_names_g"])
+            adata_ct_cats = np.asarray(batch["cell_type_categories"])
+
+    arrow_x_parts: list[np.ndarray] = []
+    arrow_obs_parts: list[np.ndarray] = []
+    arrow_ct_parts: list[np.ndarray] = []
+    arrow_var_names: np.ndarray | None = None
+    arrow_ct_cats: np.ndarray | None = None
+
+    for batch in arrow_loader:
+        # x_ng comes back as float16 tensor; cast to float32 for comparison
+        arrow_x_parts.append(batch["x_ng"].float().numpy())
+        arrow_obs_parts.append(np.asarray(batch["obs_names_n"]))
+        arrow_ct_parts.append(batch["cell_type_n"].numpy())
+        if arrow_var_names is None:
+            arrow_var_names = np.asarray(batch["var_names_g"])
+            arrow_ct_cats = np.asarray(batch["cell_type_categories"])
+
+    # --- Concatenate and sort by obs_names for robust ordering comparison ---
+    adata_x = np.concatenate(adata_x_parts, axis=0)
+    adata_obs = np.concatenate(adata_obs_parts, axis=0)
+    adata_ct = np.concatenate(adata_ct_parts, axis=0)
+
+    arrow_x = np.concatenate(arrow_x_parts, axis=0)
+    arrow_obs = np.concatenate(arrow_obs_parts, axis=0)
+    arrow_ct = np.concatenate(arrow_ct_parts, axis=0)
+
+    adata_sort = np.argsort(adata_obs)
+    arrow_sort = np.argsort(arrow_obs)
+
+    # --- Assertions ---
+
+    # Both loaders must cover all N_CELL cells exactly once
+    assert len(adata_obs) == N_CELL, f"AnnData: expected {N_CELL} cells, got {len(adata_obs)}"
+    assert len(arrow_obs) == N_CELL, f"Arrow:   expected {N_CELL} cells, got {len(arrow_obs)}"
+
+    # Same cell ordering after sort
+    np.testing.assert_array_equal(
+        adata_obs[adata_sort],
+        arrow_obs[arrow_sort],
+        err_msg="obs_names_n mismatch between AnnData and Arrow loaders",
+    )
+
+    # Expression values agree within float16 round-trip tolerance.
+    # After NormalizeTotal(1e4) + Log1p, values are in [0, log(10001)] ≈ [0, 9.2].
+    # Float16 absolute error at that magnitude ≈ 9.2 × 2⁻¹⁰ ≈ 0.009, so atol=1e-2.
+    np.testing.assert_allclose(
+        adata_x[adata_sort],
+        arrow_x[arrow_sort],
+        atol=1e-2,
+        err_msg="x_ng mismatch between AnnData and Arrow loaders",
+    )
+
+    # Category codes must match exactly
+    np.testing.assert_array_equal(
+        adata_ct[adata_sort],
+        arrow_ct[arrow_sort],
+        err_msg="cell_type_n codes mismatch between AnnData and Arrow loaders",
+    )
+
+    # Constant fields must match exactly
+    assert adata_var_names is not None
+    assert arrow_var_names is not None
+    assert adata_ct_cats is not None
+    assert arrow_ct_cats is not None
+    np.testing.assert_array_equal(
+        adata_var_names,
+        arrow_var_names,
+        err_msg="var_names_g mismatch",
+    )
+    np.testing.assert_array_equal(
+        adata_ct_cats,
+        arrow_ct_cats,
+        err_msg="cell_type_categories mismatch",
+    )

--- a/tests/dataloader/test_parity_anndata_arrow.py
+++ b/tests/dataloader/test_parity_anndata_arrow.py
@@ -18,12 +18,12 @@ import torch
 from anndata import AnnData
 from torch.utils.data import DataLoader
 
+from cellarium.ml.callbacks.prediction_writer_arrow import PredictionWriterArrow
 from cellarium.ml.data import (
     DistributedAnnDataCollection,
     DistributedArrowDataCollection,
     IterableDistributedAnnDataCollectionDataset,
 )
-from cellarium.ml.models.data_preformatter import DataPreformatter
 from cellarium.ml.transforms import Log1p, NormalizeTotal
 from cellarium.ml.utilities.data import (
     AnnDataField,
@@ -142,7 +142,7 @@ def dadc_arrow(
     #   x_ng               → per-row FixedSizeBinary float16
     #   obs_names_n        → per-row large_utf8
     #   cell_type_n        → per-row int32
-    dp = DataPreformatter(output_dir=str(arrow_dir))
+    dp = PredictionWriterArrow(output_dir=str(arrow_dir))
     dp._write_arrow(
         {
             "x_ng": x_ng,

--- a/tests/dataloader/test_parity_anndata_arrow.py
+++ b/tests/dataloader/test_parity_anndata_arrow.py
@@ -268,13 +268,12 @@ def test_no_shuffle_parity(
         err_msg="obs_names_n mismatch between AnnData and Arrow loaders",
     )
 
-    # Expression values agree within float16 round-trip tolerance.
-    # After NormalizeTotal(1e4) + Log1p, values are in [0, log(10001)] ≈ [0, 9.2].
-    # Float16 absolute error at that magnitude ≈ 9.2 × 2⁻¹⁰ ≈ 0.009, so atol=1e-2.
+    # Expression values agree within float32 precision.
+    # After NormalizeTotal(1e4) + Log1p, values are stored as float32 in both paths.
     np.testing.assert_allclose(
         adata_x[adata_sort],
         arrow_x[arrow_sort],
-        atol=1e-2,
+        atol=1e-5,
         err_msg="x_ng mismatch between AnnData and Arrow loaders",
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,3 +958,220 @@ def test_data_preformatter(tmp_path: Path) -> None:
     batch = dadc[list(range(min(5, dadc.n_obs)))]
     assert "x_ng" in batch, "x_ng column missing from Arrow batch"
     assert "obs_names_n" in batch, "obs_names_n column missing from Arrow batch"
+
+
+def test_arrow_onepass_end_to_end(tmp_path: Path) -> None:
+    """Full Arrow round-trip: h5ad → Arrow → OnePassMeanVarStd.
+
+    Stages:
+    1. Convert h5ad to Arrow shards via ``data_preformatter predict``, writing
+       ``batch_index_n`` (sourced from ``total_mrna_umis``) to exercise the
+       scatter-add OOB regression.
+    2. Run ``onepass_mean_var_std fit`` on Arrow shards *with*
+       ``include_fields=["x_ng", "obs_names_n"]`` — excludes ``batch_index_n``
+       so ``n_batch=1`` works correctly.
+    3. Same run *without* ``include_fields`` — ``batch_index_n`` flows into the
+       model with values >> 1 and must trigger ``RuntimeError("out of bounds")``.
+    4. Run ``onepass_mean_var_std fit`` directly on h5ad as a reference baseline.
+    5. Compare per-gene means from Stage 2 and Stage 4 to float32 precision.
+    """
+    import pandas as pd
+
+    from cellarium.ml.data import DistributedArrowDataCollection
+
+    GCS_H5AD = "https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_0.h5ad"
+    arrow_output = tmp_path / "arrow_output"
+    stats_arrow = tmp_path / "stats_arrow.csv"
+    stats_arrow_no_filter = tmp_path / "stats_arrow_no_filter.csv"
+    stats_h5ad = tmp_path / "stats_h5ad.csv"
+
+    # ------------------------------------------------------------------
+    # Stage 1 — h5ad → Arrow (with batch_index_n to reproduce the bug)
+    # ------------------------------------------------------------------
+    dp_config = f"""
+    model:
+      transforms:
+        - class_path: cellarium.ml.transforms.NormalizeTotal
+          init_args:
+            target_count: 10_000
+        - cellarium.ml.transforms.Log1p
+      model:
+        class_path: cellarium.ml.models.DataPreformatter
+    data:
+      dadc:
+        class_path: cellarium.ml.data.DistributedAnnDataCollection
+        init_args:
+          filenames: {GCS_H5AD}
+          shard_size: 100
+          max_cache_size: 2
+          obs_columns_to_validate: [total_mrna_umis]
+      batch_keys:
+        x_ng:
+          attr: X
+          convert_fn: cellarium.ml.utilities.data.densify
+        var_names_g:
+          attr: var_names
+        obs_names_n:
+          attr: obs_names
+        batch_index_n:
+          attr: obs
+          key: total_mrna_umis
+      batch_size: 5
+      num_workers: 0
+    trainer:
+      accelerator: cpu
+      devices: 1
+      limit_predict_batches: 2
+      callbacks:
+        - class_path: cellarium.ml.callbacks.PredictionWriterArrow
+          init_args:
+            output_dir: {arrow_output}
+            compression: lz4
+    return_predictions: false
+    """
+    with open(dp_cfg := str(tmp_path / "dp_config.yaml"), "w") as f:
+        f.write(dp_config)
+    main(["data_preformatter", "predict", "--config", dp_cfg])
+
+    arrow_files = sorted(arrow_output.glob("*.arrow"))
+    assert len(arrow_files) >= 1, "No Arrow shards were written"
+
+    # Verify batch_index_n is present in the Arrow shards (confirms bug scenario)
+    dadc_check = DistributedArrowDataCollection([str(f) for f in arrow_files], shard_size=5)
+    sample = dadc_check[list(range(min(5, dadc_check.n_obs)))]
+    assert "batch_index_n" in sample, "batch_index_n must be in Arrow shards for regression test"
+    assert "x_ng" in sample
+
+    n_vars = dadc_check.n_vars
+    # Filenames as a brace-expand-compatible list for the YAML configs below
+    arrow_filenames = [str(f) for f in arrow_files]
+    arrow_shard_size = 5  # matches limit_predict_batches=2 × batch_size=5
+
+    # ------------------------------------------------------------------
+    # Stage 2 — Arrow → onepass WITH include_fields (the fix)
+    # ------------------------------------------------------------------
+    op_arrow_config = f"""
+    model:
+      model:
+        class_path: cellarium.ml.models.OnePassMeanVarStd
+        init_args:
+          n_batch: 1
+          output_path: {stats_arrow}
+    data:
+      dadc:
+        class_path: cellarium.ml.data.DistributedArrowDataCollection
+        init_args:
+          filenames: {arrow_filenames}
+          shard_size: {arrow_shard_size}
+          include_fields:
+            - x_ng
+            - obs_names_n
+      batch_keys: null
+      batch_size: 5
+      num_workers: 0
+    trainer:
+      accelerator: cpu
+      devices: 1
+      max_epochs: 1
+    """
+    with open(op_arrow_cfg := str(tmp_path / "op_arrow_config.yaml"), "w") as f:
+        f.write(op_arrow_config)
+    main(["onepass_mean_var_std", "fit", "--config", op_arrow_cfg])
+
+    assert stats_arrow.exists(), "Arrow-based onepass CSV was not written"
+    df_arrow = pd.read_csv(stats_arrow)
+    assert len(df_arrow) == n_vars, "Row count in CSV must match n_vars"
+    assert not df_arrow["mean_g"].isna().any(), "mean_g must not contain NaN"
+
+    # ------------------------------------------------------------------
+    # Stage 3 — Arrow → onepass WITHOUT include_fields (regression: must fail)
+    #
+    # batch_index_n values are UMI counts (e.g. 2 000–3 500), which are far
+    # outside [0, n_batch=1) and trigger scatter_add_ index OOB.
+    # ------------------------------------------------------------------
+    op_arrow_no_filter_config = f"""
+    model:
+      model:
+        class_path: cellarium.ml.models.OnePassMeanVarStd
+        init_args:
+          n_batch: 1
+          output_path: {stats_arrow_no_filter}
+    data:
+      dadc:
+        class_path: cellarium.ml.data.DistributedArrowDataCollection
+        init_args:
+          filenames: {arrow_filenames}
+          shard_size: {arrow_shard_size}
+      batch_keys: null
+      batch_size: 5
+      num_workers: 0
+    trainer:
+      accelerator: cpu
+      devices: 1
+      max_epochs: 1
+    """
+    with open(op_arrow_no_filter_cfg := str(tmp_path / "op_arrow_no_filter_config.yaml"), "w") as f:
+        f.write(op_arrow_no_filter_config)
+    with pytest.raises(ValueError, match="batch_index_n values were supplied"):
+        main(["onepass_mean_var_std", "fit", "--config", op_arrow_no_filter_cfg])
+
+    # ------------------------------------------------------------------
+    # Stage 4 — h5ad → onepass directly (reference baseline)
+    # ------------------------------------------------------------------
+    op_h5ad_config = f"""
+    model:
+      transforms:
+        - class_path: cellarium.ml.transforms.NormalizeTotal
+          init_args:
+            target_count: 10_000
+        - cellarium.ml.transforms.Log1p
+      model:
+        class_path: cellarium.ml.models.OnePassMeanVarStd
+        init_args:
+          n_batch: 1
+          output_path: {stats_h5ad}
+    data:
+      dadc:
+        class_path: cellarium.ml.data.DistributedAnnDataCollection
+        init_args:
+          filenames: {GCS_H5AD}
+          shard_size: 100
+          max_cache_size: 2
+          obs_columns_to_validate: [total_mrna_umis]
+      batch_keys:
+        x_ng:
+          attr: X
+          convert_fn: cellarium.ml.utilities.data.densify
+        var_names_g:
+          attr: var_names
+      batch_size: 5
+      num_workers: 0
+    trainer:
+      accelerator: cpu
+      devices: 1
+      max_epochs: 1
+      limit_train_batches: 2
+    """
+    with open(op_h5ad_cfg := str(tmp_path / "op_h5ad_config.yaml"), "w") as f:
+        f.write(op_h5ad_config)
+    main(["onepass_mean_var_std", "fit", "--config", op_h5ad_cfg])
+
+    assert stats_h5ad.exists(), "h5ad-based onepass CSV was not written"
+
+    # ------------------------------------------------------------------
+    # Stage 5 — Numeric comparison: Arrow-based vs h5ad-based means
+    # ------------------------------------------------------------------
+    df_h5ad = pd.read_csv(stats_h5ad)
+
+    # Align on gene names (order may differ if iteration orders differ)
+    df_arrow_sorted = df_arrow.set_index("var_names_g").sort_index()
+    df_h5ad_sorted = df_h5ad.set_index("var_names_g").sort_index()
+
+    import numpy as np
+
+    np.testing.assert_allclose(
+        df_arrow_sorted["mean_g"].values,
+        df_h5ad_sorted["mean_g"].values,
+        atol=1e-5,
+        err_msg="Per-gene means from Arrow-based and h5ad-based onepass must match to float32 precision",
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -889,3 +889,70 @@ def test_return_predictions_userwarning(tmp_path: Path):
             print(warning_message)
             n += 1
     assert n < 2, "Unexpected UserWarning when running predict with return_predictions=false"
+
+
+def test_data_preformatter(tmp_path: Path) -> None:
+    """Run data_preformatter predict via YAML config and verify Arrow shards are written."""
+    from cellarium.ml.data import DistributedArrowDataCollection
+
+    arrow_output = tmp_path / "arrow_output"
+
+    dp_config = f"""
+    model:
+      transforms:
+        - class_path: cellarium.ml.transforms.NormalizeTotal
+          init_args:
+            target_count: 10_000
+        - cellarium.ml.transforms.Log1p
+      model:
+        class_path: cellarium.ml.models.DataPreformatter
+        init_args:
+          output_dir: {arrow_output}
+    data:
+      dadc:
+        class_path: cellarium.ml.data.DistributedAnnDataCollection
+        init_args:
+          filenames: https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_0.h5ad
+          shard_size: 100
+          max_cache_size: 2
+          obs_columns_to_validate: [total_mrna_umis]
+      batch_keys:
+        x_ng:
+          attr: X
+          convert_fn: cellarium.ml.utilities.data.densify
+        var_names_g:
+          attr: var_names
+        obs_names_n:
+          attr: obs_names
+        total_mrna_umis_n:
+          attr: obs
+          key: total_mrna_umis
+      batch_size: 5
+      num_workers: 1
+    trainer:
+      accelerator: cpu
+      devices: 1
+      limit_predict_batches: 2
+    return_predictions: false
+    """
+    with open(dp_config_path := str(tmp_path / "dp_config.yaml"), "w") as f:
+        f.write(dp_config)
+    main(["data_preformatter", "predict", "--config", dp_config_path])
+
+    # Arrow output directory must exist and contain at least one shard
+    assert arrow_output.exists(), "Arrow output directory was not created"
+    arrow_files = sorted(arrow_output.glob("*.arrow"))
+    assert len(arrow_files) >= 1, "No Arrow shard files were written"
+
+    # Load the first shard and verify schema metadata and column presence
+    dadc = DistributedArrowDataCollection(
+        [str(f) for f in arrow_files],
+        shard_size=5,
+    )
+    meta = dadc.get_schema_metadata()
+    assert "var_names_g" in meta, "var_names_g missing from Arrow schema metadata"
+    assert meta["n_vars"] >= 1, "n_vars should be at least 1"
+
+    batch = dadc[list(range(min(5, dadc.n_obs)))]
+    assert "x_ng" in batch, "x_ng column missing from Arrow batch"
+    assert "obs_names_n" in batch, "obs_names_n column missing from Arrow batch"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -906,8 +906,6 @@ def test_data_preformatter(tmp_path: Path) -> None:
         - cellarium.ml.transforms.Log1p
       model:
         class_path: cellarium.ml.models.DataPreformatter
-        init_args:
-          output_dir: {arrow_output}
     data:
       dadc:
         class_path: cellarium.ml.data.DistributedAnnDataCollection
@@ -933,6 +931,10 @@ def test_data_preformatter(tmp_path: Path) -> None:
       accelerator: cpu
       devices: 1
       limit_predict_batches: 2
+      callbacks:
+        - class_path: cellarium.ml.callbacks.PredictionWriterArrow
+          init_args:
+            output_dir: {arrow_output}
     return_predictions: false
     """
     with open(dp_config_path := str(tmp_path / "dp_config.yaml"), "w") as f:


### PR DESCRIPTION
Adds two things:

- dataloader that handles special pyarrow data format built for speed
    - benchmarking makes it seem like 71ms per shard compared to full h5ad at 1222ms or filtered h5ad at 882ms
- a dummy kind of model that is used specifically to take one pass through the data and write this special fast pyarrow file format

Still a bit experimental.  Tests are written but it hasn't been run for real in the wild.