### PR TITLE
CellFilter transform to eliminate cells during training

### DIFF
--- a/cellarium/ml/core/pipeline.py
+++ b/cellarium/ml/core/pipeline.py
@@ -52,6 +52,7 @@ class CellariumPipeline(torch.nn.ModuleList):
     def predict(
         self, batch: dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]
     ) -> dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor]:
+        batch["_predict_mode"] = True  # type: ignore[assignment]
         for module in self[:-1]:
             batch |= call_func_with_batch(module.forward, batch)
 

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -515,8 +515,6 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             ``size_factor_key`` parameter in the model's ``setup_anndata`` method as the scaling
             factor in the mean of the conditional distribution. If ``False``, the observed library
             size (log of the sum of counts per cell) is used. Should be ``False``.
-        min_count_per_cell_threshold: Minimum number of counts required per cell. Cells with fewer counts will
-            be filtered out. Useful when gene filtering may push cells to very low counts. Default 0 (no filtering).
         reconstruct_counts_on_predict: Changes the behavior of :meth:`predict`. True will reconstruct gene
             expression count data, False will return the latent representations
         reconstruction_var_names_g: List of var_names to be reconstructed (outputs are dense matrices)
@@ -577,7 +575,6 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         kl_warmup_steps: int | None = None,
         kl_annealing_start: float = 0.0,
         use_size_factor_key: bool = False,
-        min_count_per_cell_threshold: int = 0,
         reconstruct_counts_on_predict: bool = False,
         reconstruction_var_names_g: np.ndarray | list | None = None,
         reconstruction_transform_batch: None | int | str = 0,
@@ -604,7 +601,6 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         self.latent_distribution = latent_distribution
         self.n_cats_per_cov = n_cats_per_cov if n_cats_per_cov is not None else []
         self.use_size_factor_key = use_size_factor_key
-        self.min_count_per_cell_threshold = min_count_per_cell_threshold
         self.batch_embedded = batch_embedded
         self.batch_representation_sampled = batch_representation_sampled
         self.n_latent_batch = n_latent_batch
@@ -986,49 +982,6 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
 
         return dict(px=count_distribution, pz=pz)
 
-    def _filter_cells_by_min_count(
-        self,
-        x_ng: torch.Tensor,
-        batch_index_n: torch.Tensor,
-        continuous_covariates_nc: torch.Tensor | None = None,
-        categorical_covariate_index_nd: torch.Tensor | None = None,
-        total_mrna_umis_n: torch.Tensor | None = None,
-        validation_cell_type_index_n: torch.Tensor | None = None,
-    ) -> tuple[
-        torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
-    ]:
-        """Filter cells by minimum count threshold.
-
-        Args:
-            *tensors: A list of tensors to filter. The first tensor must be the gene counts matrix.
-
-        Returns:
-            A tuple of filtered tensors.
-        """
-        if self.min_count_per_cell_threshold > 0:
-            cell_counts_n = x_ng.sum(dim=-1)
-            keeper_logic = cell_counts_n >= self.min_count_per_cell_threshold
-            x_ng = x_ng[keeper_logic]
-            batch_index_n = batch_index_n[keeper_logic]
-            continuous_covariates_nc = (
-                continuous_covariates_nc[keeper_logic] if continuous_covariates_nc is not None else None
-            )
-            categorical_covariate_index_nd = (
-                categorical_covariate_index_nd[keeper_logic] if categorical_covariate_index_nd is not None else None
-            )
-            total_mrna_umis_n = total_mrna_umis_n[keeper_logic] if total_mrna_umis_n is not None else None
-            validation_cell_type_index_n = (
-                validation_cell_type_index_n[keeper_logic] if validation_cell_type_index_n is not None else None
-            )
-        return (
-            x_ng,
-            batch_index_n,
-            continuous_covariates_nc,
-            categorical_covariate_index_nd,
-            total_mrna_umis_n,
-            validation_cell_type_index_n,
-        )
-
     def forward(
         self,
         x_ng: torch.Tensor,
@@ -1063,24 +1016,6 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
 
         assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
         assert_arrays_equal("var_names_g", var_names_g, "var_names_g", self.var_names_g)
-
-        (
-            x_ng,
-            batch_index_n,
-            continuous_covariates_nc,
-            categorical_covariate_index_nd,
-            total_mrna_umis_n,
-            _,
-        ) = self._filter_cells_by_min_count(
-            x_ng, batch_index_n, continuous_covariates_nc, categorical_covariate_index_nd, total_mrna_umis_n
-        )
-        if x_ng.shape[0] == 0:
-            return {
-                "loss": torch.tensor(0.0, device=x_ng.device),
-                "reconstruction_loss": None,
-                "kl_divergence_z": None,
-                "z_nk": None,
-            }
 
         batch_nb = self.batch_representation_from_batch_index(batch_index_n)
         categorical_covariate_np = self.categorical_onehot_from_categorical_index(categorical_covariate_index_nd)
@@ -1499,22 +1434,6 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         total_mrna_umis_n: torch.Tensor | None = None,
         validation_cell_type_index_n: torch.Tensor | None = None,
     ) -> None:
-
-        (
-            x_ng,
-            batch_index_n,
-            continuous_covariates_nc,
-            categorical_covariate_index_nd,
-            total_mrna_umis_n,
-            validation_cell_type_index_n,
-        ) = self._filter_cells_by_min_count(
-            x_ng,
-            batch_index_n,
-            continuous_covariates_nc,
-            categorical_covariate_index_nd,
-            total_mrna_umis_n,
-            validation_cell_type_index_n,
-        )
 
         n = x_ng.shape[0]
         if n == 0:

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -515,6 +515,8 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             ``size_factor_key`` parameter in the model's ``setup_anndata`` method as the scaling
             factor in the mean of the conditional distribution. If ``False``, the observed library
             size (log of the sum of counts per cell) is used. Should be ``False``.
+        min_count_per_cell_threshold: Minimum number of counts required per cell. Cells with fewer counts will
+            be filtered out. Useful when gene filtering may push cells to very low counts. Default 0 (no filtering).
         reconstruct_counts_on_predict: Changes the behavior of :meth:`predict`. True will reconstruct gene
             expression count data, False will return the latent representations
         reconstruction_var_names_g: List of var_names to be reconstructed (outputs are dense matrices)
@@ -575,6 +577,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         kl_warmup_steps: int | None = None,
         kl_annealing_start: float = 0.0,
         use_size_factor_key: bool = False,
+        min_count_per_cell_threshold: int = 0,
         reconstruct_counts_on_predict: bool = False,
         reconstruction_var_names_g: np.ndarray | list | None = None,
         reconstruction_transform_batch: None | int | str = 0,
@@ -601,6 +604,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         self.latent_distribution = latent_distribution
         self.n_cats_per_cov = n_cats_per_cov if n_cats_per_cov is not None else []
         self.use_size_factor_key = use_size_factor_key
+        self.min_count_per_cell_threshold = min_count_per_cell_threshold
         self.batch_embedded = batch_embedded
         self.batch_representation_sampled = batch_representation_sampled
         self.n_latent_batch = n_latent_batch
@@ -982,6 +986,49 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
 
         return dict(px=count_distribution, pz=pz)
 
+    def _filter_cells_by_min_count(
+        self,
+        x_ng: torch.Tensor,
+        batch_index_n: torch.Tensor,
+        continuous_covariates_nc: torch.Tensor | None = None,
+        categorical_covariate_index_nd: torch.Tensor | None = None,
+        total_mrna_umis_n: torch.Tensor | None = None,
+        validation_cell_type_index_n: torch.Tensor | None = None,
+    ) -> tuple[
+        torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
+    ]:
+        """Filter cells by minimum count threshold.
+
+        Args:
+            *tensors: A list of tensors to filter. The first tensor must be the gene counts matrix.
+
+        Returns:
+            A tuple of filtered tensors.
+        """
+        if self.min_count_per_cell_threshold > 0:
+            cell_counts_n = x_ng.sum(dim=-1)
+            keeper_logic = cell_counts_n >= self.min_count_per_cell_threshold
+            x_ng = x_ng[keeper_logic]
+            batch_index_n = batch_index_n[keeper_logic]
+            continuous_covariates_nc = (
+                continuous_covariates_nc[keeper_logic] if continuous_covariates_nc is not None else None
+            )
+            categorical_covariate_index_nd = (
+                categorical_covariate_index_nd[keeper_logic] if categorical_covariate_index_nd is not None else None
+            )
+            total_mrna_umis_n = total_mrna_umis_n[keeper_logic] if total_mrna_umis_n is not None else None
+            validation_cell_type_index_n = (
+                validation_cell_type_index_n[keeper_logic] if validation_cell_type_index_n is not None else None
+            )
+        return (
+            x_ng,
+            batch_index_n,
+            continuous_covariates_nc,
+            categorical_covariate_index_nd,
+            total_mrna_umis_n,
+            validation_cell_type_index_n,
+        )
+
     def forward(
         self,
         x_ng: torch.Tensor,
@@ -1016,6 +1063,24 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
 
         assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
         assert_arrays_equal("var_names_g", var_names_g, "var_names_g", self.var_names_g)
+
+        (
+            x_ng,
+            batch_index_n,
+            continuous_covariates_nc,
+            categorical_covariate_index_nd,
+            total_mrna_umis_n,
+            _,
+        ) = self._filter_cells_by_min_count(
+            x_ng, batch_index_n, continuous_covariates_nc, categorical_covariate_index_nd, total_mrna_umis_n
+        )
+        if x_ng.shape[0] == 0:
+            return {
+                "loss": torch.tensor(0.0, device=x_ng.device),
+                "reconstruction_loss": None,
+                "kl_divergence_z": None,
+                "z_nk": None,
+            }
 
         batch_nb = self.batch_representation_from_batch_index(batch_index_n)
         categorical_covariate_np = self.categorical_onehot_from_categorical_index(categorical_covariate_index_nd)
@@ -1434,7 +1499,26 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         total_mrna_umis_n: torch.Tensor | None = None,
         validation_cell_type_index_n: torch.Tensor | None = None,
     ) -> None:
+
+        (
+            x_ng,
+            batch_index_n,
+            continuous_covariates_nc,
+            categorical_covariate_index_nd,
+            total_mrna_umis_n,
+            validation_cell_type_index_n,
+        ) = self._filter_cells_by_min_count(
+            x_ng,
+            batch_index_n,
+            continuous_covariates_nc,
+            categorical_covariate_index_nd,
+            total_mrna_umis_n,
+            validation_cell_type_index_n,
+        )
+
         n = x_ng.shape[0]
+        if n == 0:
+            return
 
         output = self(
             x_ng=x_ng,

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -1434,10 +1434,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         total_mrna_umis_n: torch.Tensor | None = None,
         validation_cell_type_index_n: torch.Tensor | None = None,
     ) -> None:
-
         n = x_ng.shape[0]
-        if n == 0:
-            return
 
         output = self(
             x_ng=x_ng,

--- a/cellarium/ml/transforms/__init__.py
+++ b/cellarium/ml/transforms/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from cellarium.ml.transforms.binomial_resample import BinomialResample
+from cellarium.ml.transforms.cell_filter import CellFilter
 from cellarium.ml.transforms.cellarium_gpt_tokenizer import CellariumGPTPredictTokenizer, CellariumGPTTrainTokenizer
 from cellarium.ml.transforms.center_per_cell import CenterPerCell
 from cellarium.ml.transforms.densify import Densify
@@ -17,6 +18,7 @@ from cellarium.ml.transforms.z_score import ZScore
 
 __all__ = [
     "BinomialResample",
+    "CellFilter",
     "CellariumGPTTrainTokenizer",
     "CellariumGPTPredictTokenizer",
     "CenterPerCell",

--- a/cellarium/ml/transforms/cell_filter.py
+++ b/cellarium/ml/transforms/cell_filter.py
@@ -1,0 +1,93 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+from torch import nn
+
+
+class CellFilter(nn.Module):
+    """
+    Filter cells from the batch by a minimum quality threshold.
+
+    Exactly one of ``min_count_per_cell`` or ``min_nonzero_genes_per_cell`` may be
+    set to a positive value; setting both is an error.
+
+    Any :class:`torch.Tensor` value in the batch whose first dimension matches the
+    number of input cells (``x_ng.shape[0]``) is filtered consistently.  Non-tensor
+    values and tensors whose first dimension differs from ``n`` (e.g. gene-indexed
+    arrays) are left unchanged.
+
+    When both thresholds are ``0`` (default) the transform is a no-op: an empty dict
+    is returned and the pipeline merge leaves the batch unmodified.  The transform is
+    also a no-op during predict mode (``_predict_mode=True`` in the batch dict, set
+    automatically by :meth:`~cellarium.ml.core.CellariumPipeline.predict`).
+
+    .. warning::
+
+        ``CellFilter`` is **incompatible with** :class:`~cellarium.ml.models.ContrastiveMLP`.
+        The NT-Xent loss asserts a fixed, world-size-divisible batch size and computes
+        positive-pair offsets from it; a variable per-batch cell count breaks both the
+        assertion and the pair alignment, even on a single device.
+
+    Args:
+        min_count_per_cell:
+            Minimum total count (``x_ng`` row sum) required for a cell to be retained.
+            ``0`` disables this filter.
+        min_nonzero_genes_per_cell:
+            Minimum number of genes with nonzero expression required for a cell to be
+            retained, computed as ``(x_ng > 0).sum(dim=-1)``.  ``0`` disables this filter.
+    """
+
+    def __init__(self, min_count_per_cell: int = 0, min_nonzero_genes_per_cell: int = 0) -> None:
+        super().__init__()
+        if min_count_per_cell < 0:
+            raise ValueError(f"min_count_per_cell must be >= 0, got {min_count_per_cell}")
+        if min_nonzero_genes_per_cell < 0:
+            raise ValueError(f"min_nonzero_genes_per_cell must be >= 0, got {min_nonzero_genes_per_cell}")
+        if min_count_per_cell > 0 and min_nonzero_genes_per_cell > 0:
+            raise ValueError(
+                "min_count_per_cell and min_nonzero_genes_per_cell are mutually exclusive; "
+                "set at most one to a positive value."
+            )
+        self.min_count_per_cell = min_count_per_cell
+        self.min_nonzero_genes_per_cell = min_nonzero_genes_per_cell
+
+    def forward(self, **kwargs: torch.Tensor) -> dict[str, torch.Tensor]:
+        """
+        Args:
+            kwargs:
+                Full batch dictionary forwarded by :class:`~cellarium.ml.core.CellariumPipeline`
+                via :func:`~cellarium.ml.utilities.core.call_func_with_batch`.  Must contain
+                ``x_ng``.
+
+        Returns:
+            A dictionary of filtered tensors to merge back into the batch.  Only tensors
+            whose first dimension equals ``n`` are included; all others are omitted so the
+            pipeline merge leaves them unchanged.  Returns ``{}`` when both thresholds are
+            ``0`` or when ``_predict_mode`` is set.
+        """
+        if kwargs.get("_predict_mode", False):
+            return {}
+
+        x_ng: torch.Tensor = kwargs["x_ng"]
+        n = x_ng.shape[0]
+
+        if self.min_count_per_cell > 0:
+            mask = x_ng.sum(dim=-1) >= self.min_count_per_cell
+        elif self.min_nonzero_genes_per_cell > 0:
+            mask = (x_ng > 0).sum(dim=-1) >= self.min_nonzero_genes_per_cell
+        else:
+            return {}
+
+        return {
+            key: value[mask]
+            for key, value in kwargs.items()
+            if isinstance(value, torch.Tensor) and value.ndim >= 1 and value.shape[0] == n
+        }
+
+    def __repr__(self) -> str:
+        if self.min_count_per_cell > 0:
+            return f"{self.__class__.__name__}(min_count_per_cell={self.min_count_per_cell})"
+        if self.min_nonzero_genes_per_cell > 0:
+            return f"{self.__class__.__name__}(min_nonzero_genes_per_cell={self.min_nonzero_genes_per_cell})"
+        return f"{self.__class__.__name__}()"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -8,6 +8,7 @@ import torch
 
 from cellarium.ml import CellariumPipeline
 from cellarium.ml.transforms import (
+    CellFilter,
     CenterPerCell,
     Densify,
     DivideByScale,
@@ -460,3 +461,184 @@ def test_pflogpf_matches_manual_pipeline():
     x = CenterPerCell()(x)["x_ng"]
 
     np.testing.assert_allclose(out_wrapper.numpy(), x.numpy(), atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# CellFilter tests
+# ---------------------------------------------------------------------------
+
+_N, _G = 10, 4
+# Row sums: rows 0-6 have sum 30, rows 7-9 have sum 3 (below threshold of 10)
+_THRESHOLD = 10
+
+
+@pytest.fixture
+def cell_filter_batch():
+    rng = torch.Generator()
+    rng.manual_seed(0)
+    x_ng = torch.zeros(_N, _G)
+    x_ng[:7] = 10.0  # row sum 40 — above threshold
+    x_ng[7:] = 1.0  # row sum 4  — below threshold
+    batch_index_n = torch.arange(_N, dtype=torch.float32)
+    total_mrna_umis_n = x_ng.sum(dim=-1)
+    categorical_covariate_index_nd = torch.zeros(_N, 2)
+    var_names_g = np.array([f"gene_{i}" for i in range(_G)])
+    return {
+        "x_ng": x_ng,
+        "batch_index_n": batch_index_n,
+        "total_mrna_umis_n": total_mrna_umis_n,
+        "categorical_covariate_index_nd": categorical_covariate_index_nd,
+        "var_names_g": var_names_g,
+    }
+
+
+def test_cell_filter_removes_low_count_cells(cell_filter_batch):
+    result = CellFilter(min_count_per_cell=_THRESHOLD)(**cell_filter_batch)
+    assert result["x_ng"].shape[0] == 7
+
+
+def test_cell_filter_all_n_indexed_tensors_filtered_consistently(cell_filter_batch):
+    result = CellFilter(min_count_per_cell=_THRESHOLD)(**cell_filter_batch)
+    n_kept = result["x_ng"].shape[0]
+    for key, val in result.items():
+        assert val.shape[0] == n_kept, f"{key} has inconsistent first dimension after filtering"
+
+
+def test_cell_filter_gene_indexed_array_not_in_return(cell_filter_batch):
+    # var_names_g is a numpy array — must not appear in the returned dict
+    result = CellFilter(min_count_per_cell=_THRESHOLD)(**cell_filter_batch)
+    assert "var_names_g" not in result
+
+
+def test_cell_filter_zero_threshold_returns_empty_dict(cell_filter_batch):
+    result = CellFilter(min_count_per_cell=0)(**cell_filter_batch)
+    assert result == {}
+
+
+def test_cell_filter_exact_threshold_boundary():
+    # Cells at exactly the threshold are kept; one below is not.
+    x_ng = torch.tensor([[10.0, 0.0], [9.0, 0.0], [11.0, 0.0]])
+    batch_index_n = torch.tensor([0.0, 1.0, 2.0])
+    result = CellFilter(min_count_per_cell=10)(x_ng=x_ng, batch_index_n=batch_index_n)
+    assert result["x_ng"].shape[0] == 2
+    assert torch.equal(result["batch_index_n"], torch.tensor([0.0, 2.0]))
+
+
+def test_cell_filter_all_cells_removed():
+    x_ng = torch.ones(5, 3)  # row sum = 3
+    batch_index_n = torch.zeros(5)
+    result = CellFilter(min_count_per_cell=100)(x_ng=x_ng, batch_index_n=batch_index_n)
+    assert result["x_ng"].shape[0] == 0
+    assert result["batch_index_n"].shape[0] == 0
+
+
+def test_cell_filter_in_pipeline(cell_filter_batch):
+    pipeline = CellariumPipeline([CellFilter(min_count_per_cell=_THRESHOLD), NormalizeTotal(target_count=10_000)])
+    batch = dict(cell_filter_batch)
+    out = pipeline(batch)
+    n_kept = out["x_ng"].shape[0]
+    assert n_kept == 7
+    # All n-indexed tensors in the batch must have the same first dimension after pipeline
+    for key in ("batch_index_n", "total_mrna_umis_n", "categorical_covariate_index_nd"):
+        assert out[key].shape[0] == n_kept, f"{key} inconsistent after pipeline"
+
+
+def test_cell_filter_unknown_extra_tensor_filtered():
+    x_ng = torch.ones(6, 3) * 5
+    x_ng[4:] = 0.0  # rows 4-5: sum = 0, filtered out
+    my_custom_tensor_n = torch.arange(6, dtype=torch.float32).unsqueeze(1).expand(6, 2).clone()
+    batch_index_n = torch.zeros(6)
+    result = CellFilter(min_count_per_cell=1)(
+        x_ng=x_ng, batch_index_n=batch_index_n, my_custom_tensor_n=my_custom_tensor_n
+    )
+    assert result["x_ng"].shape[0] == 4
+    assert "my_custom_tensor_n" in result
+    assert result["my_custom_tensor_n"].shape[0] == 4
+
+
+def test_cell_filter_negative_threshold_raises():
+    with pytest.raises(ValueError, match="min_count_per_cell must be >= 0"):
+        CellFilter(min_count_per_cell=-1)
+
+
+def test_cell_filter_predict_mode_is_noop():
+    # _predict_mode sentinel injected by CellariumPipeline.predict() must disable filtering
+    x_ng = torch.ones(5, 3)  # all rows below threshold of 100
+    batch_index_n = torch.zeros(5)
+    result = CellFilter(min_count_per_cell=100)(x_ng=x_ng, batch_index_n=batch_index_n, _predict_mode=True)
+    assert result == {}
+
+
+def test_cell_filter_predict_mode_via_pipeline():
+    # End-to-end: pipeline.predict() injects _predict_mode; CellFilter becomes a no-op
+    # so all 5 cells survive despite being below the threshold.
+    from cellarium.ml.models.model import CellariumModel, PredictMixin
+
+    class _PassthroughModel(CellariumModel, PredictMixin):
+        def reset_parameters(self):
+            pass
+
+        def forward(self, **kwargs):
+            return {}
+
+        def predict(self, x_ng: torch.Tensor, **kwargs) -> dict:
+            return {"x_ng": x_ng}
+
+    x_ng = torch.ones(5, 3)  # row sum = 3, below threshold of 100
+    var_names_g = np.array(["g0", "g1", "g2"])
+    batch_index_n = torch.zeros(5)
+
+    pipeline = CellariumPipeline([CellFilter(min_count_per_cell=100), _PassthroughModel()])
+    batch: dict[str, dict[str, np.ndarray | torch.Tensor] | np.ndarray | torch.Tensor] = {
+        "x_ng": x_ng,
+        "var_names_g": var_names_g,
+        "batch_index_n": batch_index_n,
+    }
+    out = pipeline.predict(batch)
+    x_ng_out = out["x_ng"]
+    assert isinstance(x_ng_out, torch.Tensor)
+    assert x_ng_out.shape[0] == 5
+
+
+# ---------------------------------------------------------------------------
+# CellFilter — min_nonzero_genes_per_cell mode
+# ---------------------------------------------------------------------------
+
+
+def test_cell_filter_nonzero_genes_removes_sparse_cells():
+    # Rows 0-4: 3 nonzero genes each.  Rows 5-9: 1 nonzero gene each.
+    x_ng = torch.zeros(10, 5)
+    x_ng[:5, :3] = 1.0
+    x_ng[5:, :1] = 1.0
+    batch_index_n = torch.zeros(10)
+    result = CellFilter(min_nonzero_genes_per_cell=3)(x_ng=x_ng, batch_index_n=batch_index_n)
+    assert result["x_ng"].shape[0] == 5
+    assert result["batch_index_n"].shape[0] == 5
+
+
+def test_cell_filter_nonzero_genes_boundary():
+    # Cell 0: exactly 3 nonzero genes (kept).  Cell 1: 2 nonzero genes (dropped).
+    x_ng = torch.tensor([[1.0, 1.0, 1.0, 0.0], [1.0, 1.0, 0.0, 0.0]])
+    batch_index_n = torch.tensor([0.0, 1.0])
+    result = CellFilter(min_nonzero_genes_per_cell=3)(x_ng=x_ng, batch_index_n=batch_index_n)
+    assert result["x_ng"].shape[0] == 1
+    assert torch.equal(result["batch_index_n"], torch.tensor([0.0]))
+
+
+def test_cell_filter_nonzero_genes_zero_threshold_is_noop():
+    x_ng = torch.zeros(5, 4)
+    batch_index_n = torch.zeros(5)
+    result = CellFilter(min_nonzero_genes_per_cell=0)(x_ng=x_ng, batch_index_n=batch_index_n)
+    assert result == {}
+
+
+def test_cell_filter_both_modes_raises():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        CellFilter(min_count_per_cell=10, min_nonzero_genes_per_cell=5)
+
+
+def test_cell_filter_nonzero_genes_predict_mode_noop():
+    x_ng = torch.zeros(5, 4)  # all cells have 0 nonzero genes — would all be dropped
+    batch_index_n = torch.zeros(5)
+    result = CellFilter(min_nonzero_genes_per_cell=1)(x_ng=x_ng, batch_index_n=batch_index_n, _predict_mode=True)
+    assert result == {}


### PR DESCRIPTION
There is a possibility that after applying some arbitrary gene filtering, scVI would encounter cells with only a few counts... or even zero counts!  The upfront cell filtering we do in Nexus looks for cells with some minimal number of UMIs or nonzero genes.  But there is no guarantee this doesn't change after `Filter`ing to just 4k or 8k genes.  If we are encountering cells with extremely low UMIs during training, we should probably skip them.

OLD:
This PR introduces `min_count_per_cell_threshold` to allow us to skip such cells during training (on the fly).

EDIT:
This PR introduces the `CellFilter` `Transform` which can eliminate cells from a minibatch on the fly.  It can be used with any model.  It cannot be used with the contrastive learning model (due to shape expectations).