### PR TITLE
Address torch.compile issues with docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       id-token: write  # required for Workload Identity Federation
+      actions: write   # required for GHA cache read/write
 
     steps:
     - name: Resolve version
@@ -57,6 +58,8 @@ jobs:
         platforms: linux/amd64
         build-args: VERSION=${{ steps.version.outputs.value }}
         tags: cellarium-ml-test:ci
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Test torch.compile()
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,14 +47,33 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Build and push Docker image
+    - name: Build Docker image
       uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile
-        push: true
+        push: false
+        load: true
         platforms: linux/amd64
         build-args: VERSION=${{ steps.version.outputs.value }}
-        tags: |
-          us-central1-docker.pkg.dev/broad-dsde-methods/cellarium-ai/cellarium-ml:${{ steps.version.outputs.value }}
-          us-central1-docker.pkg.dev/broad-dsde-methods/cellarium-ai/cellarium-ml:latest
+        tags: cellarium-ml-test:ci
+
+    - name: Test torch.compile()
+      run: |
+        timeout 180 docker run --rm cellarium-ml-test:ci python -c "
+        import torch
+        torch._dynamo.config.suppress_errors = False
+        torch._dynamo.config.raise_on_backend_error = True
+        def f(x):
+            return (x * x).sum()
+        compiled = torch.compile(f, backend='inductor')
+        result = compiled(torch.randn(10))
+        print('torch.compile() succeeded, result:', result.item())
+        "
+
+    - name: Push Docker image
+      run: |
+        docker tag cellarium-ml-test:ci us-central1-docker.pkg.dev/broad-dsde-methods/cellarium-ai/cellarium-ml:${{ steps.version.outputs.value }}
+        docker tag cellarium-ml-test:ci us-central1-docker.pkg.dev/broad-dsde-methods/cellarium-ai/cellarium-ml:latest
+        docker push us-central1-docker.pkg.dev/broad-dsde-methods/cellarium-ai/cellarium-ml:${{ steps.version.outputs.value }}
+        docker push us-central1-docker.pkg.dev/broad-dsde-methods/cellarium-ai/cellarium-ml:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,15 +60,18 @@ jobs:
 
     - name: Test torch.compile()
       run: |
-        timeout 180 docker run --rm cellarium-ml-test:ci python -c "
-        import torch
+        timeout 180 docker run --rm \
+          -e TORCHINDUCTOR_CACHE_DIR=/tmp/inductor_test_cache \
+          cellarium-ml-test:ci python -c "
+        import glob, torch
         torch._dynamo.config.suppress_errors = False
-        torch._dynamo.config.raise_on_backend_error = True
         def f(x):
             return (x * x).sum()
         compiled = torch.compile(f, backend='inductor')
         result = compiled(torch.randn(10))
-        print('torch.compile() succeeded, result:', result.item())
+        so_files = glob.glob('/tmp/inductor_test_cache/**/*.so', recursive=True)
+        assert so_files, 'No .so files in inductor cache — torch.compile() fell back to eager (g++ missing?)'
+        print(f'torch.compile() succeeded: {len(so_files)} compiled artifact(s) found')
         "
 
     - name: Push Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DOCKER=true \
 ARG VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv python-is-python3 git curl gnupg \
+    python3 python3-pip python3-venv python-is-python3 git curl gnupg gcc g++ \
  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV DOCKER=true \
 ARG VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv python-is-python3 git curl gnupg gcc g++ \
+    python3 python3-dev python3-pip python3-venv python-is-python3 git curl gnupg gcc g++ \
  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
     | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
  && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* \
  && python3 -m venv /opt/venv \
  && /opt/venv/bin/pip install torch --index-url https://download.pytorch.org/whl/cu124 \
- && /opt/venv/bin/pip install git+https://github.com/cellarium-ai/cellarium-ml@${VERSION} \
+ && rm -rf ~/.cache/pip
+
+RUN /opt/venv/bin/pip install git+https://github.com/cellarium-ai/cellarium-ml@${VERSION} \
  && rm -rf ~/.cache/pip


### PR DESCRIPTION
Closes #407 

Add gcc and g++ and python3-dev to docker image (all requirements for torch.compile() to work).

Add an explicit compilation test in the docker.yml action, so that the image will not push if the test fails.  Currently the docker.yml action succeeds and `0.0.11` tag has been pushed with these changes.  Compilation should work.