### PR TITLE
patch EarlyStopping and scvi: fix validation metric logging

### DIFF
--- a/cellarium/ml/callbacks/__init__.py
+++ b/cellarium/ml/callbacks/__init__.py
@@ -2,9 +2,17 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from cellarium.ml.callbacks.compute_norm import ComputeNorm
+from cellarium.ml.callbacks.early_stopping_patch import MetaSafeEarlyStopping
 from cellarium.ml.callbacks.get_coord_data import GetCoordData
 from cellarium.ml.callbacks.loss_scale_monitor import LossScaleMonitor
 from cellarium.ml.callbacks.prediction_writer import PredictionWriter
 from cellarium.ml.callbacks.variance_monitor import VarianceMonitor
 
-__all__ = ["ComputeNorm", "GetCoordData", "LossScaleMonitor", "PredictionWriter", "VarianceMonitor"]
+__all__ = [
+    "ComputeNorm",
+    "GetCoordData",
+    "LossScaleMonitor",
+    "MetaSafeEarlyStopping",
+    "PredictionWriter",
+    "VarianceMonitor",
+]

--- a/cellarium/ml/callbacks/early_stopping_patch.py
+++ b/cellarium/ml/callbacks/early_stopping_patch.py
@@ -1,0 +1,17 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import torch
+from lightning.pytorch.callbacks import EarlyStopping
+
+
+class MetaSafeEarlyStopping(EarlyStopping):
+    def setup(self, trainer, pl_module, stage: str) -> None:
+        super().setup(trainer, pl_module, stage)
+
+        # override the empty meta tensor with a real CPU tensor
+        if self.mode == "min":
+            self.best_score = torch.tensor(np.inf, device="cpu")
+        else:
+            self.best_score = torch.tensor(-np.inf, device="cpu")

--- a/cellarium/ml/core/module.py
+++ b/cellarium/ml/core/module.py
@@ -482,7 +482,7 @@ class CellariumModule(pl.LightningModule):
         """
         hook = getattr(self.model, "on_validation_epoch_end", None)
         if callable(hook):
-            hook(self.trainer)
+            hook(self, self.trainer)
 
     def on_train_end(self) -> None:
         """

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -1605,7 +1605,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             val_rec = self._val_rec_sum / self._val_n_cells
             lightning_module.log(
                 name="val_reconstruction_loss",
-                value=val_rec.detach().to(lightning_module.device),
+                value=val_rec.detach(),
                 sync_dist=True,
             )
 
@@ -1673,7 +1673,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
                 top1 = (preds == y_test).float().mean().detach()
                 lightning_module.log(
                     name="val_cell_type_top1_accuracy",
-                    value=top1.to(lightning_module.device),
+                    value=top1,
                     sync_dist=True,
                 )
 

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -1602,8 +1602,8 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         if n_cells > 0:
             val_elbo = (self._val_elbo_sum / self._val_n_cells).item()
             trainer.logger.log_metrics({"val_elbo": val_elbo}, step=step)
-            val_rec = (self._val_rec_sum / self._val_n_cells).item()
-            lightning_module.log(name="val_reconstruction_loss", value=val_rec)
+            val_rec = self._val_rec_sum / self._val_n_cells
+            lightning_module.log(name="val_reconstruction_loss", value=val_rec.detach(), sync_dist=True)
 
         # ontology-weighted Spearman
         if self.num_classes is not None and self.ontology_distance_matrix is not None:
@@ -1666,8 +1666,8 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             with torch.no_grad():
                 logits_test = X_test @ W.T + b
                 preds = logits_test.argmax(dim=-1)
-                top1 = (preds == y_test).float().mean().item()
-                lightning_module.log(name="val_cell_type_top1_accuracy", value=top1)
+                top1 = (preds == y_test).float().mean().detach()
+                lightning_module.log(name="val_cell_type_top1_accuracy", value=top1, sync_dist=True)
 
                 if self.ontology_distance_matrix is not None:
                     wrong_mask = preds != y_test

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -1603,7 +1603,11 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             val_elbo = (self._val_elbo_sum / self._val_n_cells).item()
             trainer.logger.log_metrics({"val_elbo": val_elbo}, step=step)
             val_rec = self._val_rec_sum / self._val_n_cells
-            lightning_module.log(name="val_reconstruction_loss", value=val_rec.detach(), sync_dist=True)
+            lightning_module.log(
+                name="val_reconstruction_loss",
+                value=val_rec.detach().to(lightning_module.device),
+                sync_dist=True,
+            )
 
         # ontology-weighted Spearman
         if self.num_classes is not None and self.ontology_distance_matrix is not None:
@@ -1667,7 +1671,11 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
                 logits_test = X_test @ W.T + b
                 preds = logits_test.argmax(dim=-1)
                 top1 = (preds == y_test).float().mean().detach()
-                lightning_module.log(name="val_cell_type_top1_accuracy", value=top1, sync_dist=True)
+                lightning_module.log(
+                    name="val_cell_type_top1_accuracy",
+                    value=top1.to(lightning_module.device),
+                    sync_dist=True,
+                )
 
                 if self.ontology_distance_matrix is not None:
                     wrong_mask = preds != y_test

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -1543,7 +1543,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             return 0.0
         return float(cov[0, 1] / denom)
 
-    def on_validation_epoch_end(self, trainer: pl.Trainer) -> None:
+    def on_validation_epoch_end(self, lightning_module: pl.LightningModule, trainer: pl.Trainer) -> None:
         if trainer.sanity_checking:
             return
 
@@ -1603,7 +1603,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             val_elbo = (self._val_elbo_sum / self._val_n_cells).item()
             trainer.logger.log_metrics({"val_elbo": val_elbo}, step=step)
             val_rec = (self._val_rec_sum / self._val_n_cells).item()
-            trainer.logger.log_metrics({"val_reconstruction_loss": val_rec}, step=step)
+            lightning_module.log(name="val_reconstruction_loss", value=val_rec)
 
         # ontology-weighted Spearman
         if self.num_classes is not None and self.ontology_distance_matrix is not None:
@@ -1667,7 +1667,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
                 logits_test = X_test @ W.T + b
                 preds = logits_test.argmax(dim=-1)
                 top1 = (preds == y_test).float().mean().item()
-                trainer.logger.log_metrics({"val_cell_type_top1_accuracy": top1}, step=step)
+                lightning_module.log(name="val_cell_type_top1_accuracy", value=top1)
 
                 if self.ontology_distance_matrix is not None:
                     wrong_mask = preds != y_test

--- a/cellarium/ml/models/socam.py
+++ b/cellarium/ml/models/socam.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from typing import TypedDict
 
 import lightning.pytorch as pl
@@ -374,8 +375,11 @@ class SOCAM(CellariumModel, PredictMixin, ValidateMixin):
 
         for logger in trainer.loggers:
             if isinstance(logger, pl.loggers.TensorBoardLogger):
-                logger.experiment.add_histogram(
-                    "W_gc",
-                    self.W_gc,
-                    global_step=trainer.global_step,
-                )
+                try:
+                    logger.experiment.add_histogram(
+                        "b_c",
+                        self.b_c,
+                        global_step=trainer.global_step,
+                    )
+                except ValueError as e:
+                    warnings.warn(f"Failed to log histogram for b_c step={trainer.global_step} due to {e}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -624,6 +624,9 @@ TWO_DEVICE_CONFIGS = [
             },
         },
     },
+]
+
+SINGLE_DEVICE_CONFIGS = [
     {
         "model_name": "scvi",
         "subcommand": "fit",
@@ -768,9 +771,6 @@ TWO_DEVICE_CONFIGS = [
             },
         },
     },
-]
-
-SINGLE_DEVICE_CONFIGS = [
     {
         "model_name": "socam",
         "subcommand": "fit",
@@ -1134,6 +1134,7 @@ def test_cpu_two_device(config: dict[str, Any]):
     ],
 )
 def test_cpu_single_device(config: dict[str, Any]):
+    config = {k: v for k, v in config.items() if not k.startswith("_")}
     if config["subcommand"] == "predict":
         assert config["predict"]["return_predictions"] == "false"
     main(config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -685,6 +685,7 @@ TWO_DEVICE_CONFIGS = [
                 },
                 "batch_size": "50",
                 "num_workers": "0",
+                "val_size": "0.1",
             },
             "trainer": {
                 "accelerator": "cpu",


### PR DESCRIPTION
EarlyStopping cannot see metrics logged using `trainer.logger.log_metrics`

The right way seems to be `lightning_module.log` so the metrics become visible.

This PR changes the call signature for `on_validation_epoch_end` in models.  Currently scvi is the only model using this hook.


Also important:

`EarlyStopping` is not really compatible with cellarium-ml directly.  cellarium-ml initializes everything on meta device, and when this is happening, EarlyStopping gets instantiated.  It pulls device context from the init context.  So it initializes all its internal tracking stuff on the meta device.  This then errors during training.

This patch creates `MetaSafeEarlyStopping` which just forces the internal trackers onto cpu (which can then get cast correctly later).