### PR TITLE
Dataloading: enable keeping data sparse until gpu

### DIFF
--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -321,7 +321,34 @@ def compute_var_names_g(
             t_copy.to_empty(device="cpu")
         all_transforms.append(t_copy)
     pipeline = CellariumPipeline(all_transforms)
-    output = pipeline(collate_fn([batch]))
+    try:
+        output = pipeline(collate_fn([batch]))
+    except (RuntimeError, ValueError) as e:
+        error_msg = str(e)
+        if "stride" in error_msg or "sparse" in error_msg.lower():
+            raise ValueError(
+                f"compute_var_names_g pipeline failed: {error_msg}\n\n"
+                "This typically occurs when using the sparse data path (keep_sparse or to_torch_sparse_csr) "
+                "and Filter is incorrectly placed in model.transforms (GPU transforms) instead of "
+                "model.cpu_transforms (CPU transforms). When using sparse data, Filter MUST be in "
+                "model.cpu_transforms to filter and convert to torch.sparse_csr_tensor before GPU transfer. "
+                "\n\nCorrect configuration:\n"
+                "  model:\n"
+                "    cpu_transforms:\n"
+                "      - class_path: cellarium.ml.transforms.Filter\n"
+                "        init_args:\n"
+                "          filter_list: [...]\n"
+                "    transforms:\n"
+                "      - cellarium.ml.transforms.Densify\n"
+                "      - cellarium.ml.transforms.NormalizeTotal\n"
+                "      - ...\n"
+                "  data:\n"
+                "    batch_keys:\n"
+                "      x_ng:\n"
+                "        attr: X\n"
+                "        convert_fn: cellarium.ml.utilities.data.keep_sparse"
+            ) from e
+        raise
     return output["var_names_g"]
 
 
@@ -350,6 +377,130 @@ def compute_batch_index_n_categories(data: CellariumAnnDataDataModule) -> int:
         return int(x.apply(lambda col: len(col.cat.categories)).product())
     else:
         return len(x.cat.categories)
+
+
+def _get_transform_name(transform_spec: Any) -> str | None:
+    """
+    Extract a canonical transform class name from a transform specification.
+    Handles both string paths, short names, class_path dicts, and instantiated modules.
+    Returns None if unable to extract.
+    """
+    if isinstance(transform_spec, str):
+        # Already a string path like "cellarium.ml.transforms.Filter" or short name like "Filter"
+        return transform_spec.split(".")[-1] if "." in transform_spec else transform_spec
+    elif isinstance(transform_spec, dict):
+        # YAML class_path format: {"class_path": "cellarium.ml.transforms.Filter", "init_args": {...}}
+        if "class_path" in transform_spec:
+            class_path = transform_spec["class_path"]
+            return class_path.split(".")[-1]
+    elif isinstance(transform_spec, torch.nn.Module):
+        # Instantiated module
+        return transform_spec.__class__.__name__
+    return None
+
+
+def _validate_sparse_config(config: dict[Any, Any] | Namespace) -> list[str]:
+    """
+    Validate sparse data path configuration and return list of warning messages.
+    Checks for common misconfigurations like Filter in wrong transform list.
+    """
+    warnings_list: list[str] = []
+
+    try:
+        # Convert Namespace to dict if needed
+        if isinstance(config, Namespace):
+            config = vars(config)
+
+        # Try to access model and data config; skip if not present (e.g., during --help)
+        if "model" not in config or "data" not in config:
+            return warnings_list
+
+        model_config = config.get("model", {})
+        data_config = config.get("data", {})
+
+        # Extract batch_keys and x_ng convert_fn
+        batch_keys = data_config.get("batch_keys", {})
+        x_ng_config = batch_keys.get("x_ng", {})
+        convert_fn = x_ng_config.get("convert_fn", "")
+        if isinstance(convert_fn, str):
+            convert_fn_name = convert_fn.split(".")[-1]
+        else:
+            convert_fn_name = ""
+
+        # Only validate if using sparse convert_fn
+        if convert_fn_name not in ("keep_sparse", "to_torch_sparse_csr"):
+            return warnings_list
+
+        # Extract cpu_transforms and transforms
+        cpu_transforms = model_config.get("cpu_transforms", [])
+        if cpu_transforms is None:
+            cpu_transforms = []
+        transforms = model_config.get("transforms", [])
+        if transforms is None:
+            transforms = []
+
+        # Extract transform names from both lists
+        cpu_transform_names = [_get_transform_name(t) for t in cpu_transforms]
+        cpu_transform_names = [n for n in cpu_transform_names if n]  # filter None
+        transform_names = [_get_transform_name(t) for t in transforms]
+        transform_names = [n for n in transform_names if n]  # filter None
+
+        # Warning A: keep_sparse with Filter in model.transforms but not in cpu_transforms
+        if convert_fn_name == "keep_sparse":
+            if "Filter" in transform_names and "Filter" not in cpu_transform_names:
+                warnings_list.append(
+                    "Configuration Issue: Using `keep_sparse` with Filter in `model.transforms` (GPU transforms) "
+                    "instead of `model.cpu_transforms` (CPU transforms). \n"
+                    "When using `keep_sparse`, Filter MUST be in `model.cpu_transforms` to filter and convert to "
+                    "torch.sparse_csr_tensor BEFORE GPU transfer. Placing Filter in GPU transforms defeats the "
+                    "purpose of sparse transfer.\n\n"
+                    "Correct configuration:\n"
+                    "  model:\n"
+                    "    cpu_transforms:\n"
+                    "      - class_path: cellarium.ml.transforms.Filter\n"
+                    "        init_args:\n"
+                    "          filter_list: [...]\n"
+                    "    transforms:\n"
+                    "      - cellarium.ml.transforms.Densify\n"
+                    "      - ...\n"
+                )
+
+            # Warning B: keep_sparse without any Filter in cpu_transforms
+            if "Filter" not in cpu_transform_names:
+                warnings_list.append(
+                    "Configuration Issue: Using `keep_sparse` but Filter not found in `model.cpu_transforms`.\n"
+                    "Without Filter, sparse data may bypass automatic GPU device transfer, potentially causing "
+                    "device mismatches (CPU/GPU errors).\n\n"
+                    "Either:\n"
+                    "  (1) Add Filter to `model.cpu_transforms` to filter and convert before GPU transfer, OR\n"
+                    "  (2) Switch to `convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr` with "
+                    "`Densify` as the first entry in `model.transforms`.\n"
+                )
+
+        # Warning C: Sparse path without Densify as first GPU transform
+        if convert_fn_name in ("keep_sparse", "to_torch_sparse_csr"):
+            if "Densify" not in transform_names:
+                warnings_list.append(
+                    f"Configuration Issue: Using sparse data path ({convert_fn_name}) but `Densify` not found in "
+                    f"`model.transforms`.\n"
+                    f"`Densify` should be the first entry in `model.transforms` when using sparse data to convert "
+                    f"torch.sparse_csr_tensor to dense on GPU.\n\n"
+                    f"Add to model.transforms (as first item):\n"
+                    f"  - cellarium.ml.transforms.Densify\n"
+                )
+            elif transform_names and transform_names[0] != "Densify":
+                densify_idx = transform_names.index("Densify") if "Densify" in transform_names else -1
+                warnings_list.append(
+                    f"Configuration Issue: `Densify` found at position {densify_idx} in `model.transforms` but should "
+                    f"be first (position 0). Dense-only transforms must run AFTER densification.\n"
+                    f"Move `Densify` to the first entry in `model.transforms`.\n"
+                )
+
+    except Exception:
+        # Silently skip validation if config structure is unexpected
+        pass
+
+    return warnings_list
 
 
 def lightning_cli_factory(
@@ -419,6 +570,10 @@ def lightning_cli_factory(
                         "model:  ...\ndata:  ...\ntrainer:  ...\nreturn_predictions: false",
                         UserWarning,
                     )
+            # Validate sparse data path configuration
+            sparse_config_warnings = _validate_sparse_config(self.config)
+            for warning_msg in sparse_config_warnings:
+                warnings.warn(warning_msg, UserWarning)
             return super().before_instantiate_classes()
 
         def instantiate_classes(self) -> None:

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -22,7 +22,6 @@ from jsonargparse import Namespace, class_from_function
 from jsonargparse._loaders_dumpers import DefaultLoader
 from jsonargparse._util import import_object
 from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCLI
-from torch._subclasses.fake_tensor import FakeCopyMode, FakeTensorMode
 from torch.utils._pytree import tree_map
 
 from cellarium.ml import CellariumAnnDataDataModule, CellariumModule, CellariumPipeline
@@ -309,12 +308,20 @@ def compute_var_names_g(
     """
     adata = data.dadc[0]
     batch = tree_map(lambda field: field(adata), data.batch_keys)
-    pipeline = CellariumPipeline(cpu_transforms) + CellariumPipeline(transforms)
-    with FakeTensorMode(allow_non_fake_inputs=True) as fake_mode:
-        fake_batch = collate_fn([batch])
-        with FakeCopyMode(fake_mode):
-            fake_pipeline = copy.deepcopy(pipeline)
-        output = fake_pipeline(fake_batch)
+    # Transforms may have been instantiated under torch.device("meta") by Lightning CLI
+    # (see CellariumModule.configure_model).  Deep-copy each transform and materialise
+    # any meta-device parameters to uninitialised CPU tensors so the pipeline can run
+    # with real tensor inputs without calling reset_parameters.
+    all_transforms: list[torch.nn.Module] = []
+    for t in list(cpu_transforms or []) + list(transforms or []):
+        t_copy = copy.deepcopy(t)
+        if any(p.device.type == "meta" for p in t_copy.parameters()) or any(
+            b.device.type == "meta" for b in t_copy.buffers()
+        ):
+            t_copy.to_empty(device="cpu")
+        all_transforms.append(t_copy)
+    pipeline = CellariumPipeline(all_transforms)
+    output = pipeline(collate_fn([batch]))
     return output["var_names_g"]
 
 

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cache
 from operator import attrgetter
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -306,6 +306,10 @@ def compute_var_names_g(
     Returns:
         The variable names.
     """
+    import scipy.sparse
+
+    from cellarium.ml.transforms.densify import Densify
+
     adata = data.dadc[0]
     batch = tree_map(lambda field: field(adata), data.batch_keys)
     # Transforms may have been instantiated under torch.device("meta") by Lightning CLI
@@ -320,18 +324,54 @@ def compute_var_names_g(
         ):
             t_copy.to_empty(device="cpu")
         all_transforms.append(t_copy)
+
+    # Pre-flight sparse configuration checks: inspect x_ng before running the
+    # pipeline to give actionable errors instead of confusing mid-pipeline failures.
+    # These checks also fire when compute_var_names_g is called directly from Python
+    # (without going through the CLI config validator in before_instantiate_classes).
+    collated = collate_fn([batch])
+    x_ng = collated.get("x_ng")
+    if x_ng is not None:
+        if scipy.sparse.issparse(x_ng):
+            # scipy sparse x_ng is valid only if Filter is in the transform pipeline
+            # (Filter converts scipy sparse → torch.sparse_csr_tensor).
+            # If there's no Filter, keep_sparse was used without a required cpu_transform.
+            has_filter = any(type(t).__name__ == "Filter" for t in all_transforms)
+            if not has_filter:
+                raise ValueError(
+                    "Configuration Error: x_ng is a scipy sparse matrix in compute_var_names_g. "
+                    "The `keep_sparse` convert_fn requires a Filter in `model.cpu_transforms` to convert "
+                    "scipy sparse to torch.sparse_csr_tensor before this point.\n\n"
+                    "Either:\n"
+                    "  (1) Add Filter to `model.cpu_transforms` with your gene filter_list, OR\n"
+                    "  (2) Switch to `convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr` and add "
+                    "`Densify` as the first entry in `model.transforms`.\n"
+                )
+        if isinstance(x_ng, torch.Tensor) and x_ng.is_sparse_csr:
+            has_densify = any(isinstance(t, Densify) for t in all_transforms)
+            if not has_densify:
+                raise ValueError(
+                    "Configuration Error: x_ng is a torch.sparse_csr_tensor but no `Densify` transform "
+                    "was found in the combined cpu_transforms + transforms list.\n"
+                    "`Densify` must be the first entry in `model.transforms` to convert "
+                    "torch.sparse_csr_tensor to dense before any dense-only transforms run.\n\n"
+                    "Add to model.transforms (as first item):\n"
+                    "  - cellarium.ml.transforms.Densify\n"
+                )
+
     pipeline = CellariumPipeline(all_transforms)
     try:
-        output = pipeline(collate_fn([batch]))
-    except (RuntimeError, ValueError) as e:
+        output = pipeline(collated)
+    except (RuntimeError, ValueError, TypeError) as e:
         error_msg = str(e)
-        if "stride" in error_msg or "sparse" in error_msg.lower():
+        if "stride" in error_msg or "sparse" in error_msg.lower() or "csr_matrix" in error_msg:
             raise ValueError(
                 f"compute_var_names_g pipeline failed: {error_msg}\n\n"
                 "This typically occurs when using the sparse data path (keep_sparse or to_torch_sparse_csr) "
                 "and Filter is incorrectly placed in model.transforms (GPU transforms) instead of "
                 "model.cpu_transforms (CPU transforms). When using sparse data, Filter MUST be in "
                 "model.cpu_transforms to filter and convert to torch.sparse_csr_tensor before GPU transfer. "
+                "Can also occur if Densify is not included as the first transform.\n"
                 "\n\nCorrect configuration:\n"
                 "  model:\n"
                 "    cpu_transforms:\n"
@@ -401,7 +441,8 @@ def _get_transform_name(transform_spec: Any) -> str | None:
 
 def _validate_sparse_config(config: dict[Any, Any] | Namespace) -> list[str]:
     """
-    Validate sparse data path configuration and return list of warning messages.
+    Validate sparse data path configuration.
+    Raises ValueError for fatal misconfigurations, returns list of advisory warnings.
     Checks for common misconfigurations like Filter in wrong transform list.
     """
     warnings_list: list[str] = []
@@ -445,7 +486,30 @@ def _validate_sparse_config(config: dict[Any, Any] | Namespace) -> list[str]:
         transform_names = [_get_transform_name(t) for t in transforms]
         transform_names = [n for n in transform_names if n]  # filter None
 
-        # Warning A: keep_sparse with Filter in model.transforms but not in cpu_transforms
+        # error: keep_sparse without Filter in cpu_transforms
+        if convert_fn_name == "keep_sparse" and "Filter" not in cpu_transform_names:
+            raise ValueError(
+                "Configuration Error: Using `keep_sparse` but Filter not found in `model.cpu_transforms`.\n"
+                "The `keep_sparse` convert_fn requires a Filter cpu_transform to filter sparse data and convert to "
+                "torch.sparse_csr_tensor BEFORE GPU transfer.\n\n"
+                "Either:\n"
+                "  (1) Add Filter to `model.cpu_transforms` with your gene filter_list, OR\n"
+                "  (2) Switch to `convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr` and ensure "
+                "`Densify` is the first entry in `model.transforms`.\n"
+            )
+
+        # error: Sparse path without Densify
+        if convert_fn_name in ("keep_sparse", "to_torch_sparse_csr") and "Densify" not in transform_names:
+            raise ValueError(
+                f"Configuration Error: Using sparse data path ({convert_fn_name}) but `Densify` not found in "
+                f"`model.transforms`.\n"
+                f"`Densify` must be the first entry in `model.transforms` to convert torch.sparse_csr_tensor to dense "
+                f"on GPU before any dense-only transforms run.\n\n"
+                f"Add to model.transforms (as first item):\n"
+                f"  - cellarium.ml.transforms.Densify\n"
+            )
+
+        # warning: keep_sparse with Filter in wrong transform list
         if convert_fn_name == "keep_sparse":
             if "Filter" in transform_names and "Filter" not in cpu_transform_names:
                 warnings_list.append(
@@ -465,37 +529,19 @@ def _validate_sparse_config(config: dict[Any, Any] | Namespace) -> list[str]:
                     "      - ...\n"
                 )
 
-            # Warning B: keep_sparse without any Filter in cpu_transforms
-            if "Filter" not in cpu_transform_names:
-                warnings_list.append(
-                    "Configuration Issue: Using `keep_sparse` but Filter not found in `model.cpu_transforms`.\n"
-                    "Without Filter, sparse data may bypass automatic GPU device transfer, potentially causing "
-                    "device mismatches (CPU/GPU errors).\n\n"
-                    "Either:\n"
-                    "  (1) Add Filter to `model.cpu_transforms` to filter and convert before GPU transfer, OR\n"
-                    "  (2) Switch to `convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr` with "
-                    "`Densify` as the first entry in `model.transforms`.\n"
-                )
-
-        # Warning C: Sparse path without Densify as first GPU transform
+        # warning: Densify not first in transforms
         if convert_fn_name in ("keep_sparse", "to_torch_sparse_csr"):
-            if "Densify" not in transform_names:
-                warnings_list.append(
-                    f"Configuration Issue: Using sparse data path ({convert_fn_name}) but `Densify` not found in "
-                    f"`model.transforms`.\n"
-                    f"`Densify` should be the first entry in `model.transforms` when using sparse data to convert "
-                    f"torch.sparse_csr_tensor to dense on GPU.\n\n"
-                    f"Add to model.transforms (as first item):\n"
-                    f"  - cellarium.ml.transforms.Densify\n"
-                )
-            elif transform_names and transform_names[0] != "Densify":
-                densify_idx = transform_names.index("Densify") if "Densify" in transform_names else -1
+            if transform_names and transform_names[0] != "Densify" and "Densify" in transform_names:
+                densify_idx = transform_names.index("Densify")
                 warnings_list.append(
                     f"Configuration Issue: `Densify` found at position {densify_idx} in `model.transforms` but should "
                     f"be first (position 0). Dense-only transforms must run AFTER densification.\n"
                     f"Move `Densify` to the first entry in `model.transforms`.\n"
                 )
 
+    except ValueError:
+        # Re-raise ValueError (fatal configuration errors)
+        raise
     except Exception:
         # Silently skip validation if config structure is unexpected
         pass
@@ -570,8 +616,9 @@ def lightning_cli_factory(
                         "model:  ...\ndata:  ...\ntrainer:  ...\nreturn_predictions: false",
                         UserWarning,
                     )
-            # Validate sparse data path configuration
-            sparse_config_warnings = _validate_sparse_config(self.config)
+            # Validate sparse data path configuration (pass subcommand-scoped config)
+            subcommand_config = self.config.get(cast(str, self.subcommand), {})
+            sparse_config_warnings = _validate_sparse_config(subcommand_config)
             for warning_msg in sparse_config_warnings:
                 warnings.warn(warning_msg, UserWarning)
             return super().before_instantiate_classes()

--- a/cellarium/ml/transforms/__init__.py
+++ b/cellarium/ml/transforms/__init__.py
@@ -3,6 +3,7 @@
 
 from cellarium.ml.transforms.binomial_resample import BinomialResample
 from cellarium.ml.transforms.cellarium_gpt_tokenizer import CellariumGPTPredictTokenizer, CellariumGPTTrainTokenizer
+from cellarium.ml.transforms.densify import Densify
 from cellarium.ml.transforms.divide_by_scale import DivideByScale
 from cellarium.ml.transforms.dropout import Dropout
 from cellarium.ml.transforms.duplicate import Duplicate
@@ -16,6 +17,7 @@ __all__ = [
     "BinomialResample",
     "CellariumGPTTrainTokenizer",
     "CellariumGPTPredictTokenizer",
+    "Densify",
     "DivideByScale",
     "Dropout",
     "Duplicate",

--- a/cellarium/ml/transforms/densify.py
+++ b/cellarium/ml/transforms/densify.py
@@ -33,7 +33,7 @@ class Densify(nn.Module):
         try:
             if scipy.sparse.issparse(x_ng):
                 raise TypeError(
-                    "Densify received a scipy sparse matrix, which should have been converted to " \
+                    "Densify received a scipy sparse matrix, which should have been converted to "
                     "torch.sparse_csr_tensor earlier in the pipeline. \n\n"
                     "The convert_fn used for x_ng (sparse mode, where Densify is used) must be either:\n"
                     "    - keep_sparse: ensure Filter is in model.cpu_transforms to convert scipy sparse to "

--- a/cellarium/ml/transforms/densify.py
+++ b/cellarium/ml/transforms/densify.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import scipy.sparse
 import torch
 from torch import nn
 
@@ -24,7 +25,24 @@ class Densify(nn.Module):
 
         Returns:
             A dictionary with the key ``x_ng`` containing a dense :class:`torch.Tensor`.
+
+        Raises:
+            TypeError: If ``x_ng`` is a scipy sparse matrix (which should have been converted earlier).
         """
+        # check for scipy sparse matrices that should have been converted earlier
+        try:
+            if scipy.sparse.issparse(x_ng):
+                raise TypeError(
+                    "Densify received a scipy sparse matrix, which should have been converted to " \
+                    "torch.sparse_csr_tensor earlier in the pipeline. \n\n"
+                    "The convert_fn used for x_ng (sparse mode, where Densify is used) must be either:\n"
+                    "    - keep_sparse: ensure Filter is in model.cpu_transforms to convert scipy sparse to "
+                    "torch.sparse_csr_tensor before GPU transfer.\n"
+                    "    - to_torch_sparse_csr: can be used with no Filter, since CSR is torch.\n"
+                )
+        except TypeError:
+            raise
+
         if x_ng.is_sparse_csr:
             x_ng = x_ng.to_dense()
         return {"x_ng": x_ng}

--- a/cellarium/ml/transforms/densify.py
+++ b/cellarium/ml/transforms/densify.py
@@ -30,18 +30,17 @@ class Densify(nn.Module):
             TypeError: If ``x_ng`` is a scipy sparse matrix (which should have been converted earlier).
         """
         # check for scipy sparse matrices that should have been converted earlier
-        try:
-            if scipy.sparse.issparse(x_ng):
-                raise TypeError(
-                    "Densify received a scipy sparse matrix, which should have been converted to "
-                    "torch.sparse_csr_tensor earlier in the pipeline. \n\n"
-                    "The convert_fn used for x_ng (sparse mode, where Densify is used) must be either:\n"
-                    "    - keep_sparse: ensure Filter is in model.cpu_transforms to convert scipy sparse to "
-                    "torch.sparse_csr_tensor before GPU transfer.\n"
-                    "    - to_torch_sparse_csr: can be used with no Filter, since CSR is torch.\n"
-                )
-        except TypeError:
-            raise
+        if scipy.sparse.issparse(x_ng):
+            raise TypeError(
+                "Densify received a scipy sparse matrix, but sparse inputs should already "
+                "have been converted to torch.sparse_csr_tensor earlier in the pipeline.\n\n"
+                f"Received type: {type(x_ng).__name__}\n\n"
+                "For sparse x_ng with Densify, use one of the following convert_fn options:\n"
+                "  - keep_sparse: use when Filter is in model.cpu_transforms, so Filter converts "
+                "scipy sparse input to torch.sparse_csr_tensor before GPU transfer.\n"
+                "  - to_torch_sparse_csr: use when there is no Filter, since the output is already "
+                "a torch sparse CSR tensor."
+            )
 
         if x_ng.is_sparse_csr:
             x_ng = x_ng.to_dense()

--- a/cellarium/ml/transforms/densify.py
+++ b/cellarium/ml/transforms/densify.py
@@ -1,0 +1,33 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+from torch import nn
+
+
+class Densify(nn.Module):
+    """
+    Convert a sparse ``x_ng`` to a dense tensor on the current device.
+
+    Use this as the first entry in ``transforms`` (GPU transforms) when ``x_ng`` arrives as a
+    :class:`torch.sparse_csr_tensor` \u2014 for example when no :class:`~cellarium.ml.transforms.Filter`
+    cpu_transform is in the pipeline and the sparse-transfer strategy is still desired (e.g. for
+    statistics models that operate on all genes).
+
+    If ``x_ng`` is already dense this transform is a no-op.
+    """
+
+    def forward(self, x_ng: torch.Tensor, **kwargs: object) -> dict[str, torch.Tensor]:
+        """
+        Args:
+            x_ng: Gene counts.  May be a :class:`torch.sparse_csr_tensor` or a dense tensor.
+
+        Returns:
+            A dictionary with the key ``x_ng`` containing a dense :class:`torch.Tensor`.
+        """
+        if x_ng.is_sparse_csr:
+            x_ng = x_ng.to_dense()
+        return {"x_ng": x_ng}
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"

--- a/cellarium/ml/transforms/filter.py
+++ b/cellarium/ml/transforms/filter.py
@@ -6,9 +6,11 @@ from functools import cache
 from typing import Any
 
 import numpy as np
+import scipy.sparse
 import torch
 from torch import nn
 
+from cellarium.ml.utilities.data import to_torch_sparse_csr
 from cellarium.ml.utilities.testing import (
     assert_columns_and_array_lengths_equal,
 )
@@ -109,16 +111,24 @@ class Filter(nn.Module):
             return src_indices_ordered, np.array(out_indices, dtype=np.intp)
         return src_indices_ordered
 
-    def forward(self, x_ng: torch.Tensor, var_names_g: np.ndarray) -> dict[str, torch.Tensor | np.ndarray]:
+    def forward(
+        self, x_ng: torch.Tensor | scipy.sparse.spmatrix, var_names_g: np.ndarray
+    ) -> dict[str, torch.Tensor | np.ndarray]:
         """
         .. note::
 
             When used with :class:`~cellarium.ml.core.CellariumModule` or :class:`~cellarium.ml.core.CellariumPipeline`,
             ``x_ng`` and ``var_names_g`` keys in the input dictionary will be overwritten with the filtered values.
 
+            When ``x_ng`` is a :class:`scipy.sparse.spmatrix` (e.g. when this transform is used as a
+            ``cpu_transform`` operating on data from
+            :func:`~cellarium.ml.utilities.data.keep_sparse`), column filtering is performed with
+            scipy and the result is returned as a :class:`torch.sparse_csr_tensor`.  The
+            ``allow_missing=True`` path always returns a dense :class:`torch.Tensor`.
+
         Args:
             x_ng:
-                Gene counts.
+                Gene counts.  Either a dense :class:`torch.Tensor` or a scipy sparse matrix.
             var_names_g:
                 The list of the variable names in the input data.
 
@@ -130,6 +140,9 @@ class Filter(nn.Module):
               otherwise ``(n, num_matched)``.
             - ``var_names_g``: Gene names corresponding to the output columns.
         """
+        if scipy.sparse.issparse(x_ng):
+            return self._forward_sparse(x_ng, var_names_g)
+
         assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
 
         result = self.filter(tuple(var_names_g.tolist()))
@@ -152,6 +165,50 @@ class Filter(nn.Module):
             var_names_g = var_names_g[result]
 
         return {"x_ng": x_ng, "var_names_g": var_names_g}
+
+    def _forward_sparse(
+        self,
+        x_ng: scipy.sparse.spmatrix,
+        var_names_g: np.ndarray,
+    ) -> dict[str, torch.Tensor | np.ndarray]:
+        """
+        Sparse-input path for :meth:`forward`.
+
+        Filters columns using scipy (no dense allocation for the full gene set), then converts
+        the result to a :class:`torch.sparse_csr_tensor` so that dataloader workers can place
+        it in shared memory for zero-copy transfer to the main process.
+
+        The ``allow_missing=True`` path densifies after filtering because zero-fill semantics
+        require allocating the full output width.
+        """
+        if x_ng.shape[1] != len(var_names_g):
+            raise ValueError(
+                f"The number of `x_ng` columns must match the `var_names_g` length. "
+                f"Got {x_ng.shape[1]} != {len(var_names_g)}"
+            )
+
+        result = self.filter(tuple(var_names_g.tolist()))
+
+        if self.allow_missing:
+            src_indices, out_indices = result
+            assert isinstance(src_indices, np.ndarray) and isinstance(out_indices, np.ndarray)
+            # Column selection with scipy avoids densifying the full gene set.
+            x_filtered = np.asarray(x_ng[:, src_indices].todense(), dtype=np.float32)
+            x_out = torch.zeros(x_ng.shape[0], len(self.filter_list), dtype=torch.float32)
+            x_out[:, out_indices] = torch.from_numpy(x_filtered)
+            return {"x_ng": x_out, "var_names_g": self.filter_list.copy()}
+        elif self.ordering:
+            assert isinstance(result, np.ndarray)
+            return {
+                "x_ng": to_torch_sparse_csr(x_ng[:, result]),
+                "var_names_g": self.filter_list.copy(),
+            }
+        else:
+            assert isinstance(result, np.ndarray)
+            return {
+                "x_ng": to_torch_sparse_csr(x_ng[:, result]),
+                "var_names_g": var_names_g[result],
+            }
 
     def __repr__(self) -> str:
         return (

--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from operator import attrgetter
 from typing import Any, cast
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -184,14 +185,22 @@ def to_torch_sparse_csr(x: scipy.sparse.spmatrix) -> torch.Tensor:
         A :class:`torch.sparse_csr_tensor` on CPU.
     """
     csr = x.tocsr().astype(np.float32, copy=False)
-    return torch.sparse_csr_tensor(
-        torch.from_numpy(csr.indptr.astype(np.int32, copy=False)),
-        torch.from_numpy(csr.indices.astype(np.int32, copy=False)),
-        torch.from_numpy(csr.data),
-        size=csr.shape,
-        dtype=torch.float32,
-        device="cpu",
-    )
+    # Suppress two PyTorch warnings that fire on every sparse tensor creation:
+    #   - "Sparse CSR tensor support is in beta state" (from SparseCsrTensorImpl.cpp)
+    #   - "Sparse invariant checks are implicitly disabled" (Mac-specific, Context.cpp)
+    with (
+        warnings.catch_warnings(),
+        torch.sparse.check_sparse_tensor_invariants(False),
+    ):
+        warnings.filterwarnings("ignore", message="Sparse CSR tensor support is in beta state")
+        return torch.sparse_csr_tensor(
+            torch.from_numpy(csr.indptr.astype(np.int32, copy=False)),
+            torch.from_numpy(csr.indices.astype(np.int32, copy=False)),
+            torch.from_numpy(csr.data),
+            size=csr.shape,
+            dtype=torch.float32,
+            device="cpu",
+        )
 
 
 def categories_to_codes(x: pd.Series | pd.DataFrame) -> np.ndarray:

--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -71,6 +71,8 @@ class AnnDataField:
 
 
 def convert_to_tensor(value: np.ndarray) -> np.ndarray | torch.Tensor:
+    if isinstance(value, torch.Tensor) or scipy.sparse.issparse(value):
+        return value
     if np.issubdtype(value.dtype, np.str_) or np.issubdtype(value.dtype, np.object_):
         return value
     return torch.tensor(value, device="cpu")
@@ -111,6 +113,16 @@ def collate_fn(
             if len(batch) > 1 and not all(subkeys == data[key].keys() for data in batch[1:]):  # type: ignore[union-attr]
                 raise ValueError(f"All '{key}' sub-dictionaries in the batch must have the same subkeys.")
             value = {subkey: np.concatenate([data[key][subkey] for data in batch], axis=0) for subkey in subkeys}
+        elif scipy.sparse.issparse(batch[0][key]):
+            value = scipy.sparse.vstack([data[key] for data in batch]) if len(batch) > 1 else batch[0][key]
+        elif isinstance(batch[0][key], torch.Tensor):
+            # Sparse CSR tensors cannot be passed to np.concatenate. Since IterableDataset
+            # always yields complete batches (len == 1 here), a direct passthrough is safe.
+            # For the rare len > 1 dense case, fall back to torch.cat.
+            if len(batch) == 1:
+                value = batch[0][key]
+            else:
+                value = torch.cat([data[key] for data in batch], dim=0)
         else:
             value = np.concatenate([data[key] for data in batch], axis=0)
 
@@ -130,6 +142,53 @@ def densify(x: scipy.sparse.csr_matrix) -> np.ndarray:
         Dense matrix.
     """
     return x.toarray()
+
+
+def keep_sparse(x: scipy.sparse.spmatrix) -> scipy.sparse.spmatrix:
+    """
+    Identity function for scipy sparse matrices.
+
+    Use as ``convert_fn`` for :class:`~cellarium.ml.utilities.data.AnnDataField` when the
+    sparse matrix should remain sparse inside the dataloader worker. A
+    :class:`~cellarium.ml.transforms.Filter` cpu_transform will then filter the columns and
+    convert to :class:`torch.sparse_csr_tensor` — keeping the transferred data volume small
+    before it reaches the main process and the PCIe bus.
+
+    Args:
+        x: Sparse matrix.
+
+    Returns:
+        The same sparse matrix, unchanged.
+    """
+    return x
+
+
+def to_torch_sparse_csr(x: scipy.sparse.spmatrix) -> torch.Tensor:
+    """
+    Convert a scipy sparse matrix to a :class:`torch.sparse_csr_tensor` (float32, CPU).
+
+    Use as ``convert_fn`` for :class:`~cellarium.ml.utilities.data.AnnDataField` when no
+    :class:`~cellarium.ml.transforms.Filter` cpu_transform is in the pipeline and the full
+    (unfiltered) gene set should still be transferred sparsely.  The resulting
+    :class:`torch.sparse_csr_tensor` is placed in shared memory by dataloader workers
+    for zero-copy transfer to the main process, then moved to GPU and densified by
+    :class:`~cellarium.ml.transforms.Densify`.
+
+    Args:
+        x: Sparse matrix.  Converted to CSR format if not already.
+
+    Returns:
+        A :class:`torch.sparse_csr_tensor` on CPU.
+    """
+    csr = x.tocsr().astype(np.float32, copy=False)
+    return torch.sparse_csr_tensor(
+        torch.from_numpy(csr.indptr.astype(np.int32, copy=False)),
+        torch.from_numpy(csr.indices.astype(np.int32, copy=False)),
+        torch.from_numpy(csr.data),
+        size=csr.shape,
+        dtype=torch.float32,
+        device="cpu",
+    )
 
 
 def categories_to_codes(x: pd.Series | pd.DataFrame) -> np.ndarray:

--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -11,7 +11,7 @@ This module contains helper functions for data loading and processing.
 from collections.abc import Callable
 from dataclasses import dataclass
 from operator import attrgetter
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -70,7 +70,7 @@ class AnnDataField:
         return value
 
 
-def convert_to_tensor(value: np.ndarray) -> np.ndarray | torch.Tensor:
+def convert_to_tensor(value: np.ndarray | scipy.sparse.spmatrix | torch.Tensor) -> np.ndarray | torch.Tensor:
     if isinstance(value, torch.Tensor) or scipy.sparse.issparse(value):
         return value
     if np.issubdtype(value.dtype, np.str_) or np.issubdtype(value.dtype, np.object_):
@@ -122,7 +122,10 @@ def collate_fn(
             if len(batch) == 1:
                 value = batch[0][key]
             else:
-                value = torch.cat([data[key] for data in batch], dim=0)
+                value = torch.cat(  # type: ignore[assignment]
+                    [cast(torch.Tensor, data[key]) for data in batch],
+                    dim=0,
+                )
         else:
             value = np.concatenate([data[key] for data in batch], axis=0)
 

--- a/cellarium/ml/utilities/data.py
+++ b/cellarium/ml/utilities/data.py
@@ -8,11 +8,11 @@ Data utilities
 This module contains helper functions for data loading and processing.
 """
 
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from operator import attrgetter
 from typing import Any, cast
-import warnings
 
 import numpy as np
 import pandas as pd

--- a/examples/cli_workflow/hvg_seurat_v3_train_config.yaml
+++ b/examples/cli_workflow/hvg_seurat_v3_train_config.yaml
@@ -72,7 +72,8 @@ trainer:
   model_registry: null
 model:
   cpu_transforms: null
-  transforms: null
+  transforms:
+    - cellarium.ml.transforms.Densify
   model:
     class_path: cellarium.ml.models.HVGSeuratV3
     init_args:
@@ -106,7 +107,7 @@ data:
   batch_keys:
     x_ng:
       attr: X
-      convert_fn: cellarium.ml.utilities.data.densify
+      convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr
     var_names_g:
       attr: var_names
       convert_fn: null
@@ -123,5 +124,5 @@ data:
   test_mode: false
   num_workers: 2
   prefetch_factor: null
-  persistent_workers: false
+  persistent_workers: true
 ckpt_path: null

--- a/examples/cli_workflow/ipca_train_config.yaml
+++ b/examples/cli_workflow/ipca_train_config.yaml
@@ -58,6 +58,7 @@ trainer:
   default_root_dir: /tmp/test_examples/ipca
 model:
   transforms:
+    - cellarium.ml.transforms.Densify
     - class_path: cellarium.ml.transforms.NormalizeTotal
       init_args:
         target_count: 10_000
@@ -108,7 +109,7 @@ data:
   batch_keys:
     x_ng:
       attr: X
-      convert_fn: cellarium.ml.utilities.data.densify
+      convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr
     var_names_g:
       attr: var_names
     total_mrna_umis_n:

--- a/examples/cli_workflow/lr_resume_train_config.yaml
+++ b/examples/cli_workflow/lr_resume_train_config.yaml
@@ -46,6 +46,7 @@ trainer:
   default_root_dir: /tmp/test_examples/lr
 model:
   transforms:
+    - cellarium.ml.transforms.Densify
     - !CheckpointLoader
       file_path: /tmp/test_examples/ipca/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
       attr: null
@@ -84,7 +85,7 @@ data:
   batch_keys:
     x_ng:
       attr: X
-      convert_fn: cellarium.ml.utilities.data.densify
+      convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr
     var_names_g:
       attr: var_names
     total_mrna_umis_n:
@@ -108,5 +109,5 @@ data:
   test_mode: false
   num_workers: 2
   prefetch_factor: null
-  persistent_workers: false
+  persistent_workers: true
 ckpt_path: /tmp/test_examples/lr/lightning_logs/version_0/checkpoints/epoch=1-step=13.ckpt

--- a/examples/cli_workflow/lr_train_config.yaml
+++ b/examples/cli_workflow/lr_train_config.yaml
@@ -46,6 +46,7 @@ trainer:
   default_root_dir: /tmp/test_examples/lr
 model:
   transforms:
+    - cellarium.ml.transforms.Densify
     - !CheckpointLoader
       file_path: /tmp/test_examples/ipca/lightning_logs/version_0/checkpoints/epoch=0-step=2.ckpt
       attr: null
@@ -84,7 +85,7 @@ data:
   batch_keys:
     x_ng:
       attr: X
-      convert_fn: cellarium.ml.utilities.data.densify
+      convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr
     var_names_g:
       attr: var_names
     total_mrna_umis_n:
@@ -108,5 +109,5 @@ data:
   test_mode: false
   num_workers: 2
   prefetch_factor: null
-  persistent_workers: false
+  persistent_workers: true
 ckpt_path: null

--- a/examples/cli_workflow/onepass_train_config.yaml
+++ b/examples/cli_workflow/onepass_train_config.yaml
@@ -58,6 +58,7 @@ trainer:
   default_root_dir: /tmp/test_examples/onepass
 model:
   transforms:
+    - cellarium.ml.transforms.Densify
     - class_path: cellarium.ml.transforms.NormalizeTotal
       init_args:
         target_count: 10_000
@@ -92,7 +93,7 @@ data:
   batch_keys:
     x_ng:
       attr: X
-      convert_fn: cellarium.ml.utilities.data.densify
+      convert_fn: cellarium.ml.utilities.data.to_torch_sparse_csr
     var_names_g:
       attr: var_names
     total_mrna_umis_n:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,6 +276,114 @@ CONFIGS = [
         },
     },
     {
+        "model_name": "onepass_mean_var_std",
+        "subcommand": "fit",
+        "fit": {
+            "model": {
+                "transforms": [
+                    "cellarium.ml.transforms.Densify",
+                    {
+                        "class_path": "cellarium.ml.transforms.NormalizeTotal",
+                        "init_args": {"target_count": "10_000"},
+                    },
+                    "cellarium.ml.transforms.Log1p",
+                ],
+                "model": "cellarium.ml.models.OnePassMeanVarStd",
+            },
+            "data": {
+                "dadc": {
+                    "class_path": "cellarium.ml.data.DistributedAnnDataCollection",
+                    "init_args": {
+                        "filenames": "https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_0.h5ad",
+                        "shard_size": "100",
+                        "max_cache_size": "2",
+                        "obs_columns_to_validate": ["total_mrna_umis"],
+                    },
+                },
+                "batch_keys": {
+                    "x_ng": {
+                        "attr": "X",
+                        "convert_fn": "cellarium.ml.utilities.data.to_torch_sparse_csr",
+                    },
+                    "var_names_g": {"attr": "var_names"},
+                    "total_mrna_umis_n": {
+                        "attr": "obs",
+                        "key": "total_mrna_umis",
+                    },
+                },
+                "batch_size": "50",
+                "num_workers": "2",
+            },
+            "trainer": {
+                "accelerator": "cpu",
+                "devices": devices,
+            },
+        },
+    },
+    {
+        "model_name": "onepass_mean_var_std",
+        "subcommand": "fit",
+        "fit": {
+            "model": {
+                "cpu_transforms": [
+                    {
+                        "class_path": "cellarium.ml.transforms.Filter",
+                        "init_args": {
+                            "filter_list": [
+                                "ENSG00000187642",
+                                "ENSG00000078808",
+                                "ENSG00000272106",
+                                "ENSG00000162585",
+                                "ENSG00000272088",
+                                "ENSG00000204624",
+                                "ENSG00000162490",
+                                "ENSG00000177000",
+                                "ENSG00000011021",
+                            ]
+                        },
+                    }
+                ],
+                "transforms": [
+                    "cellarium.ml.transforms.Densify",
+                    {
+                        "class_path": "cellarium.ml.transforms.NormalizeTotal",
+                        "init_args": {"target_count": "10_000"},
+                    },
+                    "cellarium.ml.transforms.Log1p",
+                ],
+                "model": "cellarium.ml.models.OnePassMeanVarStd",
+            },
+            "data": {
+                "dadc": {
+                    "class_path": "cellarium.ml.data.DistributedAnnDataCollection",
+                    "init_args": {
+                        "filenames": "https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_0.h5ad",
+                        "shard_size": "100",
+                        "max_cache_size": "2",
+                        "obs_columns_to_validate": ["total_mrna_umis"],
+                    },
+                },
+                "batch_keys": {
+                    "x_ng": {
+                        "attr": "X",
+                        "convert_fn": "cellarium.ml.utilities.data.keep_sparse",
+                    },
+                    "var_names_g": {"attr": "var_names"},
+                    "total_mrna_umis_n": {
+                        "attr": "obs",
+                        "key": "total_mrna_umis",
+                    },
+                },
+                "batch_size": "50",
+                "num_workers": "2",
+            },
+            "trainer": {
+                "accelerator": "cpu",
+                "devices": devices,
+            },
+        },
+    },
+    {
         "model_name": "incremental_pca",
         "subcommand": "fit",
         "fit": {

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -6,7 +6,10 @@ import pytest
 import torch
 
 from cellarium.ml import CellariumPipeline
-from cellarium.ml.transforms import DivideByScale, Filter, Log1p, NormalizeTotal, ZScore
+import scipy.sparse
+
+from cellarium.ml.transforms import Densify, DivideByScale, Filter, Log1p, NormalizeTotal, ZScore
+from cellarium.ml.utilities.data import to_torch_sparse_csr
 
 n, g, target_count = 100, 3, 10_000
 
@@ -197,6 +200,36 @@ def test_zscore_unknown_gene_raises(zscore_full: ZScore):
     x = torch.ones(2, 2)
     with pytest.raises(ValueError, match="gene_unknown"):
         zscore_full(x, bad_names)
+
+
+# ---------------------------------------------------------------------------
+# Densify tests
+# ---------------------------------------------------------------------------
+
+
+def test_densify_dense_passthrough():
+    """Dense tensor passes through unchanged (values and shape preserved)."""
+    x = torch.tensor([[1.0, 2.0, 0.0], [0.0, 3.0, 4.0]])
+    out = Densify()(x)["x_ng"]
+    assert not out.is_sparse
+    torch.testing.assert_close(out, x)
+
+
+def test_densify_sparse_csr_to_dense():
+    """torch.sparse_csr_tensor is converted to a dense tensor with identical values."""
+    dense = torch.tensor([[0.0, 2.0, 0.0], [1.0, 0.0, 3.0]], dtype=torch.float32)
+    x_sparse = to_torch_sparse_csr(scipy.sparse.csr_matrix(dense.numpy()))
+    assert x_sparse.is_sparse_csr
+    out = Densify()(x_sparse)["x_ng"]
+    assert not out.is_sparse
+    torch.testing.assert_close(out, dense)
+
+
+def test_densify_scipy_sparse_raises():
+    """scipy sparse matrices must have been converted before reaching Densify."""
+    x = scipy.sparse.csr_matrix(np.eye(3, dtype=np.float32))
+    with pytest.raises(TypeError, match="scipy sparse matrix"):
+        Densify()(x)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -3,11 +3,10 @@
 
 import numpy as np
 import pytest
+import scipy.sparse
 import torch
 
 from cellarium.ml import CellariumPipeline
-import scipy.sparse
-
 from cellarium.ml.transforms import Densify, DivideByScale, Filter, Log1p, NormalizeTotal, ZScore
 from cellarium.ml.utilities.data import to_torch_sparse_csr
 


### PR DESCRIPTION
The idea here is to try to solve the GPU starvation issue.

I've been seeing that it's not file I/O, it's not decompression, it's not python object overhead.  It seems to be PCIe data volume being transferred from the workers to the GPU.  The system just cannot handle the throughput, even an n1-standard-16, not at all.  The issue is that we're passing around dense matrices from the workers.  If we can densify on GPU, we can potentially alleviate this bottleneck.  (Still remains to be proven that this actually makes an epoch faster. EDIT: conclusively proven, it's faster.)

Two new data flow paths:

Scenario | convert_fn | cpu_transforms | first transforms
-- | -- | -- | --
With gene filtering | keep_sparse | Filter(filter_list) | Densify
All genes (OnePass, HVG, …) | to_torch_sparse_csr | (none) | Densify