### PR TITLE
socam: log hist of W_gc not b_c

### DIFF
--- a/cellarium/ml/models/socam.py
+++ b/cellarium/ml/models/socam.py
@@ -377,9 +377,9 @@ class SOCAM(CellariumModel, PredictMixin, ValidateMixin):
             if isinstance(logger, pl.loggers.TensorBoardLogger):
                 try:
                     logger.experiment.add_histogram(
-                        "b_c",
-                        self.b_c,
+                        "W_gc",
+                        self.W_gc,
                         global_step=trainer.global_step,
                     )
                 except ValueError as e:
-                    warnings.warn(f"Failed to log histogram for b_c step={trainer.global_step} due to {e}")
+                    warnings.warn(f"Failed to log histogram for W_gc step={trainer.global_step} due to {e}")


### PR DESCRIPTION
fix an AI induced logging change

it had always been the intent to log `W-gc`'s histogram, since we would care about the weight matrix, never the bias vector