### PR TITLE
scvi: implement SwiGLU and ResNet as options

### DIFF
--- a/cellarium/ml/layers/__init__.py
+++ b/cellarium/ml/layers/__init__.py
@@ -8,11 +8,12 @@ from cellarium.ml.layers.head import MultiHeadReadout
 from cellarium.ml.layers.mu_linear import MuLinear
 from cellarium.ml.layers.normadd import NormAdd
 from cellarium.ml.layers.transformer import Transformer, TransformerBlock
-from cellarium.ml.layers.vae import DressedLayer, FullyConnectedLinear
+from cellarium.ml.layers.vae import DressedLayer, FullyConnectedLinear, SwiGLUActivation
 
 __all__ = [
     "DressedLayer",
     "FullyConnectedLinear",
+    "SwiGLUActivation",
     "TokenEmbedding",
     "MuLinear",
     "MultiHeadAttention",

--- a/cellarium/ml/layers/vae.py
+++ b/cellarium/ml/layers/vae.py
@@ -1,9 +1,27 @@
 # Copyright Contributors to the Cellarium project.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from typing import Any, Type
 
 import torch
+
+
+class SwiGLUActivation(torch.nn.Module):
+    """
+    Stateless SwiGLU gated activation.
+
+    Chunks the input in half along the last dimension and returns
+    ``x_val * F.silu(gate)``. When used as ``activation_fn`` in
+    :class:`DressedLayer`, the upstream linear layer should produce
+    ``2 × inner_dim`` outputs; :class:`~cellarium.ml.models.scvi.FullyConnectedWithBatchArchitecture`
+    handles this automatically when ``out_features`` is set to the desired
+    post-gating width.
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_val, gate = x.chunk(2, dim=-1)
+        return x_val * torch.nn.functional.silu(gate)
 
 
 class DressedLayer(torch.nn.Module):
@@ -29,6 +47,9 @@ class DressedLayer(torch.nn.Module):
         use_layer_norm: whether to use layer normalization
         activation_fn: the activation function to use
         dropout_rate: dropout rate, can be zero
+        use_residual: if ``True``, adds the input as a residual when the output shape matches the
+            input shape. Silently disabled when shapes differ (e.g. dimension-changing layers).
+            Intended for constant-width hidden stacks.
     """
 
     def __init__(
@@ -40,6 +61,7 @@ class DressedLayer(torch.nn.Module):
         layer_norm_kwargs: dict | None = None,
         activation_fn: Type[torch.nn.Module] | None = torch.nn.ReLU,
         dropout_rate: float = 0,
+        use_residual: bool = False,
     ):
         if batch_norm_kwargs is None:
             batch_norm_kwargs = {"momentum": 0.01, "eps": 0.001}
@@ -57,14 +79,28 @@ class DressedLayer(torch.nn.Module):
         dropout = torch.nn.Dropout(p=dropout_rate) if dropout_rate > 0 else None
         module_list = [batch_norm, layer_norm, activation, dropout]
         self.layer = layer
+        self.use_residual = use_residual
+        self.out_features = out_features // 2 if (activation_fn is SwiGLUActivation) else out_features
+        if use_residual:
+            in_features = getattr(layer, "in_features", None)
+            if in_features is not None and in_features != self.out_features:
+                warnings.warn(
+                    f"use_residual=True but in_features={in_features} != out_features={self.out_features}; "
+                    "residual connection will be disabled for this layer.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         self.dressing = torch.nn.Sequential(*[m for m in module_list if m is not None])
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
         """
         Computes the forward pass of the block.
         """
-        x = self.layer(*args, **kwargs)
-        return self.dressing(x)
+        residual = args[0]
+        h = self.dressing(self.layer(*args, **kwargs))
+        if self.use_residual and h.shape == residual.shape:
+            h = h + residual
+        return h
 
 
 class FullyConnectedLinear(torch.nn.Module):

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -19,7 +19,7 @@ from torch.distributions import Distribution, Normal, Poisson
 from torch.distributions import kl_divergence as kl
 
 from cellarium.ml.distributions import NegativeBinomial
-from cellarium.ml.layers import DressedLayer, FullyConnectedLinear
+from cellarium.ml.layers import DressedLayer, FullyConnectedLinear, SwiGLUActivation
 from cellarium.ml.models.model import CellariumModel, PredictMixin, ValidateMixin
 from cellarium.ml.utilities.data import categories_to_product_codes
 from cellarium.ml.utilities.testing import (
@@ -198,24 +198,33 @@ class FullyConnectedWithBatchArchitecture(torch.nn.Module):
             out_features = in_features
         else:
             module_list = torch.nn.ModuleList()
-            n_hidden = [layer["init_args"].get("out_features") for layer in layers]
-            for layer, n_in, n_out in zip(layers, [in_features] + n_hidden, n_hidden):
-                layer["init_args"]["out_features"] = n_out
+            current_in = in_features
+            for layer_spec in layers:
+                init_args = {**layer_spec["init_args"]}
+                dressing_init_args = {**layer_spec["dressing_init_args"]}
+                # Resolve string activation_fn to a class (supports YAML/CLI class-path strings)
+                activation_fn_val = dressing_init_args.get("activation_fn")
+                if isinstance(activation_fn_val, str):
+                    dressing_init_args["activation_fn"] = class_from_class_path(activation_fn_val)
+                    activation_fn_val = dressing_init_args["activation_fn"]
+                # Double out_features for SwiGLU so chunking yields the user-configured effective output
+                if activation_fn_val is SwiGLUActivation:
+                    init_args["out_features"] = init_args["out_features"] * 2
                 module_list.append(
                     DressedLayer(
                         instantiate_from_class_path(
-                            layer["class_path"],
-                            in_features=n_in,
+                            layer_spec["class_path"],
+                            in_features=current_in,
                             bias=True,
-                            **layer["init_args"],
+                            **init_args,
                         ),
-                        **layer["dressing_init_args"],
+                        **dressing_init_args,
                     )
                 )
-            assert hasattr(module_list[-1].layer, "out_features") and isinstance(
-                module_list[-1].layer.out_features, int
-            )
-            out_features = module_list[-1].layer.out_features
+                assert isinstance(module_list[-1], torch.nn.Module)
+                assert isinstance(module_list[-1].out_features, int)
+                current_in = module_list[-1].out_features
+            out_features = current_in
         self.module_list = module_list
         self.out_features = out_features
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -772,6 +772,104 @@ SINGLE_DEVICE_CONFIGS = [
         },
     },
     {
+        "model_name": "scvi",
+        "_display_id": "scvi_swiglu_resnet",
+        "subcommand": "fit",
+        "fit": {
+            "model": {
+                "model": {
+                    "class_path": "cellarium.ml.models.SingleCellVariationalInference",
+                    "init_args": {
+                        "n_batch": None,
+                        "use_size_factor_key": False,
+                        "use_batch_norm": "none",
+                        "use_layer_norm": "both",
+                        "encoder": {
+                            "hidden_layers": [
+                                {
+                                    "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                                    "init_args": {"out_features": 32, "label_to_bias_hidden_layers": []},
+                                    "dressing_init_args": {
+                                        "activation_fn": "cellarium.ml.layers.SwiGLUActivation",
+                                    },
+                                },
+                                {
+                                    "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                                    "init_args": {"out_features": 32, "label_to_bias_hidden_layers": []},
+                                    "dressing_init_args": {
+                                        "activation_fn": "cellarium.ml.layers.SwiGLUActivation",
+                                        "use_residual": True,
+                                    },
+                                },
+                            ],
+                            "final_layer": {
+                                "class_path": "torch.nn.Linear",
+                                "init_args": {},
+                            },
+                            "output_bias": True,
+                        },
+                        "decoder": {
+                            "hidden_layers": [
+                                {
+                                    "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                                    "init_args": {"out_features": 64, "label_to_bias_hidden_layers": []},
+                                    "dressing_init_args": {
+                                        "activation_fn": "cellarium.ml.layers.SwiGLUActivation",
+                                    },
+                                },
+                                {
+                                    "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                                    "init_args": {"out_features": 64, "label_to_bias_hidden_layers": []},
+                                    "dressing_init_args": {
+                                        "activation_fn": "cellarium.ml.layers.SwiGLUActivation",
+                                        "use_residual": True,
+                                    },
+                                },
+                            ],
+                            "final_layer": {
+                                "class_path": "torch.nn.Linear",
+                                "init_args": {},
+                            },
+                            "final_additive_bias": False,
+                        },
+                    },
+                },
+                "optim_fn": "torch.optim.Adam",
+                "optim_kwargs": {"lr": "1e-3"},
+            },
+            "data": {
+                "dadc": {
+                    "class_path": "cellarium.ml.data.DistributedAnnDataCollection",
+                    "init_args": {
+                        "filenames": "https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_{0..1}.h5ad",
+                        "shard_size": "100",
+                        "max_cache_size": "2",
+                        "obs_columns_to_validate": [],
+                    },
+                },
+                "batch_keys": {
+                    "x_ng": {
+                        "attr": "X",
+                        "convert_fn": "cellarium.ml.utilities.data.densify",
+                    },
+                    "var_names_g": {"attr": "var_names"},
+                    "batch_index_n": {
+                        "attr": "obs",
+                        "key": "dataset_id",
+                        "convert_fn": "cellarium.ml.utilities.data.categories_to_codes",
+                    },
+                },
+                "batch_size": "50",
+                "num_workers": "0",
+            },
+            "trainer": {
+                "accelerator": "cpu",
+                "devices": devices,
+                "max_epochs": 3,
+            },
+        },
+    },
+    {
         "model_name": "socam",
         "subcommand": "fit",
         "fit": {

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -18,6 +18,7 @@ from lightning.pytorch.strategies import DDPStrategy
 
 from cellarium.ml import CellariumAnnDataDataModule, CellariumModule
 from cellarium.ml.data.fileio import read_h5ad_file
+from cellarium.ml.layers import SwiGLUActivation
 from cellarium.ml.models import SingleCellVariationalInference
 from cellarium.ml.models.scvi import DecoderSCVI, EncoderSCVI
 from cellarium.ml.utilities.data import AnnDataField, categories_to_codes, collate_fn, densify
@@ -376,6 +377,81 @@ def test_vae_architectures():
             inverse_overdispersion=model.px_r.exp(),
             library_size_n1=batch["x_ng"].float().sum(dim=-1, keepdim=True),
         )
+
+
+def test_swiglu_resnet_encoder():
+    g = len(var_names_g)  # 10
+    hidden_dim = 32
+
+    # use_residual=True with mismatched dims should emit a UserWarning
+    mismatch_kwargs = copy.deepcopy(standard_kwargs)
+    mismatch_kwargs["encoder"] = {
+        **linear_encoder_kwargs,
+        "hidden_layers": [
+            {
+                "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                "init_args": {"out_features": hidden_dim, "label_to_bias_hidden_layers": []},
+                "dressing_init_args": {"activation_fn": SwiGLUActivation, "use_residual": True},
+            },
+        ],
+    }
+    with pytest.warns(UserWarning, match="residual connection will be disabled"):
+        SingleCellVariationalInference(**mismatch_kwargs)
+
+    # Good config: expanding first layer (no residual) + constant-width second layer (residual)
+    good_kwargs = copy.deepcopy(standard_kwargs)
+    good_kwargs["encoder"] = {
+        **linear_encoder_kwargs,
+        "hidden_layers": [
+            {
+                "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                "init_args": {"out_features": hidden_dim, "label_to_bias_hidden_layers": []},
+                "dressing_init_args": {"activation_fn": SwiGLUActivation},
+            },
+            {
+                "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                "init_args": {"out_features": hidden_dim, "label_to_bias_hidden_layers": []},
+                "dressing_init_args": {"activation_fn": SwiGLUActivation, "use_residual": True},
+            },
+        ],
+    }
+    model = SingleCellVariationalInference(**good_kwargs)
+
+    # Structural assertions
+    fc = model.z_encoder.fully_connected
+    layer0, layer1 = fc.module_list[0], fc.module_list[1]
+
+    # layer0: expanding (g -> hidden_dim), inner linear doubled, no residual
+    assert isinstance(layer0.layer, torch.nn.Module)
+    assert layer0.layer.in_features == g
+    assert layer0.layer.out_features == 2 * hidden_dim
+    assert layer0.out_features == hidden_dim
+    assert not layer0.use_residual
+
+    # layer1: constant-width (hidden_dim -> hidden_dim), inner linear doubled, residual active
+    assert isinstance(layer1.layer, torch.nn.Module)
+    assert layer1.layer.in_features == hidden_dim
+    assert layer1.layer.out_features == 2 * hidden_dim
+    assert layer1.out_features == hidden_dim
+    assert layer1.use_residual
+
+    assert fc.out_features == hidden_dim
+
+    # Forward pass smoke test
+    n = 8
+    x_ng = torch.from_numpy(np.random.poisson(lam=2.0, size=(n, g))).float()
+    batch_index_n = torch.randint(0, standard_kwargs["n_batch"], (n,))
+
+    output = model(
+        x_ng=x_ng,
+        var_names_g=np.array(var_names_g),
+        batch_index_n=batch_index_n,
+    )
+    assert isinstance(output["loss"], torch.Tensor)
+    assert output["loss"].shape == ()
+    assert torch.isfinite(output["loss"])
+    assert isinstance(output["z_nk"], torch.Tensor)
+    assert output["z_nk"].shape == (n, standard_kwargs["n_latent"])
 
 
 def compute_neighbor_accuracy(


### PR DESCRIPTION
When training scVI at "foundation model" scale (i.e. all of cellxgene), it might be beneficial to have the option to beef up the capacity of the encoder and decoder networks.  They do have to learn 10k+ batch effects after all.  Typically vanilla MLPs are fine for several-dataset level integration that people typically do with scvi-tools.  But the kind of thing we're doing may actually benefit from more capacity.  Remains to be seen.

Anyway, this implements `SwiGLUActivation` (which is a real cool, powerful activation function), and the ResNet block idea, where `DressedLayer` dressing is allowed to add the input back to the output of a same-size-input-and-output layer.  This might allow for constant-width layers 5 or 6 blocks deep.  Again, remains to be seen if scVI likes it.

The SwiGLU activation function is weird because it halves the feature size when it acts.  So this has to be taken into account at layer shape construction size, and actually the thing right before the SwiGLU gets automatically doubled in out_features size, so that when SwiGLU halves it, we get what we wanted.