### PR TITLE
Workaround argument linking in CLI for scvi

### DIFF
--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -6,6 +6,7 @@ Command line interface for Cellarium ML.
 """
 
 import copy
+import os
 import sys
 import warnings
 from collections.abc import Callable
@@ -1062,18 +1063,28 @@ def scvi(args: ArgsType = None) -> None:
     Args:
         args: Arguments to parse. If ``None`` the arguments are taken from ``sys.argv``.
     """
+    link_arguments = [
+        LinkArguments(
+            ("model.cpu_transforms", "model.transforms", "data"),
+            "model.model.init_args.var_names_g",
+            compute_var_names_g,
+        ),
+        LinkArguments("data", "model.model.init_args.cell_type_categories", compute_cell_type_categories),
+    ]
+    if not os.environ.get("SCVI_PREDICT_SKIP_ARG_LINKING"):
+        link_arguments.extend(
+            [
+                LinkArguments("data", "model.model.init_args.n_batch", compute_batch_index_n_categories),
+                LinkArguments("data", "model.model.init_args.n_cats_per_cov", compute_n_cats_per_cov),
+            ]
+        )
+    else:
+        # todo: add linking of the above from the checkpoint config when running predict,
+        # so that the user doesn't have to manually specify them
+        pass
     cli = lightning_cli_factory(
         "cellarium.ml.models.SingleCellVariationalInference",
-        link_arguments=[
-            LinkArguments(
-                ("model.cpu_transforms", "model.transforms", "data"),
-                "model.model.init_args.var_names_g",
-                compute_var_names_g,
-            ),
-            LinkArguments("data", "model.model.init_args.n_batch", compute_batch_index_n_categories),
-            LinkArguments("data", "model.model.init_args.n_cats_per_cov", compute_n_cats_per_cov),
-            LinkArguments("data", "model.model.init_args.cell_type_categories", compute_cell_type_categories),
-        ],
+        link_arguments=link_arguments,
     )
     cli(args=args)
 

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -1069,13 +1069,13 @@ def scvi(args: ArgsType = None) -> None:
             "model.model.init_args.var_names_g",
             compute_var_names_g,
         ),
-        LinkArguments("data", "model.model.init_args.cell_type_categories", compute_cell_type_categories),
     ]
     if not os.environ.get("SCVI_PREDICT_SKIP_ARG_LINKING"):
         link_arguments.extend(
             [
                 LinkArguments("data", "model.model.init_args.n_batch", compute_batch_index_n_categories),
                 LinkArguments("data", "model.model.init_args.n_cats_per_cov", compute_n_cats_per_cov),
+                LinkArguments("data", "model.model.init_args.cell_type_categories", compute_cell_type_categories),
             ]
         )
     else:


### PR DESCRIPTION
With a trained scvi model running `predict`, argument linking in the lightning CLI enforces that things like `n_batch` and `n_cats_per_cov` come from the data.  This is very convenient during training, since the user doesn't have to manually specify everything (error prone).  But during prediction, it's possible `n_batch` and `n_cats_per_cov` are not used (in the encoder).  If the model is approached with new data (which is a common use case), then the lightning CLI will fail on instantiation.  Series of events:

- lightning instantiates model
- argument linking sets `n_batch` based on dataset
- lightning tries to load state dict from the saved checkpoint
- state dict loading fails due to tensor shapes mismatch (different `n_batch` during training made tensor shapes different)
- cannot proceed

This patch adds a specific environment variable to omit that automatic argument linking.