### PR TITLE
add the kotliar hvg function

### DIFF
--- a/cellarium/ml/preprocessing/__init__.py
+++ b/cellarium/ml/preprocessing/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from cellarium.ml.preprocessing.highly_variable_genes import get_highly_variable_genes
+from cellarium.ml.preprocessing.highly_variable_genes import seurat_compute_highly_variable_genes
 
-__all__ = ["get_highly_variable_genes"]
+__all__ = ["seurat_compute_highly_variable_genes"]

--- a/cellarium/ml/preprocessing/highly_variable_genes.py
+++ b/cellarium/ml/preprocessing/highly_variable_genes.py
@@ -56,10 +56,10 @@ def _hvg_seurat_single_batch(
     return df
 
 
-def get_highly_variable_genes(
-    gene_names: list,
-    mean: torch.Tensor,
-    var: torch.Tensor,
+def seurat_compute_highly_variable_genes(
+    var_names_g: list,
+    mean_g: torch.Tensor,
+    var_g: torch.Tensor,
     n_top_genes: int | None = None,
     min_disp: float | None = 0.5,
     max_disp: float | None = np.inf,
@@ -82,11 +82,11 @@ def get_highly_variable_genes(
        <https://scanpy.readthedocs.io/en/stable/generated/scanpy.pp.highly_variable_genes.html>`_.
 
     Args:
-        gene_names:
+        var_names_g:
             Ensembl gene ids.
-        mean:
+        mean_g:
             Overall gene expression means in count space (shape ``n_genes``).
-        var:
+        var_g:
             Overall gene expression variances in count space (shape ``n_genes``).
         n_top_genes:
             Number of highly-variable genes to keep.
@@ -108,13 +108,13 @@ def get_highly_variable_genes(
             Batch labels of length ``n_batch``.
 
     Returns:
-        DataFrame indexed by ``gene_names`` with columns ``highly_variable``,
+        DataFrame indexed by ``var_names_g`` with columns ``highly_variable``,
         ``means``, ``dispersions``, ``dispersions_norm``, ``mean_bin``
         (single-batch), ``highly_variable_nbatches`` and
         ``highly_variable_intersection`` (batch mode).
     """
-    n_genes = len(gene_names)
-    if not (n_genes == len(mean) == len(var)):
+    n_genes = len(var_names_g)
+    if not (n_genes == len(mean_g) == len(var_g)):
         raise ValueError("Sizes of `gene_names`, `mean`, and `var` should be the same")
 
     batch_args = (batch_mean_bg, batch_var_bg, batch_ids)
@@ -129,9 +129,9 @@ def get_highly_variable_genes(
                 f"`batch_mean_bg` and `batch_var_bg` must have shape (n_batch={n_batch}, n_genes={n_genes})."
             )
         return _get_highly_variable_genes_batched(
-            gene_names=gene_names,
-            mean=mean,
-            var=var,
+            var_names_g=var_names_g,
+            mean_g=mean_g,
+            var_g=var_g,
             batch_mean_bg=batch_mean_bg,
             batch_var_bg=batch_var_bg,
             batch_ids=batch_ids,
@@ -144,8 +144,8 @@ def get_highly_variable_genes(
         )
 
     # --- Single-batch path ---
-    df = _hvg_seurat_single_batch(mean, var, n_bins)
-    df.index = gene_names
+    df = _hvg_seurat_single_batch(mean_g, var_g, n_bins)
+    df.index = var_names_g
 
     dispersion_norm = df["dispersions_norm"].values
     mean_log1p = df["means"].values
@@ -181,9 +181,9 @@ def get_highly_variable_genes(
 
 
 def _get_highly_variable_genes_batched(
-    gene_names: list,
-    mean: torch.Tensor,
-    var: torch.Tensor,
+    var_names_g: list,
+    mean_g: torch.Tensor,
+    var_g: torch.Tensor,
     batch_mean_bg: torch.Tensor,
     batch_var_bg: torch.Tensor,
     batch_ids: list[str],
@@ -199,7 +199,7 @@ def _get_highly_variable_genes_batched(
     ``scanpy.pp.highly_variable_genes(..., flavor='seurat', batch_key=...)``.
     """
     n_batch = len(batch_ids)
-    n_genes = len(gene_names)
+    n_genes = len(var_names_g)
 
     per_batch_disp_norm = np.zeros((n_batch, n_genes), dtype=np.float64)
     per_batch_hvg = np.zeros((n_batch, n_genes), dtype=bool)
@@ -230,10 +230,10 @@ def _get_highly_variable_genes_batched(
     highly_variable_nbatches = per_batch_hvg.sum(axis=0).astype(int)
     dispersions_norm_mean = per_batch_disp_norm.mean(axis=0)
 
-    df_overall = _hvg_seurat_single_batch(mean, var, n_bins)
-    df_overall.index = gene_names
+    df_overall = _hvg_seurat_single_batch(mean_g, var_g, n_bins)
+    df_overall.index = var_names_g
 
-    df_out = pd.DataFrame(index=gene_names)
+    df_out = pd.DataFrame(index=var_names_g)
     df_out["means"] = df_overall["means"].values
     df_out["dispersions"] = df_overall["dispersions"].values
     df_out["dispersions_norm"] = dispersions_norm_mean
@@ -261,3 +261,117 @@ def _get_highly_variable_genes_batched(
         )
 
     return df_out
+
+
+def kotliar_compute_highly_variable_genes(
+    mean_g: np.array,
+    var_g: np.array,
+    var_names_g: np.array,
+    num_genes: int | None = 2000,
+    expected_fano_threshold: float | None = None,
+    minimal_mean: float = 0.5,
+    plot: bool = False,
+):
+    """
+    Helper function to run the highly variable gene selection procedure from Kotliar et al. 2019,
+    implemented in the function ``get_highvar_genes_sparse`` in the dylkot/cNMF repository.
+    Modified to work in cellarium based on a run of a onepass_mean_var_std model on the data.
+
+    NOTE: taken from
+    https://github.com/dylkot/cNMF/blob/5dbc5baaa0b9079b55bce554d801caa235a50457/src/cnmf/cnmf.py#L136-L188
+
+    Args:
+        mean_g: The mean expression levels of genes
+        var_g: The variance of expression levels of genes
+        var_names_g: The names of the genes
+        num_genes: The number of highly variable genes to select. If None, uses a threshold-based approach
+        expected_fano_threshold: If num_genes is None, this threshold is used to select highly variable genes
+            based on their Fano factor relative to the expected Fano factor. If None, a default threshold is
+            computed based on the standard deviation of the Fano factors of genes that pass a winsorized box filter.
+        minimal_mean: The minimum mean expression level for a gene to be considered highly variable.
+            This is used only in the threshold-based approach (i.e. when num_genes is None)
+        plot: Whether to plot the mean-variance relationship and the Fano factor distribution. Useful for debugging.
+
+    Returns:
+        A DataFrame with columns
+        - mean: The mean expression level of each gene
+        - var: The variance of each gene
+        - fano: The Fano factor of each gene (variance / mean)
+        - fano_fit: The expected Fano factor of each gene based on the fitted line
+        - fano_ratio: The ratio of the observed Fano factor to the expected Fano factor
+        - highly_variable: A boolean indicating whether the gene is selected as highly variable
+    """
+
+    df = pd.DataFrame({"mean_g": mean_g, "var_g": var_g, "fano_g": var_g / mean_g}, index=var_names_g)
+
+    # Find parameters for expected fano line
+    top_genes = df["mean_g"].sort_values(ascending=False)[:20].index
+    A = (np.sqrt(df["var_g"]) / df["mean_g"])[top_genes].min()
+    
+    w_mean_low, w_mean_high = df["mean_g"].quantile([0.10, 0.90])
+    w_fano_low, w_fano_high = df["fano_g"].quantile([0.10, 0.90])
+    winsor_box_logic = (
+        (df["fano_g"] > w_fano_low)
+        & (df["fano_g"] < w_fano_high)
+        & (df["mean_g"] > w_mean_low)
+        & (df["mean_g"] < w_mean_high)
+    )
+    fano_median = df["fano_g"][winsor_box_logic].median()
+    B = np.sqrt(fano_median)
+    
+    df["fano_fit_g"] = (A**2) * df["mean_g"] + (B**2)
+    df["fano_ratio_g"] = df["fano_g"] / df["fano_fit_g"]
+
+    # Identify high var genes
+    if num_genes is not None:
+        hvg_var_names = df["fano_ratio_g"].sort_values(ascending=False).index[:num_genes]
+        hvg_logic_g = df.index.isin(hvg_var_names)
+        T = None
+    else:
+        if not expected_fano_threshold:
+            T = (1. + df["fano_g"][winsor_box_logic].std())
+        else:
+            T = expected_fano_threshold
+        hvg_logic_g = (df["fano_ratio_g"] > T) & (df["mean_g"] > minimal_mean)
+
+    df["highly_variable_g"] = hvg_logic_g
+
+    if plot:
+        import matplotlib.pyplot as plt
+        plt.figure(figsize=(12, 3.5))
+        plt.subplot(1, 3, 1)
+        plt.scatter(df["mean_g"], df["var_g"], s=2, alpha=1, color='lightgray', label='All genes')
+        plt.scatter(df["mean_g"][hvg_logic_g], df["var_g"][hvg_logic_g], s=4, alpha=0.2, color="r", label='Highly variable genes')
+        plt.xscale("log")
+        plt.yscale("log")
+        plt.xlabel("Mean expression")
+        plt.ylabel("Variance of expression")
+        plt.title("Gene mean vs. variance")
+        plt.legend()
+
+        plt.subplot(1, 3, 2)
+        plt.scatter(df["mean_g"], df["fano_g"], s=2, alpha=1, color='lightgray', label='All genes')
+        plt.scatter(df["mean_g"][hvg_logic_g], df["fano_g"][hvg_logic_g], s=4, alpha=0.2, color="r", label='Highly variable genes')
+        order = np.argsort(df["mean_g"])
+        plt.plot(df["mean_g"][order], df["fano_fit_g"][order], color="k", linestyle="--")
+        plt.xscale("log")
+        plt.yscale("log")
+        plt.xlabel("Mean expression")
+        plt.ylabel("Fano factor")
+        plt.title("Gene mean vs. Fano factor")
+        plt.legend()
+
+        plt.subplot(1, 3, 3)
+        plt.scatter(df["mean_g"], df["fano_ratio_g"], s=2, alpha=1, color='lightgray', label='All genes')
+        plt.scatter(df["mean_g"][hvg_logic_g], df["fano_ratio_g"][hvg_logic_g], s=4, alpha=0.2, color="r", label='Highly variable genes')
+        plt.xscale("log")
+        plt.yscale("log")
+        plt.xlabel("Mean expression")
+        plt.ylabel("Fano ratio")
+        plt.title("Gene mean vs. Fano ratio")
+        plt.legend()
+        plt.tight_layout()
+        plt.show()
+
+    df = df.rename(columns={c: c.split("_g")[0] for c in df.columns})
+    return df

--- a/cellarium/ml/preprocessing/highly_variable_genes.py
+++ b/cellarium/ml/preprocessing/highly_variable_genes.py
@@ -264,10 +264,10 @@ def _get_highly_variable_genes_batched(
 
 
 def kotliar_compute_highly_variable_genes(
+    var_names_g: list | np.ndarray,
     mean_g: np.ndarray,
     var_g: np.ndarray,
-    var_names_g: list | np.ndarray,
-    num_genes: int | None = 2000,
+    n_top_genes: int | None = 2000,
     expected_fano_threshold: float | None = None,
     minimal_mean: float = 0.5,
     plot: bool = False,
@@ -284,12 +284,12 @@ def kotliar_compute_highly_variable_genes(
         mean_g: The mean expression levels of genes
         var_g: The variance of expression levels of genes
         var_names_g: The names of the genes
-        num_genes: The number of highly variable genes to select. If None, uses a threshold-based approach
-        expected_fano_threshold: If num_genes is None, this threshold is used to select highly variable genes
+        n_top_genes: The number of highly variable genes to select. If None, uses a threshold-based approach
+        expected_fano_threshold: If n_top_genes is None, this threshold is used to select highly variable genes
             based on their Fano factor relative to the expected Fano factor. If None, a default threshold is
             computed based on the standard deviation of the Fano factors of genes that pass a winsorized box filter.
         minimal_mean: The minimum mean expression level for a gene to be considered highly variable.
-            This is used only in the threshold-based approach (i.e. when num_genes is None)
+            This is used only in the threshold-based approach (i.e. when n_top_genes is None)
         plot: Whether to plot the mean-variance relationship and the Fano factor distribution. Useful for debugging.
 
     Returns:
@@ -323,8 +323,8 @@ def kotliar_compute_highly_variable_genes(
     df["fano_ratio_g"] = df["fano_g"] / df["fano_fit_g"]
 
     # Identify high var genes
-    if num_genes is not None:
-        hvg_var_names = df["fano_ratio_g"].sort_values(ascending=False).index[:num_genes]
+    if n_top_genes is not None:
+        hvg_var_names = df["fano_ratio_g"].sort_values(ascending=False).index[:n_top_genes]
         hvg_logic_g = df.index.isin(hvg_var_names)
         T = None
     else:

--- a/cellarium/ml/preprocessing/highly_variable_genes.py
+++ b/cellarium/ml/preprocessing/highly_variable_genes.py
@@ -264,9 +264,9 @@ def _get_highly_variable_genes_batched(
 
 
 def kotliar_compute_highly_variable_genes(
-    mean_g: np.array,
-    var_g: np.array,
-    var_names_g: np.array,
+    mean_g: np.ndarray,
+    var_g: np.ndarray,
+    var_names_g: list | np.ndarray,
     num_genes: int | None = 2000,
     expected_fano_threshold: float | None = None,
     minimal_mean: float = 0.5,
@@ -307,7 +307,7 @@ def kotliar_compute_highly_variable_genes(
     # Find parameters for expected fano line
     top_genes = df["mean_g"].sort_values(ascending=False)[:20].index
     A = (np.sqrt(df["var_g"]) / df["mean_g"])[top_genes].min()
-    
+
     w_mean_low, w_mean_high = df["mean_g"].quantile([0.10, 0.90])
     w_fano_low, w_fano_high = df["fano_g"].quantile([0.10, 0.90])
     winsor_box_logic = (
@@ -318,7 +318,7 @@ def kotliar_compute_highly_variable_genes(
     )
     fano_median = df["fano_g"][winsor_box_logic].median()
     B = np.sqrt(fano_median)
-    
+
     df["fano_fit_g"] = (A**2) * df["mean_g"] + (B**2)
     df["fano_ratio_g"] = df["fano_g"] / df["fano_fit_g"]
 
@@ -329,7 +329,7 @@ def kotliar_compute_highly_variable_genes(
         T = None
     else:
         if not expected_fano_threshold:
-            T = (1. + df["fano_g"][winsor_box_logic].std())
+            T = 1.0 + df["fano_g"][winsor_box_logic].std()
         else:
             T = expected_fano_threshold
         hvg_logic_g = (df["fano_ratio_g"] > T) & (df["mean_g"] > minimal_mean)
@@ -338,10 +338,18 @@ def kotliar_compute_highly_variable_genes(
 
     if plot:
         import matplotlib.pyplot as plt
+
         plt.figure(figsize=(12, 3.5))
         plt.subplot(1, 3, 1)
-        plt.scatter(df["mean_g"], df["var_g"], s=2, alpha=1, color='lightgray', label='All genes')
-        plt.scatter(df["mean_g"][hvg_logic_g], df["var_g"][hvg_logic_g], s=4, alpha=0.2, color="r", label='Highly variable genes')
+        plt.scatter(df["mean_g"], df["var_g"], s=2, alpha=1, color="lightgray", label="All genes")
+        plt.scatter(
+            df["mean_g"][hvg_logic_g],
+            df["var_g"][hvg_logic_g],
+            s=4,
+            alpha=0.2,
+            color="r",
+            label="Highly variable genes",
+        )
         plt.xscale("log")
         plt.yscale("log")
         plt.xlabel("Mean expression")
@@ -350,8 +358,15 @@ def kotliar_compute_highly_variable_genes(
         plt.legend()
 
         plt.subplot(1, 3, 2)
-        plt.scatter(df["mean_g"], df["fano_g"], s=2, alpha=1, color='lightgray', label='All genes')
-        plt.scatter(df["mean_g"][hvg_logic_g], df["fano_g"][hvg_logic_g], s=4, alpha=0.2, color="r", label='Highly variable genes')
+        plt.scatter(df["mean_g"], df["fano_g"], s=2, alpha=1, color="lightgray", label="All genes")
+        plt.scatter(
+            df["mean_g"][hvg_logic_g],
+            df["fano_g"][hvg_logic_g],
+            s=4,
+            alpha=0.2,
+            color="r",
+            label="Highly variable genes",
+        )
         order = np.argsort(df["mean_g"])
         plt.plot(df["mean_g"][order], df["fano_fit_g"][order], color="k", linestyle="--")
         plt.xscale("log")
@@ -362,8 +377,15 @@ def kotliar_compute_highly_variable_genes(
         plt.legend()
 
         plt.subplot(1, 3, 3)
-        plt.scatter(df["mean_g"], df["fano_ratio_g"], s=2, alpha=1, color='lightgray', label='All genes')
-        plt.scatter(df["mean_g"][hvg_logic_g], df["fano_ratio_g"][hvg_logic_g], s=4, alpha=0.2, color="r", label='Highly variable genes')
+        plt.scatter(df["mean_g"], df["fano_ratio_g"], s=2, alpha=1, color="lightgray", label="All genes")
+        plt.scatter(
+            df["mean_g"][hvg_logic_g],
+            df["fano_ratio_g"][hvg_logic_g],
+            s=4,
+            alpha=0.2,
+            color="r",
+            label="Highly variable genes",
+        )
         plt.xscale("log")
         plt.yscale("log")
         plt.xlabel("Mean expression")

--- a/tests/test_highly_variable_genes.py
+++ b/tests/test_highly_variable_genes.py
@@ -6,7 +6,10 @@ import pytest
 import scipy.sparse
 import torch
 
-from cellarium.ml.preprocessing.highly_variable_genes import get_highly_variable_genes
+from cellarium.ml.preprocessing.highly_variable_genes import (
+    kotliar_compute_highly_variable_genes,
+    seurat_compute_highly_variable_genes,
+)
 
 # ---------------------------------------------------------------------------
 # Original smoke tests (preserved exactly)
@@ -18,8 +21,8 @@ def test_highly_variable_genes_top_n(num_genes_to_check: int):
     gene_names = ["gene_0", "gene_1", "gene_2", "gene_3", "gene_4", "gene_5"]
     mean = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.float32)
     var = torch.tensor([1.6086e00, 2.2582e02, 9.8922e-02, 1.4379e01, 4.0901e-02, 9.9200e-01], dtype=torch.float32)
-    result = get_highly_variable_genes(
-        gene_names=gene_names, mean=mean, var=var, n_top_genes=num_genes_to_check, n_bins=1
+    result = seurat_compute_highly_variable_genes(
+        var_names_g=gene_names, mean_g=mean, var_g=var, n_top_genes=num_genes_to_check, n_bins=1
     )
     assert result[result.highly_variable].shape[0] == num_genes_to_check
 
@@ -28,7 +31,7 @@ def test_highly_variable_genes_cutoffs():
     gene_names = ["gene_0", "gene_1", "gene_2", "gene_3", "gene_4", "gene_5"]
     mean = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.float32)
     var = torch.tensor([1.6086e00, 2.2582e02, 9.8922e-02, 1.4379e01, 4.0901e-02, 9.9200e-01], dtype=torch.float32)
-    result = get_highly_variable_genes(
+    result = seurat_compute_highly_variable_genes(
         gene_names, mean, var, min_disp=0.2, max_disp=10, min_mean=0, max_mean=5, n_bins=1
     )
     assert result[result.highly_variable].shape[0] != 0
@@ -39,7 +42,7 @@ def test_highly_variable_genes_wrong_sizes():
     mean = torch.tensor([1, 2, 3])
     var = torch.tensor([0.1, 0.2, 0.3, 0.4])
     with pytest.raises(ValueError):
-        get_highly_variable_genes(gene_names, mean, var)
+        seurat_compute_highly_variable_genes(gene_names, mean, var)
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +100,7 @@ def test_hvg_matches_scanpy_n_top_genes(n_top_genes: int):
     mean_t = torch.tensor(mean_np, dtype=torch.float32)
     var_t = torch.tensor(var_np, dtype=torch.float32)
 
-    our_df = get_highly_variable_genes(list(adata_norm.var_names), mean_t, var_t, n_top_genes=n_top_genes)
+    our_df = seurat_compute_highly_variable_genes(list(adata_norm.var_names), mean_t, var_t, n_top_genes=n_top_genes)
     sc_df = sc.pp.highly_variable_genes(adata_norm, flavor="seurat", n_top_genes=n_top_genes, inplace=False)
 
     our_hvg = set(our_df[our_df.highly_variable].index)
@@ -126,7 +129,7 @@ def test_hvg_matches_scanpy_cutoffs():
     mean_t = torch.tensor(mean_np, dtype=torch.float32)
     var_t = torch.tensor(var_np, dtype=torch.float32)
 
-    our_df = get_highly_variable_genes(
+    our_df = seurat_compute_highly_variable_genes(
         list(adata_norm.var_names), mean_t, var_t, min_disp=0.5, max_disp=np.inf, min_mean=0.0125, max_mean=3.0
     )
     sc_df = sc.pp.highly_variable_genes(
@@ -168,7 +171,7 @@ def test_hvg_batch_matches_scanpy(n_top_genes: int):
         batch_mean_bg[i] = torch.tensor(bm, dtype=torch.float32)
         batch_var_bg[i] = torch.tensor(bv, dtype=torch.float32)
 
-    our_df = get_highly_variable_genes(
+    our_df = seurat_compute_highly_variable_genes(
         list(adata_norm.var_names),
         mean_t,
         var_t,
@@ -194,12 +197,12 @@ def test_hvg_batch_matches_scanpy(n_top_genes: int):
 
 def test_hvg_batch_partial_args_raises():
     with pytest.raises(ValueError, match="must all be provided together"):
-        get_highly_variable_genes(["g0", "g1"], torch.ones(2), torch.ones(2), batch_mean_bg=torch.ones(2, 2))
+        seurat_compute_highly_variable_genes(["g0", "g1"], torch.ones(2), torch.ones(2), batch_mean_bg=torch.ones(2, 2))
 
 
 def test_hvg_batch_shape_mismatch_raises():
     with pytest.raises(ValueError):
-        get_highly_variable_genes(
+        seurat_compute_highly_variable_genes(
             ["g0", "g1", "g2"],
             torch.ones(3),
             torch.ones(3),
@@ -207,3 +210,72 @@ def test_hvg_batch_shape_mismatch_raises():
             batch_var_bg=torch.ones(2, 4),
             batch_ids=["a", "b"],
         )
+
+
+# ---------------------------------------------------------------------------
+# Kotliar HVG tests
+# ---------------------------------------------------------------------------
+
+_KOTLIAR_GENE_NAMES = [f"gene_{i}" for i in range(50)]
+# Construct data with clear high-variance outliers: first 5 genes have much
+# higher variance than the rest.
+_rng = np.random.default_rng(42)
+_KOTLIAR_MEAN = np.abs(_rng.normal(loc=5.0, scale=2.0, size=50)) + 0.1
+_KOTLIAR_VAR = _KOTLIAR_MEAN * 1.1          # Fano ≈ 1 baseline
+_KOTLIAR_VAR[:5] = _KOTLIAR_MEAN[:5] * 50  # very high Fano for first 5 genes
+
+
+@pytest.mark.parametrize("num_genes", [5, 10, 20])
+def test_kotliar_num_genes_exact(num_genes: int):
+    """num_genes selected genes are returned when num_genes is specified."""
+    df = kotliar_compute_highly_variable_genes(
+        mean_g=_KOTLIAR_MEAN,
+        var_g=_KOTLIAR_VAR,
+        var_names_g=_KOTLIAR_GENE_NAMES,
+        num_genes=num_genes,
+    )
+    assert df["highly_variable"].sum() == num_genes
+
+
+def test_kotliar_output_schema():
+    """Output DataFrame has the required columns and is indexed by var_names_g."""
+    df = kotliar_compute_highly_variable_genes(
+        mean_g=_KOTLIAR_MEAN,
+        var_g=_KOTLIAR_VAR,
+        var_names_g=_KOTLIAR_GENE_NAMES,
+        num_genes=10,
+    )
+    expected_cols = {"mean", "var", "fano", "fano_fit", "fano_ratio", "highly_variable"}
+    assert expected_cols.issubset(set(df.columns)), f"Missing columns: {expected_cols - set(df.columns)}"
+    assert list(df.index) == _KOTLIAR_GENE_NAMES
+
+
+def test_kotliar_top_genes_have_highest_fano_ratio():
+    """Genes selected by num_genes should be exactly those with the highest fano_ratio."""
+    num_genes = 10
+    df = kotliar_compute_highly_variable_genes(
+        mean_g=_KOTLIAR_MEAN,
+        var_g=_KOTLIAR_VAR,
+        var_names_g=_KOTLIAR_GENE_NAMES,
+        num_genes=num_genes,
+    )
+    top_by_ratio = df["fano_ratio"].nlargest(num_genes).index
+    selected = df[df["highly_variable"]].index
+    assert set(selected) == set(top_by_ratio)
+
+
+def test_kotliar_threshold_mode_selects_outliers():
+    """With a high threshold, only the obvious high-Fano genes are selected."""
+    df = kotliar_compute_highly_variable_genes(
+        mean_g=_KOTLIAR_MEAN,
+        var_g=_KOTLIAR_VAR,
+        var_names_g=_KOTLIAR_GENE_NAMES,
+        num_genes=None,
+        expected_fano_threshold=20.0,   # only fano_ratio > 20 pass
+        minimal_mean=0.0,
+    )
+    # All selected genes must have fano_ratio > 20
+    selected = df[df["highly_variable"]]
+    assert (selected["fano_ratio"] > 20.0).all()
+    # The 5 genes we engineered to have Fano ≈ 50× the fit should all be selected
+    assert set(_KOTLIAR_GENE_NAMES[:5]).issubset(set(selected.index))

--- a/tests/test_highly_variable_genes.py
+++ b/tests/test_highly_variable_genes.py
@@ -225,16 +225,16 @@ _KOTLIAR_VAR = _KOTLIAR_MEAN * 1.1  # Fano ≈ 1 baseline
 _KOTLIAR_VAR[:5] = _KOTLIAR_MEAN[:5] * 50  # very high Fano for first 5 genes
 
 
-@pytest.mark.parametrize("num_genes", [5, 10, 20])
-def test_kotliar_num_genes_exact(num_genes: int):
-    """num_genes selected genes are returned when num_genes is specified."""
+@pytest.mark.parametrize("n_top_genes", [5, 10, 20])
+def test_kotliar_num_genes_exact(n_top_genes: int):
+    """n_top_genes selected genes are returned when n_top_genes is specified."""
     df = kotliar_compute_highly_variable_genes(
         mean_g=_KOTLIAR_MEAN,
         var_g=_KOTLIAR_VAR,
         var_names_g=_KOTLIAR_GENE_NAMES,
-        num_genes=num_genes,
+        n_top_genes=n_top_genes,
     )
-    assert df["highly_variable"].sum() == num_genes
+    assert df["highly_variable"].sum() == n_top_genes
 
 
 def test_kotliar_output_schema():
@@ -243,7 +243,7 @@ def test_kotliar_output_schema():
         mean_g=_KOTLIAR_MEAN,
         var_g=_KOTLIAR_VAR,
         var_names_g=_KOTLIAR_GENE_NAMES,
-        num_genes=10,
+        n_top_genes=10,
     )
     expected_cols = {"mean", "var", "fano", "fano_fit", "fano_ratio", "highly_variable"}
     assert expected_cols.issubset(set(df.columns)), f"Missing columns: {expected_cols - set(df.columns)}"
@@ -252,14 +252,14 @@ def test_kotliar_output_schema():
 
 def test_kotliar_top_genes_have_highest_fano_ratio():
     """Genes selected by num_genes should be exactly those with the highest fano_ratio."""
-    num_genes = 10
+    n_top_genes = 10
     df = kotliar_compute_highly_variable_genes(
         mean_g=_KOTLIAR_MEAN,
         var_g=_KOTLIAR_VAR,
         var_names_g=_KOTLIAR_GENE_NAMES,
-        num_genes=num_genes,
+        n_top_genes=n_top_genes,
     )
-    top_by_ratio = df["fano_ratio"].nlargest(num_genes).index
+    top_by_ratio = df["fano_ratio"].nlargest(n_top_genes).index
     selected = df[df["highly_variable"]].index
     assert set(selected) == set(top_by_ratio)
 
@@ -270,7 +270,7 @@ def test_kotliar_threshold_mode_selects_outliers():
         mean_g=_KOTLIAR_MEAN,
         var_g=_KOTLIAR_VAR,
         var_names_g=_KOTLIAR_GENE_NAMES,
-        num_genes=None,
+        n_top_genes=None,
         expected_fano_threshold=20.0,  # only fano_ratio > 20 pass
         minimal_mean=0.0,
     )

--- a/tests/test_highly_variable_genes.py
+++ b/tests/test_highly_variable_genes.py
@@ -221,7 +221,7 @@ _KOTLIAR_GENE_NAMES = [f"gene_{i}" for i in range(50)]
 # higher variance than the rest.
 _rng = np.random.default_rng(42)
 _KOTLIAR_MEAN = np.abs(_rng.normal(loc=5.0, scale=2.0, size=50)) + 0.1
-_KOTLIAR_VAR = _KOTLIAR_MEAN * 1.1          # Fano ≈ 1 baseline
+_KOTLIAR_VAR = _KOTLIAR_MEAN * 1.1  # Fano ≈ 1 baseline
 _KOTLIAR_VAR[:5] = _KOTLIAR_MEAN[:5] * 50  # very high Fano for first 5 genes
 
 
@@ -271,7 +271,7 @@ def test_kotliar_threshold_mode_selects_outliers():
         var_g=_KOTLIAR_VAR,
         var_names_g=_KOTLIAR_GENE_NAMES,
         num_genes=None,
-        expected_fano_threshold=20.0,   # only fano_ratio > 20 pass
+        expected_fano_threshold=20.0,  # only fano_ratio > 20 pass
         minimal_mean=0.0,
     )
     # All selected genes must have fano_ratio > 20


### PR DESCRIPTION
Renames the HVG helper function "get_highly_variable_genes" to "seurat_compute_highly_variable_genes".  Also slightly tweaks the input arg names for standardization.

Adds Kotliar HVG selection based on Fano factors as the function `kotliar_compute_highly_variable_genes`.  (Used in NMF and maybe be useful more broadly.). Adds tests for it.