### PR TITLE
scANVI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ output/
 *.tsv.gz
 *.ckpt
 CLAUDE.md
+benchmarking/

--- a/cellarium/ml/callbacks/compute_norm.py
+++ b/cellarium/ml/callbacks/compute_norm.py
@@ -43,7 +43,8 @@ class ComputeNorm(pl.Callback):
         ):
             assert trainer.strategy.model is not None
             # Sum all local norms to get the total norm
-            dist.all_reduce(param_norm_sq, op=dist.ReduceOp.SUM, group=trainer.strategy.model.process_group)
+            process_group: dist.ProcessGroup = trainer.strategy.model.process_group  # type: ignore[assignment]
+            dist.all_reduce(param_norm_sq, op=dist.ReduceOp.SUM, group=process_group)
 
         pl_module.log("model_wise_param_norm", torch.sqrt(param_norm_sq).item(), rank_zero_only=True)
 
@@ -75,11 +76,10 @@ class ComputeNorm(pl.Callback):
         ):
             assert trainer.strategy.model is not None
             # Sum all local norms to get the total norm
-            dist.all_reduce(model_wise_grad_norm_sq, op=dist.ReduceOp.SUM, group=trainer.strategy.model.process_group)
+            process_group: dist.ProcessGroup = trainer.strategy.model.process_group  # type: ignore[assignment]
+            dist.all_reduce(model_wise_grad_norm_sq, op=dist.ReduceOp.SUM, group=process_group)
             for layer_id in per_layer_grad_norm_sq:
-                dist.all_reduce(
-                    per_layer_grad_norm_sq[layer_id], op=dist.ReduceOp.SUM, group=trainer.strategy.model.process_group
-                )
+                dist.all_reduce(per_layer_grad_norm_sq[layer_id], op=dist.ReduceOp.SUM, group=process_group)
 
         pl_module.log("model_wise_grad_norm", torch.sqrt(model_wise_grad_norm_sq).item(), rank_zero_only=True)
         if per_layer_grad_norm_sq:

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -604,25 +604,27 @@ def compute_cl_name_subset(data: CellariumAnnDataDataModule) -> list[str]:
 
 
 def compute_cell_type_categories(data: CellariumAnnDataDataModule) -> list[str] | None:
-    """Derive ``cell_type_categories`` from the ``validation_cell_type_index_n`` batch key.
+    """Derive ``cell_type_categories`` from a cell-type label batch key.
 
     Reads the pandas Categorical from the first shard and returns its categories as a plain
     list of strings, in the same order as ``.cat.categories`` (which matches ``.cat.codes``).
-    Returns ``None`` when the batch key is absent so that validation metrics are simply skipped.
+    Prefers the ``cell_type_labels_n`` key (SCANVI string labels) and falls back to
+    ``validation_cell_type_index_n`` (scVI validation metrics). Returns ``None`` when neither
+    key is configured so that the value can be supplied explicitly or metrics simply skipped.
 
     Args:
         data: A :class:`CellariumAnnDataDataModule` instance.
 
     Returns:
-        Ordered list of CL ID strings, or ``None`` if the batch key is not configured.
+        Ordered list of category strings, or ``None`` if no label key is configured.
     """
-    if "validation_cell_type_index_n" not in data.batch_keys:
+    key = next((k for k in ("cell_type_labels_n", "validation_cell_type_index_n") if k in data.batch_keys), None)
+    if key is None:
         return None
-    field = data.batch_keys["validation_cell_type_index_n"]
+    field = data.batch_keys[key]
     assert isinstance(field, AnnDataField)
     obs = getattr(data.dadc[0], field.attr)
-    series = obs[field.key]
-    return list(series.cat.categories)
+    return list(obs[field.key].cat.categories)
 
 
 def lightning_cli_factory(
@@ -1109,9 +1111,12 @@ def scanvi(args: ArgsType = None) -> None:
             --trainer.default_root_dir runs/scanvi \
             --trainer.max_steps 10
 
-    ``n_classes`` must be set manually in the config to match the number of annotated
-    cell types in the training data.  When ``cell_type_categories`` is provided it must
-    have the same length as ``n_classes``.
+    Cell-type labels are provided as strings via the ``cell_type_labels_n`` batch key (cells
+    equal to ``unlabeled_category``, default ``"unknown"``, are unlabeled). In the default
+    ``classifier_type="flat"`` mode, ``cell_type_categories`` (the class partition) is linked
+    automatically from that key. For ``classifier_type="ontology"`` provide ``descendant_tensor``,
+    ``cl_names``, and ``class_counts`` (e.g. via the OWL helpers in
+    :mod:`cellarium.ml.utilities.data`).
 
     **References:**
 

--- a/cellarium/ml/cli.py
+++ b/cellarium/ml/cli.py
@@ -1090,6 +1090,61 @@ def scvi(args: ArgsType = None) -> None:
 
 
 @register_model
+def scanvi(args: ArgsType = None) -> None:
+    r"""
+    CLI to run the :class:`cellarium.ml.models.SCANVI` model.
+
+    This example shows how to fit semi-supervised scANVI to single-cell RNA-seq data.
+
+    Example run::
+
+        cellarium-ml scanvi fit \
+            --data.filenames "gs://dsp-cellarium-cas-public/test-data/test_{0..3}.h5ad" \
+            --data.shard_size 100 \
+            --data.max_cache_size 2 \
+            --data.batch_size 5 \
+            --data.num_workers 1 \
+            --trainer.accelerator gpu \
+            --trainer.devices 1 \
+            --trainer.default_root_dir runs/scanvi \
+            --trainer.max_steps 10
+
+    ``n_classes`` must be set manually in the config to match the number of annotated
+    cell types in the training data.  When ``cell_type_categories`` is provided it must
+    have the same length as ``n_classes``.
+
+    **References:**
+
+    1. `Probabilistic harmonization and annotation of single-cell transcriptomics data
+       with deep generative models (Xu et al., 2021)
+       <https://doi.org/10.15252/msb.20209620>`_.
+
+    Args:
+        args: Arguments to parse. If ``None`` the arguments are taken from ``sys.argv``.
+    """
+    link_arguments = [
+        LinkArguments(
+            ("model.cpu_transforms", "model.transforms", "data"),
+            "model.model.init_args.var_names_g",
+            compute_var_names_g,
+        ),
+    ]
+    if not os.environ.get("SCVI_PREDICT_SKIP_ARG_LINKING"):
+        link_arguments.extend(
+            [
+                LinkArguments("data", "model.model.init_args.n_batch", compute_batch_index_n_categories),
+                LinkArguments("data", "model.model.init_args.n_cats_per_cov", compute_n_cats_per_cov),
+                LinkArguments("data", "model.model.init_args.cell_type_categories", compute_cell_type_categories),
+            ]
+        )
+    cli = lightning_cli_factory(
+        "cellarium.ml.models.SCANVI",
+        link_arguments=link_arguments,
+    )
+    cli(args=args)
+
+
+@register_model
 def tdigest(args: ArgsType = None) -> None:
     r"""
     CLI to run the :class:`cellarium.ml.models.TDigest` model.

--- a/cellarium/ml/models/__init__.py
+++ b/cellarium/ml/models/__init__.py
@@ -10,6 +10,7 @@ from cellarium.ml.models.logistic_regression import LogisticRegression
 from cellarium.ml.models.model import CellariumModel, PredictMixin, TestMixin, ValidateMixin
 from cellarium.ml.models.onepass_mean_var_std import OnePassMeanVarStd
 from cellarium.ml.models.probabilistic_pca import ProbabilisticPCA
+from cellarium.ml.models.scanvi import SCANVI
 from cellarium.ml.models.scvi import SingleCellVariationalInference
 from cellarium.ml.models.socam import SOCAM
 from cellarium.ml.models.tdigest import TDigest
@@ -18,6 +19,7 @@ __all__ = [
     "CellariumGPT",
     "CellariumModel",
     "ContrastiveMLP",
+    "SCANVI",
     "Geneformer",
     "HVGSeuratV3",
     "IncrementalPCA",

--- a/cellarium/ml/models/scanvi.py
+++ b/cellarium/ml/models/scanvi.py
@@ -291,6 +291,8 @@ class SCANVI(SingleCellVariationalInference):
         if scvi_kwargs.get("use_flow", False):
             raise ValueError("SCANVI does not support use_flow=True.")
 
+        # Propagate compile flag to scVI so encoder + decoder are also compiled.
+        scvi_kwargs["use_torch_compile"] = use_torch_compile
         super().__init__(**scvi_kwargs)
 
         if classifier_n_hidden is None:

--- a/cellarium/ml/models/scanvi.py
+++ b/cellarium/ml/models/scanvi.py
@@ -1,0 +1,615 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""scANVI: Single-cell Annotation using Variational Inference."""
+
+import lightning.pytorch as pl
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.distributions import Categorical, Normal
+from torch.distributions import kl_divergence as kl
+
+from cellarium.ml.layers import DressedLayer, FullyConnectedLinear
+from cellarium.ml.models.scvi import (
+    SingleCellVariationalInference,
+    compute_annealed_kl_weight,
+    weights_init,
+)
+from cellarium.ml.utilities.testing import (
+    assert_arrays_equal,
+    assert_columns_and_array_lengths_equal,
+)
+
+
+class ConditionalNormalEncoder(torch.nn.Module):
+    """Encode concatenated [z, one_hot(c)] to a Normal distribution.
+
+    Expects 2D input ``[N, in_features]``. The caller is responsible for reshaping
+    3D inputs ``[N, chunk, in_features]`` to ``[N*chunk, in_features]`` before calling
+    and reshaping the output back.
+
+    Args:
+        in_features: Input dimensionality (typically ``n_latent + n_classes``).
+        out_features: Output (latent) dimensionality.
+        n_hidden: Widths of hidden layers. Empty list gives a single linear layer.
+        use_batch_norm: Whether to apply ``BatchNorm1d`` in hidden layers.
+        dropout_rate: Dropout rate in hidden layers.
+        var_eps: Floor added to the variance for numerical stability.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        n_hidden: list[int],
+        use_batch_norm: bool = True,
+        dropout_rate: float = 0.0,
+        var_eps: float = 1e-4,
+    ):
+        super().__init__()
+        self.var_eps = var_eps
+
+        trunk_layers: list[torch.nn.Module] = []
+        current_in = in_features
+        for h in n_hidden:
+            trunk_layers.append(
+                DressedLayer(
+                    torch.nn.Linear(current_in, h),
+                    use_batch_norm=use_batch_norm,
+                    dropout_rate=dropout_rate,
+                )
+            )
+            current_in = h
+
+        self.trunk = torch.nn.Sequential(*trunk_layers) if trunk_layers else torch.nn.Identity()
+        self.mean_head = torch.nn.Linear(current_in, out_features, bias=True)
+        self.log_var_head = torch.nn.Linear(current_in, out_features, bias=True)
+
+    def forward(self, x: torch.Tensor) -> Normal:
+        h = self.trunk(x)
+        mean = self.mean_head(h)
+        log_var = self.log_var_head(h)
+        return Normal(mean, (log_var.exp() + self.var_eps).sqrt())
+
+
+class SCANVI(SingleCellVariationalInference):
+    """Single-cell ANnotation using Variational Inference (scANVI) [1].
+
+    Extends scVI with a hierarchical prior on the latent variable ``z``:
+
+    .. math::
+
+        c \\sim p(c), \\quad u \\sim \\mathcal{N}(0, I),
+        \\quad z \\sim p(z \\mid u, c), \\quad x \\sim p(x \\mid z, s)
+
+    The encoder ``q(z|x)`` is identical to scVI. Three new networks are added:
+
+    * **Classifier** ``q(c|z)``: predicts cell-type probabilities from ``z``.
+    * **u-encoder** ``q(u|z,c)``: encodes a deeper latent ``u`` given ``z`` and cell type ``c``.
+    * **z-prior decoder** ``p(z|u,c)``: provides the class-conditional prior on ``z``.
+
+    For labeled cells the ELBO is maximized using the known cell type together with an
+    auxiliary cross-entropy classification term.  For unlabeled cells the cell-type
+    expectation is marginalized in chunks to control peak VRAM.
+
+    .. note::
+
+        At large ``n_classes`` (> ~500) the one-hot encoding of ``c`` dominates the input
+        to the secondary networks.  A learned cell-type embedding is a planned extension.
+
+    **References:**
+
+    1. `Probabilistic harmonization and annotation of single-cell transcriptomics data
+       with deep generative models (Xu et al., 2021)
+       <https://doi.org/10.15252/msb.20209620>`_.
+
+    Args:
+        n_classes:
+            Number of annotated cell-type classes.
+        unlabeled_category_index:
+            Integer code used to mark unlabeled cells in ``cell_type_index_n``. Default ``-1``.
+        classification_weight:
+            Weight ``α`` applied to the cross-entropy loss on labeled cells.
+        chunk_size:
+            Number of classes processed per chunk during the unlabeled forward pass.
+            Reduce this to lower peak VRAM at the cost of slightly more computation.
+        classifier_n_hidden:
+            Hidden layer widths for the classifier ``q(c|z)`` MLP.
+            Defaults to ``[128]`` (one hidden layer, matching scvi-tools).
+        classifier_dropout_rate:
+            Dropout rate in classifier hidden layers.
+        secondary_n_hidden:
+            Hidden layer widths shared by the u-encoder ``q(u|z,c)`` and the
+            z-prior decoder ``p(z|u,c)``. Defaults to ``[128]``.
+        y_prior_probs:
+            Prior probabilities over cell types ``p(c)``.  Must sum to 1 and have length
+            ``n_classes``. If ``None`` a uniform prior is used.
+        **scvi_kwargs:
+            All keyword arguments accepted by
+            :class:`~cellarium.ml.models.SingleCellVariationalInference`.
+    """
+
+    def __init__(
+        self,
+        n_classes: int,
+        unlabeled_category_index: int = -1,
+        classification_weight: float = 50.0,
+        chunk_size: int = 100,
+        classifier_n_hidden: list[int] | None = None,
+        classifier_dropout_rate: float = 0.1,
+        secondary_n_hidden: list[int] | None = None,
+        y_prior_probs: list[float] | None = None,
+        **scvi_kwargs,
+    ):
+        if scvi_kwargs.get("use_flow", False):
+            raise ValueError("SCANVI does not support use_flow=True.")
+
+        super().__init__(**scvi_kwargs)
+
+        if classifier_n_hidden is None:
+            classifier_n_hidden = [128]
+        if secondary_n_hidden is None:
+            secondary_n_hidden = [128]
+
+        self.n_classes = n_classes
+        self.unlabeled_category_index = unlabeled_category_index
+        self.classification_weight = classification_weight
+        self.chunk_size = chunk_size
+
+        # Verify n_classes is consistent with cell_type_categories when provided
+        cell_type_categories = scvi_kwargs.get("cell_type_categories")
+        if cell_type_categories is not None and len(cell_type_categories) != n_classes:
+            raise ValueError(
+                f"n_classes={n_classes} does not match len(cell_type_categories)={len(cell_type_categories)}."
+            )
+
+        # q(c|z): MLP classifier from latent space to cell-type logits
+        self.cell_type_classifier = FullyConnectedLinear(
+            in_features=self.n_latent,
+            out_features=n_classes,
+            n_hidden=classifier_n_hidden,
+            dressing_init_kwargs={"use_batch_norm": True, "dropout_rate": classifier_dropout_rate},
+            bias=True,
+        )
+
+        # q(u|z,c): encodes the deeper latent u given z and cell type
+        self.u_encoder = ConditionalNormalEncoder(
+            in_features=self.n_latent + n_classes,
+            out_features=self.n_latent,
+            n_hidden=secondary_n_hidden,
+        )
+
+        # p(z|u,c): class-conditional prior on z, parameterized by u and cell type
+        self.z_prior_decoder = ConditionalNormalEncoder(
+            in_features=self.n_latent + n_classes,
+            out_features=self.n_latent,
+            n_hidden=secondary_n_hidden,
+        )
+
+        # Prior over cell types p(c); uniform by default
+        if y_prior_probs is not None:
+            y_prior = torch.tensor(y_prior_probs, dtype=torch.float32)
+            y_prior = y_prior / y_prior.sum()
+        else:
+            y_prior = torch.ones(n_classes, dtype=torch.float32) / n_classes
+        self.register_buffer("y_prior", y_prior)
+
+        # Initialize new modules (parent's reset_parameters() ran before these existed)
+        self.cell_type_classifier.apply(weights_init)
+        self.u_encoder.apply(weights_init)
+        self.z_prior_decoder.apply(weights_init)
+
+    # ------------------------------------------------------------------
+    # Internal helper
+    # ------------------------------------------------------------------
+
+    def _compute_conditional_kls(
+        self,
+        z: torch.Tensor,
+        qz_mean: torch.Tensor,
+        qz_std: torch.Tensor,
+        c_onehot: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute ``KL(q(z|x) || p(z|u,c))`` and ``KL(q(u|z,c) || N(0,I))`` for cell-class pairs.
+
+        All inputs must be 2D: ``[N, ...]``.  The caller reshapes from 3D when batching over
+        the class dimension.
+
+        Args:
+            z: Latent sample from ``q(z|x)``, shape ``[N, n_latent]``.
+            qz_mean: Mean of ``q(z|x)``, shape ``[N, n_latent]``.
+            qz_std: Std of ``q(z|x)``, shape ``[N, n_latent]``.
+            c_onehot: One-hot cell-type encoding, shape ``[N, n_classes]``.
+
+        Returns:
+            ``kl_z``: ``[N]`` tensor — KL divergence for z.
+            ``kl_u``: ``[N]`` tensor — KL divergence for u.
+        """
+        zc = torch.cat([z, c_onehot], dim=-1)
+        qu = self.u_encoder(zc)
+        u = qu.rsample()
+
+        uc = torch.cat([u, c_onehot], dim=-1)
+        pz = self.z_prior_decoder(uc)
+
+        qz = Normal(qz_mean, qz_std)
+        pu = Normal(torch.zeros_like(u), torch.ones_like(u))
+
+        kl_z = kl(qz, pz).sum(dim=-1)
+        kl_u = kl(qu, pu).sum(dim=-1)
+        return kl_z, kl_u
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+
+    def forward(
+        self,
+        x_ng: torch.Tensor,
+        var_names_g: np.ndarray,
+        batch_index_n: torch.Tensor,
+        continuous_covariates_nc: torch.Tensor | None = None,
+        categorical_covariate_index_nd: torch.Tensor | None = None,
+        total_mrna_umis_n: torch.Tensor | None = None,
+        cell_type_index_n: torch.Tensor | None = None,
+    ) -> dict:
+        """Compute scANVI ELBO and auxiliary classification loss.
+
+        Args:
+            x_ng: Gene counts matrix ``[N, G]``.
+            var_names_g: Variable names for input validation.
+            batch_index_n: Integer batch indices ``[N]``.
+            continuous_covariates_nc: Continuous covariates ``[N, C]``.
+            categorical_covariate_index_nd: Integer categorical covariate codes ``[N, D]``.
+            total_mrna_umis_n: Total mRNA UMIs per cell (not log-scaled).
+            cell_type_index_n: Integer cell-type codes ``[N]``.  Cells with code equal to
+                ``unlabeled_category_index`` (default ``-1``) are treated as unlabeled.
+                If ``None``, all cells are treated as unlabeled.
+
+        Returns:
+            A dictionary with keys:
+                - ``"loss"``: Scalar training loss.
+                - ``"reconstruction_loss"``: Per-cell NLL ``[N]``.
+                - ``"kl_divergence_z"``: Per-cell ``KL(q(z|x) || p(z|u,c))`` ``[N]``.
+                - ``"kl_divergence_u"``: Per-cell ``KL(q(u|z,c) || N(0,I))`` ``[N]``.
+                - ``"kl_divergence_c"``: Per-cell ``KL(q(c|z) || p(c))`` (unlabeled only) ``[N]``.
+                - ``"kl_divergence_batch"``: Per-cell batch-embedding KL (if configured) ``[N]``.
+                - ``"classification_loss"``: Per-cell cross-entropy (labeled only) ``[N]``.
+                - ``"z_nk"``: Latent samples ``[N, n_latent]``.
+                - ``"cell_type_logits_nc"``: Raw classifier logits ``[N, n_classes]``.
+        """
+        assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
+        assert_arrays_equal("var_names_g", var_names_g, "var_names_g", self.var_names_g)
+
+        n = x_ng.shape[0]
+        device = x_ng.device
+
+        if cell_type_index_n is None:
+            cell_type_index_n = torch.full((n,), self.unlabeled_category_index, dtype=torch.long, device=device)
+
+        batch_nb = self.batch_representation_from_batch_index(batch_index_n)
+        categorical_covariate_np = self.categorical_onehot_from_categorical_index(categorical_covariate_index_nd)
+
+        if self.use_size_factor_key:
+            assert total_mrna_umis_n is not None, "total_mrna_umis_n required when use_size_factor_key=True"
+            library_size_n1 = torch.log(total_mrna_umis_n).unsqueeze(-1)
+        else:
+            library_size_n1 = torch.log(x_ng.sum(dim=-1, keepdim=True))
+
+        if self.input_gene_dropout_rate > 0.0:
+            with torch.no_grad():
+                dropout_mask_ng = torch.rand_like(x_ng) > self.input_gene_dropout_rate
+                inference_input_x_ng = x_ng * dropout_mask_ng
+        else:
+            inference_input_x_ng = x_ng
+
+        # --- scVI encoder q(z|x) and decoder p(x|z) — unchanged from parent ---
+        inference_outputs = self.inference(
+            x_ng=inference_input_x_ng,
+            batch_nb=batch_nb,
+            continuous_covariates_nc=continuous_covariates_nc,
+            categorical_covariate_np=categorical_covariate_np,
+        )
+        generative_outputs = self.generative(
+            z_nk=inference_outputs["z"],
+            library_size_n1=library_size_n1,
+            batch_nb=batch_nb,
+            continuous_covariates_nc=continuous_covariates_nc,
+            categorical_covariate_np=categorical_covariate_np,
+        )
+
+        z = inference_outputs["z"]  # [N, n_latent]
+        qz = inference_outputs["qz"]  # Normal with batch_shape [N, n_latent]
+        qz_mean = qz.mean  # [N, n_latent]
+        qz_std = qz.stddev  # [N, n_latent]
+
+        rec_loss_n = -generative_outputs["px"].log_prob(x_ng).sum(dim=-1)  # [N]
+
+        # KL annealing weight — applied to kl_z and kl_u only, per user spec
+        kl_annealing_weight = compute_annealed_kl_weight(
+            epoch=self.epoch,
+            step=self.step,
+            n_epochs_kl_warmup=self.kl_warmup_epochs,
+            n_steps_kl_warmup=self.kl_warmup_steps,
+            max_kl_weight=1.0,
+            min_kl_weight=self.kl_annealing_start,
+        )
+
+        # Optional batch-embedding KL (inherited from scVI; annealed with kl_z/kl_u)
+        kl_divergence_batch_n = torch.zeros(n, device=device)
+        if self.batch_representation_sampled and (self.batch_kl_weight_max > 0):
+            kl_divergence_batch_n = kl(
+                self.batch_embedding_distribution(batch_index_n=batch_index_n),
+                Normal(torch.zeros_like(batch_nb), torch.ones_like(batch_nb)),
+            ).sum(dim=1)
+
+        # --- Classifier q(c|z): use qz.mean for stability ---
+        logits_nc = self.cell_type_classifier(qz_mean)  # [N, n_classes]
+        probs_nc = F.softmax(logits_nc, dim=-1)  # [N, n_classes]
+
+        # --- Labeled / unlabeled split ---
+        labeled_mask = cell_type_index_n != self.unlabeled_category_index
+        unlabeled_mask = ~labeled_mask
+
+        kl_z_n = torch.zeros(n, device=device)
+        kl_u_n = torch.zeros(n, device=device)
+        kl_c_n = torch.zeros(n, device=device)
+        ce_loss_n = torch.zeros(n, device=device)
+
+        # --- Labeled cells: use known class, add cross-entropy loss ---
+        if labeled_mask.any():
+            idx_lab = labeled_mask.nonzero(as_tuple=True)[0]
+            true_labels = cell_type_index_n[idx_lab]  # [N_lab]
+            c_true = F.one_hot(true_labels, self.n_classes).float()  # [N_lab, n_classes]
+
+            kl_z_lab, kl_u_lab = self._compute_conditional_kls(
+                z=z[idx_lab],
+                qz_mean=qz_mean[idx_lab],
+                qz_std=qz_std[idx_lab],
+                c_onehot=c_true,
+            )
+            kl_z_n[idx_lab] = kl_z_lab
+            kl_u_n[idx_lab] = kl_u_lab
+            ce_loss_n[idx_lab] = F.cross_entropy(logits_nc[idx_lab], true_labels, reduction="none")
+
+        # --- Unlabeled cells: marginalize over classes in chunks ---
+        if unlabeled_mask.any():
+            idx_unl = unlabeled_mask.nonzero(as_tuple=True)[0]
+            n_unl = idx_unl.shape[0]
+
+            z_unl = z[idx_unl]  # [N_unl, n_latent]
+            qz_mean_unl = qz_mean[idx_unl]  # [N_unl, n_latent]
+            qz_std_unl = qz_std[idx_unl]  # [N_unl, n_latent]
+            probs_unl = probs_nc[idx_unl]  # [N_unl, n_classes]
+
+            kl_z_sum = torch.zeros(n_unl, device=device)
+            kl_u_sum = torch.zeros(n_unl, device=device)
+
+            for start in range(0, self.n_classes, self.chunk_size):
+                end = min(start + self.chunk_size, self.n_classes)
+                chunk = end - start
+
+                # One-hot vectors for this chunk's classes: [chunk, n_classes]
+                c_chunk = F.one_hot(torch.arange(start, end, device=device), self.n_classes).float()
+
+                # Expand to [N_unl, chunk, ...]
+                c_expanded = c_chunk.unsqueeze(0).expand(n_unl, -1, -1)  # [N_unl, chunk, n_classes]
+                z_expanded = z_unl.unsqueeze(1).expand(-1, chunk, -1)  # [N_unl, chunk, n_latent]
+                qz_mean_exp = qz_mean_unl.unsqueeze(1).expand(-1, chunk, -1)  # [N_unl, chunk, n_latent]
+                qz_std_exp = qz_std_unl.unsqueeze(1).expand(-1, chunk, -1)  # [N_unl, chunk, n_latent]
+
+                # Reshape to 2D for network forward passes (avoids BatchNorm1d shape issues)
+                nc = n_unl * chunk
+                zc_2d = torch.cat([z_expanded, c_expanded], dim=-1).reshape(nc, -1)
+                c_2d = c_expanded.reshape(nc, -1)
+
+                qu_chunk = self.u_encoder(zc_2d)  # Normal([nc, n_latent])
+                u_sample = qu_chunk.rsample()  # [nc, n_latent]
+
+                pz_chunk = self.z_prior_decoder(torch.cat([u_sample, c_2d], dim=-1))  # Normal([nc, n_latent])
+
+                qz_chunk = Normal(qz_mean_exp.reshape(nc, -1), qz_std_exp.reshape(nc, -1))
+                pu_chunk = Normal(torch.zeros_like(u_sample), torch.ones_like(u_sample))
+
+                # Per-chunk KLs, reshaped to [N_unl, chunk]
+                kl_z_chunk = kl(qz_chunk, pz_chunk).sum(dim=-1).view(n_unl, chunk)
+                kl_u_chunk = kl(qu_chunk, pu_chunk).sum(dim=-1).view(n_unl, chunk)
+
+                # Weight by predicted class probabilities and accumulate
+                probs_chunk = probs_unl[:, start:end]  # [N_unl, chunk]
+                kl_z_sum += (probs_chunk * kl_z_chunk).sum(dim=-1)
+                kl_u_sum += (probs_chunk * kl_u_chunk).sum(dim=-1)
+
+            kl_z_n[idx_unl] = kl_z_sum
+            kl_u_n[idx_unl] = kl_u_sum
+
+            # KL(q(c|z) || p(c)) for unlabeled cells — not annealed
+            kl_c_n[idx_unl] = kl(
+                Categorical(probs=probs_unl),
+                Categorical(probs=self.y_prior.unsqueeze(0).expand(n_unl, -1)),
+            )
+
+        # --- Loss assembly ---
+        loss = torch.mean(
+            rec_loss_n
+            + kl_annealing_weight
+            * (self.z_kl_weight_max * (kl_z_n + kl_u_n) + self.batch_kl_weight_max * kl_divergence_batch_n)
+            + kl_c_n
+            + self.classification_weight * ce_loss_n,
+        )
+
+        return {
+            "loss": loss,
+            "reconstruction_loss": rec_loss_n,
+            "kl_divergence_z": kl_z_n,
+            "kl_divergence_u": kl_u_n,
+            "kl_divergence_c": kl_c_n,
+            "kl_divergence_batch": kl_divergence_batch_n,
+            "classification_loss": ce_loss_n,
+            "z_nk": z,
+            "cell_type_logits_nc": logits_nc,
+        }
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        batch_idx: int,
+        x_ng: torch.Tensor,
+        var_names_g: np.ndarray,
+        batch_index_n: torch.Tensor,
+        continuous_covariates_nc: torch.Tensor | None = None,
+        categorical_covariate_index_nd: torch.Tensor | None = None,
+        total_mrna_umis_n: torch.Tensor | None = None,
+        validation_cell_type_index_n: torch.Tensor | None = None,
+        cell_type_index_n: torch.Tensor | None = None,
+    ) -> None:
+        n = x_ng.shape[0]
+
+        output = self(
+            x_ng=x_ng,
+            var_names_g=var_names_g,
+            batch_index_n=batch_index_n,
+            cell_type_index_n=cell_type_index_n,
+            continuous_covariates_nc=continuous_covariates_nc,
+            categorical_covariate_index_nd=categorical_covariate_index_nd,
+            total_mrna_umis_n=total_mrna_umis_n,
+        )
+
+        if isinstance(output["loss"], torch.Tensor):
+            pl_module.log("val_loss", output["loss"], sync_dist=True, on_epoch=True, batch_size=n)
+
+        # Full ELBO includes kl_u and kl_c (unlike base scVI)
+        kl_batch = output["kl_divergence_batch"]
+        rec_loss = output["reconstruction_loss"]
+        kl_z_val = output["kl_divergence_z"]
+        kl_u_val = output["kl_divergence_u"]
+        kl_c_val = output["kl_divergence_c"]
+        z_nk = output["z_nk"]
+        assert isinstance(kl_batch, torch.Tensor)
+        assert isinstance(rec_loss, torch.Tensor)
+        assert isinstance(kl_z_val, torch.Tensor)
+        assert isinstance(kl_u_val, torch.Tensor)
+        assert isinstance(kl_c_val, torch.Tensor)
+        assert isinstance(z_nk, torch.Tensor)
+
+        elbo_n = -(rec_loss + kl_z_val + kl_u_val + kl_c_val + kl_batch)
+        self._val_elbo_sum += elbo_n.sum().detach()
+        self._val_rec_sum += rec_loss.sum().detach()
+        self._val_n_cells += n
+
+        z_nk = z_nk.detach()
+
+        # Per-class z sums for ontology metric (uses validation labels, not training labels)
+        if validation_cell_type_index_n is not None and self.num_classes is not None:
+            idx = validation_cell_type_index_n.long()
+            self._val_z_sum_kd.index_add_(0, idx, z_nk)
+            self._val_class_count_k.index_add_(0, idx, torch.ones(n, device=x_ng.device))
+
+        # Per-batch z sums for batch silhouette metric
+        if self.n_batch > 1:
+            bidx = batch_index_n.long()
+            self._val_batch_z_sum_bk.index_add_(0, bidx, z_nk)
+            self._val_batch_z_sq_sum_b.index_add_(0, bidx, (z_nk**2).sum(dim=-1))
+            self._val_batch_count_b.index_add_(0, bidx, torch.ones(n, device=x_ng.device))
+
+        # Reservoir sampling for cell-type logistic-regression classifier
+        if validation_cell_type_index_n is not None and self.num_classes is not None:
+            if batch_idx % 2 == 0:
+                buf_z, buf_y = self._val_cl_train_z, self._val_cl_train_y
+                fill, seen = self._val_cl_train_fill, self._val_cl_train_seen
+            else:
+                buf_z, buf_y = self._val_cl_test_z, self._val_cl_test_y
+                fill, seen = self._val_cl_test_fill, self._val_cl_test_seen
+
+            rs = self.val_cell_type_classifier_reservoir_size
+            labels = validation_cell_type_index_n.long()
+
+            space = rs - fill
+            direct = min(space, n)
+            if direct > 0:
+                buf_z[fill : fill + direct] = z_nk[:direct]
+                buf_y[fill : fill + direct] = labels[:direct]
+                fill += direct
+
+            for i in range(direct, n):
+                j = int(torch.randint(0, seen + i - direct + 1, (1,)).item())
+                if j < rs:
+                    buf_z[j] = z_nk[i]
+                    buf_y[j] = labels[i]
+
+            seen += n
+            if batch_idx % 2 == 0:
+                self._val_cl_train_fill, self._val_cl_train_seen = fill, seen
+            else:
+                self._val_cl_test_fill, self._val_cl_test_seen = fill, seen
+
+    # ------------------------------------------------------------------
+    # Predict
+    # ------------------------------------------------------------------
+
+    def predict(
+        self,
+        x_ng: torch.Tensor,
+        var_names_g: np.ndarray,
+        batch_index_n: torch.Tensor,
+        continuous_covariates_nc: torch.Tensor | None = None,
+        categorical_covariate_index_nd: torch.Tensor | None = None,
+    ) -> dict:
+        """Embed cells and predict cell-type probabilities.
+
+        If :attr:`reconstruct_counts_on_predict` is ``True``, falls back to the parent's
+        count-reconstruction behaviour and omits cell-type probabilities.
+
+        Args:
+            x_ng: Gene counts matrix ``[N, G]``.
+            var_names_g: Variable names for input validation.
+            batch_index_n: Integer batch indices ``[N]``.
+            continuous_covariates_nc: Continuous covariates ``[N, C]``.
+            categorical_covariate_index_nd: Integer categorical covariate codes ``[N, D]``.
+
+        Returns:
+            A dictionary with keys:
+
+            - ``"x_ng"``: Latent embeddings ``[N, n_latent]`` (keyed ``"x_ng"`` for
+              pipeline compatibility).
+            - ``"cell_type_probs_nc"``: Soft cell-type probabilities ``[N, n_classes]``.
+
+            When :attr:`reconstruct_counts_on_predict` is ``True`` the dict contains only
+            the reconstructed counts under ``"x_ng"`` (parent behaviour).
+        """
+        if self.reconstruct_counts_on_predict:
+            return super().predict(
+                x_ng=x_ng,
+                var_names_g=var_names_g,
+                batch_index_n=batch_index_n,
+                continuous_covariates_nc=continuous_covariates_nc,
+                categorical_covariate_index_nd=categorical_covariate_index_nd,
+            )
+
+        assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
+        assert_arrays_equal("var_names_g", var_names_g, "var_names_g", self.var_names_g)
+
+        batch_nb = self.batch_representation_from_batch_index(batch_index_n)
+        categorical_covariate_np = self.categorical_onehot_from_categorical_index(categorical_covariate_index_nd)
+
+        inference_outputs = self.inference(
+            x_ng=x_ng,
+            batch_nb=batch_nb,
+            continuous_covariates_nc=continuous_covariates_nc,
+            categorical_covariate_np=categorical_covariate_np,
+        )
+        qz = inference_outputs["qz"]
+        z_nk = self._latent_value_from_latent_distribution(qz)
+        logits_nc = self.cell_type_classifier(qz.mean)
+        probs_nc = F.softmax(logits_nc, dim=-1)
+
+        return {
+            "x_ng": z_nk,
+            "cell_type_probs_nc": probs_nc,
+        }

--- a/cellarium/ml/models/scanvi.py
+++ b/cellarium/ml/models/scanvi.py
@@ -640,6 +640,182 @@ class SCANVI(SingleCellVariationalInference):
         return set_idx, active_idx
 
     # ------------------------------------------------------------------
+    # Vectorized label preprocessing and per-bucket KL helpers
+    # ------------------------------------------------------------------
+
+    def _preprocess_labels(
+        self,
+        labels: np.ndarray,
+        device: torch.device,
+    ) -> dict[str, torch.Tensor]:
+        """Partition cells into leaf, coarse, and unlabeled buckets (CPU preprocessing).
+
+        Returns a dict with keys::
+
+            leaf_idx, leaf_c_class, leaf_ce_target,
+            coarse_idx, coarse_set_idx_padded, coarse_mask, coarse_ce_target,
+            unlabeled_idx
+
+        *leaf*: labeled cells whose resolved partition set has exactly one member.
+        *coarse*: labeled cells whose resolved partition set has two or more members.
+        *unlabeled*: cells whose label equals ``unlabeled_category``.
+        """
+        leaf_groups: list[tuple[np.ndarray, int, int]] = []
+        coarse_groups: list[tuple[np.ndarray, torch.Tensor, int]] = []
+        unlabeled_ids: list[int] = []
+
+        for label in np.unique(labels):
+            label_str = str(label)
+            group = np.where(labels == label)[0]
+            set_idx, ce_target = self._resolve_group(label_str)
+
+            if label_str == self.unlabeled_category:
+                unlabeled_ids.extend(group.tolist())
+            else:
+                assert ce_target is not None
+                if set_idx.numel() == 1:
+                    leaf_groups.append((group, int(set_idx[0].item()), ce_target))
+                else:
+                    if self.classifier_type == "ontology":
+                        frac = set_idx.numel() / max(self.n_partition, 1)
+                        if frac > self.marginalization_warn_fraction and label_str not in self._warned_marg_labels:
+                            self._warned_marg_labels.add(label_str)
+                            warnings.warn(
+                                f"Coarse label {label_str!r} marginalizes over "
+                                f"{set_idx.numel()}/{self.n_partition} frontier nodes "
+                                f"({frac:.0%}); this costs nearly as much as an unlabeled cell.",
+                                UserWarning,
+                            )
+                    coarse_groups.append((group, set_idx, ce_target))
+
+        _empty = torch.empty(0, dtype=torch.long, device=device)
+
+        if leaf_groups:
+            leaf_cell_ids = np.concatenate([g for g, _, _ in leaf_groups])
+            leaf_c_class_arr = np.concatenate([[c] * len(g) for g, c, _ in leaf_groups])
+            leaf_ce_target_arr = np.concatenate([[t] * len(g) for g, _, t in leaf_groups])
+            leaf_idx = torch.tensor(leaf_cell_ids, dtype=torch.long, device=device)
+            leaf_c_class = torch.tensor(leaf_c_class_arr, dtype=torch.long, device=device)
+            leaf_ce_target = torch.tensor(leaf_ce_target_arr, dtype=torch.long, device=device)
+        else:
+            leaf_idx = leaf_c_class = leaf_ce_target = _empty
+
+        if coarse_groups:
+            max_s = max(s.numel() for _, s, _ in coarse_groups)
+            row_ids, row_set, row_mask, row_ce = [], [], [], []
+            for grp, set_idx_k, ce_t in coarse_groups:
+                n_k = len(grp)
+                s = set_idx_k.numel()
+                row_ids.append(grp)
+                padded = np.zeros(max_s, dtype=np.int64)
+                padded[:s] = set_idx_k.cpu().numpy()
+                mask_row = np.zeros(max_s, dtype=bool)
+                mask_row[:s] = True
+                row_set.append(np.tile(padded, (n_k, 1)))
+                row_mask.append(np.tile(mask_row, (n_k, 1)))
+                row_ce.append(np.full(n_k, ce_t, dtype=np.int64))
+            coarse_idx = torch.tensor(np.concatenate(row_ids), dtype=torch.long, device=device)
+            coarse_set_idx_padded = torch.tensor(np.concatenate(row_set, axis=0), dtype=torch.long, device=device)
+            coarse_mask = torch.tensor(np.concatenate(row_mask, axis=0), dtype=torch.bool, device=device)
+            coarse_ce_target = torch.tensor(np.concatenate(row_ce), dtype=torch.long, device=device)
+        else:
+            coarse_idx = coarse_ce_target = _empty
+            coarse_set_idx_padded = torch.empty((0, 0), dtype=torch.long, device=device)
+            coarse_mask = torch.empty((0, 0), dtype=torch.bool, device=device)
+
+        unlabeled_idx = torch.tensor(unlabeled_ids, dtype=torch.long, device=device) if unlabeled_ids else _empty
+
+        return {
+            "leaf_idx": leaf_idx,
+            "leaf_c_class": leaf_c_class,
+            "leaf_ce_target": leaf_ce_target,
+            "coarse_idx": coarse_idx,
+            "coarse_set_idx_padded": coarse_set_idx_padded,
+            "coarse_mask": coarse_mask,
+            "coarse_ce_target": coarse_ce_target,
+            "unlabeled_idx": unlabeled_idx,
+        }
+
+    def _leaf_kls(
+        self,
+        z: torch.Tensor,
+        qz_mean: torch.Tensor,
+        qz_std: torch.Tensor,
+        leaf_idx: torch.Tensor,
+        leaf_c_class: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Single vectorized KL pass for all singleton-set (leaf) cells.
+
+        ``kl_c`` is identically 0 for leaf cells and is not returned.
+        """
+        c_onehot = F.one_hot(leaf_c_class, self.n_partition).float()  # [N_leaf, n_partition]
+        return self._conditional_kls(z[leaf_idx], qz_mean[leaf_idx], qz_std[leaf_idx], c_onehot)
+
+    def _coarse_kls(
+        self,
+        z: torch.Tensor,
+        qz_mean: torch.Tensor,
+        qz_std: torch.Tensor,
+        q_partition: torch.Tensor,
+        coarse_idx: torch.Tensor,
+        coarse_set_idx_padded: torch.Tensor,
+        coarse_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Padded batched marginalization for all coarse-labeled cells in one GPU pass.
+
+        All coarse cells are stacked with their frontier subsets padded to ``max_s``, so a single
+        ``_conditional_kls`` call handles every cell simultaneously. The existing ``chunk_size``
+        is applied along the padded-set dimension to bound peak VRAM.
+
+        Returns:
+            ``(kl_z, kl_u, kl_c)`` each ``[N_coarse]``.
+        """
+        N_coarse = coarse_idx.numel()
+        max_s = coarse_set_idx_padded.shape[1]
+        device = z.device
+
+        # q(c|z) restricted to the subtree S, renormalized; padding positions -> 0.
+        q_S = q_partition[coarse_idx].gather(1, coarse_set_idx_padded)  # [N_coarse, max_s]
+        q_S = q_S * coarse_mask.float()
+        q_S_norm = q_S / q_S.sum(dim=-1, keepdim=True).clamp_min(_EPS)  # [N_coarse, max_s]
+
+        # Restricted kl_c (pure tensor arithmetic, no encoder call).
+        # masked_fill keeps log finite at padding positions; clamp_min guards near-zero valid probs.
+        p_S = self.y_prior[coarse_set_idx_padded]  # [N_coarse, max_s]
+        p_S = p_S * coarse_mask.float()
+        p_S_norm = p_S / p_S.sum(dim=-1, keepdim=True).clamp_min(_EPS)
+
+        q_log = q_S_norm.masked_fill(~coarse_mask, 1.0).clamp_min(_EPS).log()
+        p_log = p_S_norm.masked_fill(~coarse_mask, 1.0).clamp_min(_EPS).log()
+        kl_c = (q_S_norm * (q_log - p_log)).sum(dim=-1)  # [N_coarse]
+
+        # kl_z and kl_u: chunk over the padded-set dimension, all N_coarse cells in parallel.
+        z_c = z[coarse_idx]  # [N_coarse, n_latent]
+        qzm_c = qz_mean[coarse_idx]  # [N_coarse, n_latent]
+        qzs_c = qz_std[coarse_idx]  # [N_coarse, n_latent]
+
+        kl_z = torch.zeros(N_coarse, device=device)
+        kl_u = torch.zeros(N_coarse, device=device)
+
+        for start in range(0, max_s, self.chunk_size):
+            end = min(start + self.chunk_size, max_s)
+            chunk = end - start
+            members = coarse_set_idx_padded[:, start:end]  # [N_coarse, chunk]
+            w = q_S_norm[:, start:end] * coarse_mask[:, start:end].float()  # [N_coarse, chunk]
+
+            c_onehot = F.one_hot(members, self.n_partition).float()  # [N_coarse, chunk, n_partition]
+            z_exp = z_c.unsqueeze(1).expand(-1, chunk, -1).reshape(N_coarse * chunk, -1)
+            qzm_exp = qzm_c.unsqueeze(1).expand(-1, chunk, -1).reshape(N_coarse * chunk, -1)
+            qzs_exp = qzs_c.unsqueeze(1).expand(-1, chunk, -1).reshape(N_coarse * chunk, -1)
+            c_exp = c_onehot.reshape(N_coarse * chunk, -1)
+
+            kl_z_chunk, kl_u_chunk = self._conditional_kls(z_exp, qzm_exp, qzs_exp, c_exp)
+            kl_z += (w * kl_z_chunk.view(N_coarse, chunk)).sum(dim=-1)
+            kl_u += (w * kl_u_chunk.view(N_coarse, chunk)).sum(dim=-1)
+
+        return kl_z, kl_u, kl_c
+
+    # ------------------------------------------------------------------
     # Forward
     # ------------------------------------------------------------------
 
@@ -745,33 +921,48 @@ class SCANVI(SingleCellVariationalInference):
         kl_c_n = torch.zeros(n, device=device)
         ce_loss_n = torch.zeros(n, device=device)
 
-        # Group cells by label string: same label -> same marginalization set and CE target.
-        for label in np.unique(labels):
-            group = np.where(labels == label)[0]
-            idx = torch.as_tensor(group, dtype=torch.long, device=device)
-            set_idx, ce_target = self._resolve_group(str(label))
-            set_idx = set_idx.to(device)
+        # Partition cells into leaf / coarse / unlabeled buckets, then process each in one GPU pass.
+        buckets = self._preprocess_labels(labels, device)
 
-            if self.classifier_type == "ontology" and ce_target is not None and set_idx.numel() > 1:
-                frac = set_idx.numel() / max(self.n_partition, 1)
-                if frac > self.marginalization_warn_fraction and label not in self._warned_marg_labels:
-                    self._warned_marg_labels.add(str(label))
-                    warnings.warn(
-                        f"Coarse label {label!r} marginalizes over {set_idx.numel()}/{self.n_partition} "
-                        f"frontier nodes ({frac:.0%}); this costs nearly as much as an unlabeled cell.",
-                        UserWarning,
-                    )
+        # Leaf path: all singleton-set cells in a single encoder call; kl_c == 0 identically.
+        if buckets["leaf_idx"].numel() > 0:
+            leaf_idx = buckets["leaf_idx"]
+            kl_z_leaf, kl_u_leaf = self._leaf_kls(z, qz_mean, qz_std, leaf_idx, buckets["leaf_c_class"])
+            kl_z_n[leaf_idx] = kl_z_leaf
+            kl_u_n[leaf_idx] = kl_u_leaf
+            ce_loss_n[leaf_idx] = self._supervised_ce(logits[leaf_idx], buckets["leaf_ce_target"])
 
-            kl_z_g, kl_u_g, kl_c_g = self._marginalize_over_set(
-                z[idx], qz_mean[idx], qz_std[idx], q_partition[idx], set_idx
+        # Coarse path: all multi-set labeled cells in one padded encoder call.
+        if buckets["coarse_idx"].numel() > 0:
+            coarse_idx = buckets["coarse_idx"]
+            kl_z_c, kl_u_c, kl_c_c = self._coarse_kls(
+                z,
+                qz_mean,
+                qz_std,
+                q_partition,
+                coarse_idx,
+                buckets["coarse_set_idx_padded"],
+                buckets["coarse_mask"],
             )
-            kl_z_n[idx] = kl_z_g
-            kl_u_n[idx] = kl_u_g
-            kl_c_n[idx] = kl_c_g
+            kl_z_n[coarse_idx] = kl_z_c
+            kl_u_n[coarse_idx] = kl_u_c
+            kl_c_n[coarse_idx] = kl_c_c
+            ce_loss_n[coarse_idx] = self._supervised_ce(logits[coarse_idx], buckets["coarse_ce_target"])
 
-            if ce_target is not None:
-                target = torch.full((idx.numel(),), ce_target, dtype=torch.long, device=device)
-                ce_loss_n[idx] = self._supervised_ce(logits[idx], target)
+        # Unlabeled path: single batch marginalized over the whole frontier with a chunk loop.
+        if buckets["unlabeled_idx"].numel() > 0:
+            unlabeled_idx = buckets["unlabeled_idx"]
+            all_frontier = torch.arange(self.n_partition, dtype=torch.long, device=device)
+            kl_z_u, kl_u_u, kl_c_u = self._marginalize_over_set(
+                z[unlabeled_idx],
+                qz_mean[unlabeled_idx],
+                qz_std[unlabeled_idx],
+                q_partition[unlabeled_idx],
+                all_frontier,
+            )
+            kl_z_n[unlabeled_idx] = kl_z_u
+            kl_u_n[unlabeled_idx] = kl_u_u
+            kl_c_n[unlabeled_idx] = kl_c_u
 
         loss = torch.mean(
             rec_loss_n

--- a/cellarium/ml/models/scanvi.py
+++ b/cellarium/ml/models/scanvi.py
@@ -187,18 +187,37 @@ class SCANVI(SingleCellVariationalInference):
             n_hidden=secondary_n_hidden,
         )
 
-        # Prior over cell types p(c); uniform by default
+        # Prior over cell types p(c); uniform by default. Kept as a numpy array so it can be
+        # restored in reset_parameters() after meta-device materialization wipes the buffer.
         if y_prior_probs is not None:
-            y_prior = torch.tensor(y_prior_probs, dtype=torch.float32)
-            y_prior = y_prior / y_prior.sum()
+            y_prior_np = np.asarray(y_prior_probs, dtype=np.float32)
+            y_prior_np = y_prior_np / y_prior_np.sum()
         else:
-            y_prior = torch.ones(n_classes, dtype=torch.float32) / n_classes
-        self.register_buffer("y_prior", y_prior)
+            y_prior_np = np.ones(n_classes, dtype=np.float32) / n_classes
+        self._y_prior_numpy = y_prior_np
+        self.register_buffer("y_prior", torch.as_tensor(y_prior_np))
 
-        # Initialize new modules (parent's reset_parameters() ran before these existed)
+        # The parent's reset_parameters() ran during super().__init__(), before the
+        # SCANVI-specific modules and buffers existed. Run it again now that they do, so
+        # they are initialized (mirrors SingleCellVariationalInference.__init__).
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        super().reset_parameters()
+        # SingleCellVariationalInference.__init__ calls reset_parameters() before the
+        # SCANVI-specific attributes have been built; skip them on that first call. They
+        # are initialized by the explicit reset_parameters() call at the end of
+        # SCANVI.__init__ and re-initialized here on later calls (e.g. after meta-device
+        # materialization in CellariumModule.configure_model).
+        if not hasattr(self, "cell_type_classifier"):
+            return
         self.cell_type_classifier.apply(weights_init)
         self.u_encoder.apply(weights_init)
         self.z_prior_decoder.apply(weights_init)
+        # to_empty() during meta-device materialization leaves buffers as uninitialized
+        # memory, so restore y_prior from the stored probabilities.
+        with torch.no_grad():
+            self.y_prior.copy_(torch.as_tensor(self._y_prior_numpy, device=self.y_prior.device))
 
     # ------------------------------------------------------------------
     # Internal helper

--- a/cellarium/ml/models/scanvi.py
+++ b/cellarium/ml/models/scanvi.py
@@ -3,12 +3,15 @@
 
 """scANVI: Single-cell Annotation using Variational Inference."""
 
+import warnings
+from typing import Literal
+
 import lightning.pytorch as pl
 import numpy as np
+import pandas as pd
 import torch
 import torch.nn.functional as F
-from torch.distributions import Categorical, Normal
-from torch.distributions import kl_divergence as kl
+from torch.distributions import Normal
 
 from cellarium.ml.layers import DressedLayer, FullyConnectedLinear
 from cellarium.ml.models.scvi import (
@@ -16,10 +19,21 @@ from cellarium.ml.models.scvi import (
     compute_annealed_kl_weight,
     weights_init,
 )
+from cellarium.ml.models.socam import (
+    _build_nonleaf_info,
+    _expand_with_ancestors,
+    _propagate_logits_impl,
+    _propagate_probs_impl,
+    compute_class_weights,
+    propagate_logits,
+    propagate_probs,
+)
 from cellarium.ml.utilities.testing import (
     assert_arrays_equal,
     assert_columns_and_array_lengths_equal,
 )
+
+_EPS = 1e-8
 
 
 class ConditionalNormalEncoder(torch.nn.Module):
@@ -29,11 +43,15 @@ class ConditionalNormalEncoder(torch.nn.Module):
     3D inputs ``[N, chunk, in_features]`` to ``[N*chunk, in_features]`` before calling
     and reshaping the output back.
 
+    LayerNorm (rather than BatchNorm) is used in the hidden layers so that the module is robust
+    to the very small, variable batch sizes produced by per-label grouped marginalization (a
+    singleton group yields a batch of size 1, which BatchNorm cannot handle in train mode).
+
     Args:
-        in_features: Input dimensionality (typically ``n_latent + n_classes``).
+        in_features: Input dimensionality (typically ``n_latent + n_partition``).
         out_features: Output (latent) dimensionality.
         n_hidden: Widths of hidden layers. Empty list gives a single linear layer.
-        use_batch_norm: Whether to apply ``BatchNorm1d`` in hidden layers.
+        use_layer_norm: Whether to apply ``LayerNorm`` in hidden layers.
         dropout_rate: Dropout rate in hidden layers.
         var_eps: Floor added to the variance for numerical stability.
     """
@@ -43,7 +61,7 @@ class ConditionalNormalEncoder(torch.nn.Module):
         in_features: int,
         out_features: int,
         n_hidden: list[int],
-        use_batch_norm: bool = True,
+        use_layer_norm: bool = True,
         dropout_rate: float = 0.0,
         var_eps: float = 1e-4,
     ):
@@ -56,7 +74,7 @@ class ConditionalNormalEncoder(torch.nn.Module):
             trunk_layers.append(
                 DressedLayer(
                     torch.nn.Linear(current_in, h),
-                    use_batch_norm=use_batch_norm,
+                    use_layer_norm=use_layer_norm,
                     dropout_rate=dropout_rate,
                 )
             )
@@ -73,15 +91,100 @@ class ConditionalNormalEncoder(torch.nn.Module):
         return Normal(mean, (log_var.exp() + self.var_eps).sqrt())
 
 
+def compute_frontier(
+    descendant_tensor: torch.Tensor,
+    cl_names: list[str],
+    counts: torch.Tensor,
+    min_cells: int,
+    excluded_names: set[str],
+) -> tuple[list[str], list[str]]:
+    """Compute a support-backed frontier antichain through a cell ontology.
+
+    The frontier is the set of deepest nodes whose subtree cell-count (own + all descendant
+    counts) is at least ``min_cells``, with a coverage-repair pass that guarantees every
+    *observed* node maps to exactly one frontier ancestor. Repair adds the shallowest ancestor
+    of an orphaned node that is not itself an ancestor of any already-chosen frontier node (see
+    the module docstring / design discussion), so under-supported isolated branches become their
+    own small frontier partitions rather than being dropped.
+
+    Args:
+        descendant_tensor: ``(C, C)`` binary tensor, diagonal 1, where entry ``[i, j] == 1``
+            means ``j`` is a descendant of ``i`` (``i`` is an ancestor of ``j``).
+        cl_names: Ordered node names matching rows/columns of ``descendant_tensor``.
+        counts: ``(C,)`` per-node *direct* cell counts aligned to ``cl_names``.
+        min_cells: Support threshold for the cut.
+        excluded_names: Node names never eligible for the frontier (e.g. the unlabeled sentinel).
+
+    Returns:
+        ``(frontier_names, under_supported_names)`` — the frontier node names (a subset of
+        ``cl_names``, in ``cl_names`` order) and the subset of those that fell below
+        ``min_cells`` (added by coverage repair).
+    """
+    # Pin construction-time math to CPU so it works inside a torch.device("meta") context
+    # (the passed-in descendant_tensor/counts are concrete CPU tensors).
+    desc = descendant_tensor.float().cpu()
+    n = len(cl_names)
+    excluded_mask = torch.tensor([name in excluded_names for name in cl_names], dtype=torch.bool, device="cpu")
+
+    counts = counts.clone().float().cpu()
+    counts[excluded_mask] = 0.0
+    subtree_count = desc @ counts  # [C], row i sums over descendants of i (incl. self)
+
+    qualifies = (subtree_count >= min_cells) & (~excluded_mask) & (subtree_count > 0)
+    proper_desc = desc.clone()
+    proper_desc.fill_diagonal_(0.0)
+    has_qualifying_proper_desc = (proper_desc @ qualifies.float()) > 0
+    frontier_mask = qualifies & (~has_qualifying_proper_desc)
+
+    observed = (counts > 0) & (~excluded_mask)
+
+    def _covered(mask: torch.Tensor) -> torch.Tensor:
+        # A node w is covered if some frontier node is an ancestor of w (finer-than-frontier,
+        # binned up: desc[f, w] == 1) OR a descendant of w (coarse, marginalized: desc[w, f] == 1).
+        idx = mask.nonzero(as_tuple=True)[0]
+        if idx.numel() == 0:
+            return torch.zeros(n, dtype=torch.bool, device="cpu")
+        has_frontier_ancestor = desc[idx, :].sum(dim=0) > 0
+        has_frontier_descendant = desc[:, idx].sum(dim=1) > 0
+        return has_frontier_ancestor | has_frontier_descendant
+
+    covered = _covered(frontier_mask)
+    orphans = (observed & (~covered)).nonzero(as_tuple=True)[0].tolist()
+    for w in orphans:
+        if covered[w]:
+            continue  # already handled by a previous repair addition
+        # allowed ancestors of w: a is an ancestor of w, not excluded, and not an ancestor
+        # of any current frontier node
+        is_ancestor_of_w = desc[:, w] > 0
+        frontier_idx = frontier_mask.nonzero(as_tuple=True)[0]
+        is_ancestor_of_frontier = (
+            desc[:, frontier_idx].sum(dim=1) > 0
+            if frontier_idx.numel() > 0
+            else torch.zeros(n, dtype=torch.bool, device="cpu")
+        )
+        allowed = is_ancestor_of_w & (~is_ancestor_of_frontier) & (~excluded_mask)
+        allowed_idx = allowed.nonzero(as_tuple=True)[0]
+        # shallowest allowed ancestor = the one with the most descendants
+        descendant_counts = desc[allowed_idx, :].sum(dim=1)
+        chosen = allowed_idx[int(torch.argmax(descendant_counts).item())]
+        frontier_mask[chosen] = True
+        covered = _covered(frontier_mask)
+
+    frontier_indices = frontier_mask.nonzero(as_tuple=True)[0].tolist()
+    frontier_names = [cl_names[i] for i in frontier_indices]
+    under_supported = [cl_names[i] for i in frontier_indices if subtree_count[i].item() < min_cells]
+    return frontier_names, under_supported
+
+
 class SCANVI(SingleCellVariationalInference):
-    """Single-cell ANnotation using Variational Inference (scANVI) [1].
+    r"""Single-cell ANnotation using Variational Inference (scANVI) [1].
 
     Extends scVI with a hierarchical prior on the latent variable ``z``:
 
     .. math::
 
-        c \\sim p(c), \\quad u \\sim \\mathcal{N}(0, I),
-        \\quad z \\sim p(z \\mid u, c), \\quad x \\sim p(x \\mid z, s)
+        c \sim p(c), \quad u \sim \mathcal{N}(0, I),
+        \quad z \sim p(z \mid u, c), \quad x \sim p(x \mid z, s)
 
     The encoder ``q(z|x)`` is identical to scVI. Three new networks are added:
 
@@ -89,14 +192,26 @@ class SCANVI(SingleCellVariationalInference):
     * **u-encoder** ``q(u|z,c)``: encodes a deeper latent ``u`` given ``z`` and cell type ``c``.
     * **z-prior decoder** ``p(z|u,c)``: provides the class-conditional prior on ``z``.
 
-    For labeled cells the ELBO is maximized using the known cell type together with an
-    auxiliary cross-entropy classification term.  For unlabeled cells the cell-type
-    expectation is marginalized in chunks to control peak VRAM.
+    The class variable ``c`` ranges over a **partition** of cell-type space. Two classifier
+    modes are supported:
 
-    .. note::
+    * ``classifier_type="flat"`` (default): a plain MLP over a flat list of cell types
+      (``cell_type_categories``), with standard cross-entropy — the classic scANVI behaviour.
+    * ``classifier_type="ontology"``: a SOCAM-style ontology-aware MLP that emits logits over
+      all active ontology nodes (leaf and internal) and propagates them up the Cell Ontology.
+      The generative partition is a **support-backed frontier** (see :func:`compute_frontier`)
+      computed from ``class_counts`` at construction. A coarse (internal-node) label licenses a
+      restricted marginalization of the ELBO over the frontier leaves in its subtree, so labels
+      at any granularity supervise the model. Optional inverse-frequency class balancing is
+      applied to the (hierarchical) cross-entropy term.
 
-        At large ``n_classes`` (> ~500) the one-hot encoding of ``c`` dominates the input
-        to the secondary networks.  A learned cell-type embedding is a planned extension.
+    For labeled cells the ELBO is maximized using the known cell type (or, for a coarse label,
+    marginalized over its subtree) together with an auxiliary cross-entropy classification term.
+    For unlabeled cells (label equal to ``unlabeled_category``) the cell-type expectation is
+    marginalized over the whole partition in chunks to control peak VRAM.
+
+    The classifier is **batch-agnostic** (it consumes only ``z``), so with a batch-agnostic
+    encoder configuration one can go ``x -> z -> c`` at inference time.
 
     **References:**
 
@@ -105,41 +220,72 @@ class SCANVI(SingleCellVariationalInference):
        <https://doi.org/10.15252/msb.20209620>`_.
 
     Args:
-        n_classes:
-            Number of annotated cell-type classes.
-        unlabeled_category_index:
-            Integer code used to mark unlabeled cells in ``cell_type_index_n``. Default ``-1``.
+        classifier_type:
+            ``"flat"`` (default) for a plain MLP over ``cell_type_categories``; ``"ontology"``
+            for the SOCAM-style ontology-aware classifier.
         classification_weight:
             Weight ``α`` applied to the cross-entropy loss on labeled cells.
         chunk_size:
-            Number of classes processed per chunk during the unlabeled forward pass.
-            Reduce this to lower peak VRAM at the cost of slightly more computation.
+            Number of partition members processed per chunk during marginalization. Reduce this
+            to lower peak VRAM at the cost of slightly more computation.
         classifier_n_hidden:
-            Hidden layer widths for the classifier ``q(c|z)`` MLP.
-            Defaults to ``[128]`` (one hidden layer, matching scvi-tools).
+            Hidden layer widths for the classifier ``q(c|z)`` MLP. Defaults to ``[128]``.
         classifier_dropout_rate:
             Dropout rate in classifier hidden layers.
         secondary_n_hidden:
-            Hidden layer widths shared by the u-encoder ``q(u|z,c)`` and the
-            z-prior decoder ``p(z|u,c)``. Defaults to ``[128]``.
+            Hidden layer widths shared by the u-encoder ``q(u|z,c)`` and the z-prior decoder
+            ``p(z|u,c)``. Defaults to ``[128]``.
         y_prior_probs:
-            Prior probabilities over cell types ``p(c)``.  Must sum to 1 and have length
-            ``n_classes``. If ``None`` a uniform prior is used.
+            Prior probabilities over the partition ``p(c)``. Must sum to 1 and have length equal
+            to the partition size. If ``None`` a uniform prior is used (recommended).
+        unlabeled_category:
+            String label marking unlabeled cells. Default ``"unknown"``.
+        descendant_tensor:
+            (ontology mode) ``(C, C)`` binary tensor, diagonal 1, where ``[i, j] == 1`` means
+            ``j`` is a descendant of ``i``. Rows/columns are indexed by ``cl_names``.
+        cl_names:
+            (ontology mode) Ordered node names matching ``descendant_tensor``.
+        class_counts:
+            (ontology mode) pandas Series mapping node names to training cell counts. Drives both
+            the frontier cut and (optionally) the class-balancing weights.
+        frontier_min_cells:
+            (ontology mode) Support threshold for the frontier cut.
+        propagate_class_counts:
+            (ontology mode) If True, propagate counts up the ontology before computing balancing
+            weights (see :func:`~cellarium.ml.models.socam.compute_class_weights`).
+        probability_propagation_flag:
+            (ontology mode) If True, apply hierarchical propagation to the classifier logits.
+        use_torch_compile:
+            (ontology mode) If True, use the ``torch.compile``d propagation functions. Defaults
+            to False (eager) to avoid recompilation across variable batch shapes.
+        marginalization_warn_fraction:
+            (ontology mode) Warn (once per label) when a coarse label marginalizes over more than
+            this fraction of the frontier — a signal that the label is nearly as expensive as
+            unlabeled while providing little supervision.
         **scvi_kwargs:
             All keyword arguments accepted by
-            :class:`~cellarium.ml.models.SingleCellVariationalInference`.
+            :class:`~cellarium.ml.models.SingleCellVariationalInference`. In flat mode,
+            ``cell_type_categories`` defines the partition and is required.
     """
 
     def __init__(
         self,
-        n_classes: int,
-        unlabeled_category_index: int = -1,
+        classifier_type: Literal["flat", "ontology"] = "flat",
         classification_weight: float = 50.0,
         chunk_size: int = 100,
         classifier_n_hidden: list[int] | None = None,
         classifier_dropout_rate: float = 0.1,
         secondary_n_hidden: list[int] | None = None,
         y_prior_probs: list[float] | None = None,
+        unlabeled_category: str = "unknown",
+        descendant_tensor: torch.Tensor | None = None,
+        cl_names: list[str] | None = None,
+        class_counts: pd.Series | None = None,
+        frontier_min_cells: int = 50,
+        propagate_class_counts: bool = False,
+        probability_propagation_flag: bool = True,
+        use_torch_compile: bool = False,
+        marginalization_warn_fraction: float = 0.25,
         **scvi_kwargs,
     ):
         if scvi_kwargs.get("use_flow", False):
@@ -152,112 +298,346 @@ class SCANVI(SingleCellVariationalInference):
         if secondary_n_hidden is None:
             secondary_n_hidden = [128]
 
-        self.n_classes = n_classes
-        self.unlabeled_category_index = unlabeled_category_index
+        self.classifier_type = classifier_type
         self.classification_weight = classification_weight
         self.chunk_size = chunk_size
+        self.unlabeled_category = unlabeled_category
+        self.probability_propagation_flag = probability_propagation_flag
+        self.use_torch_compile = use_torch_compile
+        self.marginalization_warn_fraction = marginalization_warn_fraction
+        self._warned_marg_labels: set[str] = set()
 
-        # Verify n_classes is consistent with cell_type_categories when provided
-        cell_type_categories = scvi_kwargs.get("cell_type_categories")
-        if cell_type_categories is not None and len(cell_type_categories) != n_classes:
-            raise ValueError(
-                f"n_classes={n_classes} does not match len(cell_type_categories)={len(cell_type_categories)}."
+        if classifier_type == "flat":
+            self._init_flat()
+        elif classifier_type == "ontology":
+            self._init_ontology(
+                descendant_tensor=descendant_tensor,
+                cl_names=cl_names,
+                class_counts=class_counts,
+                frontier_min_cells=frontier_min_cells,
+                propagate_class_counts=propagate_class_counts,
             )
+        else:
+            raise ValueError(f"classifier_type must be 'flat' or 'ontology', got {classifier_type!r}.")
 
-        # q(c|z): MLP classifier from latent space to cell-type logits
+        # Classifier q(c|z): MLP from latent space to logits over the classifier output space.
         self.cell_type_classifier = FullyConnectedLinear(
             in_features=self.n_latent,
-            out_features=n_classes,
+            out_features=self._classifier_out_dim,
             n_hidden=classifier_n_hidden,
             dressing_init_kwargs={"use_batch_norm": True, "dropout_rate": classifier_dropout_rate},
             bias=True,
         )
 
-        # q(u|z,c): encodes the deeper latent u given z and cell type
+        # q(u|z,c): encodes the deeper latent u given z and (one-hot) partition membership c
         self.u_encoder = ConditionalNormalEncoder(
-            in_features=self.n_latent + n_classes,
+            in_features=self.n_latent + self.n_partition,
             out_features=self.n_latent,
             n_hidden=secondary_n_hidden,
         )
-
-        # p(z|u,c): class-conditional prior on z, parameterized by u and cell type
+        # p(z|u,c): class-conditional prior on z, parameterized by u and partition membership c
         self.z_prior_decoder = ConditionalNormalEncoder(
-            in_features=self.n_latent + n_classes,
+            in_features=self.n_latent + self.n_partition,
             out_features=self.n_latent,
             n_hidden=secondary_n_hidden,
         )
 
-        # Prior over cell types p(c); uniform by default. Kept as a numpy array so it can be
-        # restored in reset_parameters() after meta-device materialization wipes the buffer.
+        # Prior over the partition p(c); uniform by default (kept as numpy so reset_parameters()
+        # can restore the buffer after meta-device materialization wipes it).
         if y_prior_probs is not None:
+            if len(y_prior_probs) != self.n_partition:
+                raise ValueError(
+                    f"len(y_prior_probs)={len(y_prior_probs)} does not match partition size {self.n_partition}."
+                )
             y_prior_np = np.asarray(y_prior_probs, dtype=np.float32)
             y_prior_np = y_prior_np / y_prior_np.sum()
         else:
-            y_prior_np = np.ones(n_classes, dtype=np.float32) / n_classes
+            y_prior_np = np.ones(self.n_partition, dtype=np.float32) / self.n_partition
         self._y_prior_numpy = y_prior_np
         self.register_buffer("y_prior", torch.as_tensor(y_prior_np))
 
-        # The parent's reset_parameters() ran during super().__init__(), before the
-        # SCANVI-specific modules and buffers existed. Run it again now that they do, so
-        # they are initialized (mirrors SingleCellVariationalInference.__init__).
         self.reset_parameters()
+
+    # ------------------------------------------------------------------
+    # Mode-specific construction
+    # ------------------------------------------------------------------
+
+    def _init_flat(self) -> None:
+        """Build the flat-mode partition from ``cell_type_categories``."""
+        if self.cell_type_categories is None:
+            raise ValueError("classifier_type='flat' requires cell_type_categories to define the class partition.")
+        self.class_names: list[str] = list(self.cell_type_categories)
+        self.n_partition = len(self.class_names)
+        self._classifier_out_dim = self.n_partition
+        self._label_to_partition_idx: dict[str, int] = {name: i for i, name in enumerate(self.class_names)}
+
+    def _init_ontology(
+        self,
+        descendant_tensor: torch.Tensor | None,
+        cl_names: list[str] | None,
+        class_counts: pd.Series | None,
+        frontier_min_cells: int,
+        propagate_class_counts: bool,
+    ) -> None:
+        """Build the ontology-mode active set, frontier partition, and class weights."""
+        if descendant_tensor is None or cl_names is None:
+            raise ValueError("classifier_type='ontology' requires descendant_tensor and cl_names.")
+        # Pin to CPU so construction works inside a torch.device("meta") context.
+        descendant_tensor = descendant_tensor.float().cpu()
+        if descendant_tensor.shape[0] != descendant_tensor.shape[1]:
+            raise ValueError("descendant_tensor must be square.")
+        if descendant_tensor.trace().item() != descendant_tensor.shape[0]:
+            raise ValueError("descendant_tensor must have ones on the diagonal (each node is its own descendant).")
+        if len(cl_names) != descendant_tensor.shape[0]:
+            raise ValueError("len(cl_names) must match descendant_tensor.shape[0].")
+        if class_counts is None:
+            raise ValueError("classifier_type='ontology' requires class_counts to compute the frontier.")
+
+        self.cl_names = list(cl_names)
+        cl_index = {name: i for i, name in enumerate(self.cl_names)}
+
+        # Direct counts aligned to cl_names (missing -> 0).
+        direct_counts = torch.zeros(len(self.cl_names), dtype=torch.float, device="cpu")
+        for name, cnt in class_counts.items():
+            if name in cl_index:
+                if cnt < 0:
+                    raise ValueError("All class_counts values must be >= 0.")
+                direct_counts[cl_index[name]] = float(cnt)
+
+        frontier_names, under_supported = compute_frontier(
+            descendant_tensor=descendant_tensor,
+            cl_names=self.cl_names,
+            counts=direct_counts,
+            min_cells=frontier_min_cells,
+            excluded_names={self.unlabeled_category},
+        )
+        if len(frontier_names) == 0:
+            raise ValueError("Computed frontier is empty; check class_counts and frontier_min_cells.")
+        if under_supported:
+            warnings.warn(
+                f"{len(under_supported)} frontier node(s) fall below frontier_min_cells={frontier_min_cells} "
+                f"and were added by coverage repair to avoid orphaning cells: {under_supported}",
+                UserWarning,
+            )
+
+        # Active set = frontier plus all their ancestors (SOCAM-style).
+        active_cl_names = _expand_with_ancestors(frontier_names, self.cl_names, descendant_tensor)
+        self.active_cl_names = active_cl_names
+        self.n_active = len(active_cl_names)
+        active_index = {name: i for i, name in enumerate(active_cl_names)}
+        ix = torch.tensor([cl_index[name] for name in active_cl_names], dtype=torch.long, device="cpu")
+        active_desc = descendant_tensor[ix][:, ix]  # (n_active, n_active)
+        nonleaf_info = _build_nonleaf_info(active_desc)
+
+        # Active leaves == frontier == the generative partition.
+        leaf_mask = active_desc.sum(dim=1) == 1
+        frontier_active_idx = leaf_mask.nonzero(as_tuple=True)[0]  # (n_frontier,) in active-column space
+        self.n_partition = int(frontier_active_idx.numel())
+        self._classifier_out_dim = self.n_active
+        self.frontier_cl_names = [active_cl_names[i] for i in frontier_active_idx.tolist()]
+
+        # frontier_membership_af[a, p] == 1 iff frontier partition member p is a descendant of active node a
+        frontier_membership_af = active_desc[:, frontier_active_idx]  # (n_active, n_frontier)
+
+        # Class-balancing weights over all active nodes (data-frequency mean-1 for reduction="none").
+        class_weights = compute_class_weights(
+            active_cl_names=active_cl_names,
+            class_counts=class_counts,
+            active_descendant_tensor_cc=active_desc,
+            propagate_class_counts=propagate_class_counts,
+            normalize="data_mean",
+        )
+
+        # Label resolver: every cl_name -> active node index (finer-than-frontier binned to its
+        # frontier ancestor; coarse labels map to their own active node).
+        self._label_to_active_idx: dict[str, int] = {}
+        for name in self.cl_names:
+            if name == self.unlabeled_category:
+                continue
+            if name in active_index:
+                self._label_to_active_idx[name] = active_index[name]
+            else:
+                # finer than the frontier: bin up to the unique frontier ancestor
+                j = cl_index[name]
+                for fname in self.frontier_cl_names:
+                    if descendant_tensor[cl_index[fname], j] > 0:
+                        self._label_to_active_idx[name] = active_index[fname]
+                        break
+
+        # CPU copies for reset_parameters() restore after meta-device materialization.
+        self._active_descendant_tensor_cc = active_desc
+        self._nonleaf_desc_cc = nonleaf_info["nonleaf_desc_cc"]
+        self._perm = nonleaf_info["perm"]
+        self._inv_perm = nonleaf_info["inv_perm"]
+        self._frontier_active_idx = frontier_active_idx
+        self._frontier_membership_af = frontier_membership_af
+        self._class_weights = class_weights
+
+        self.register_buffer("active_descendant_tensor_cc", active_desc.clone())
+        self.register_buffer("nonleaf_desc_cc", nonleaf_info["nonleaf_desc_cc"].clone())
+        self.register_buffer("perm", nonleaf_info["perm"].clone())
+        self.register_buffer("inv_perm", nonleaf_info["inv_perm"].clone())
+        self.register_buffer("frontier_active_idx", frontier_active_idx.clone())
+        self.register_buffer("frontier_membership_af", frontier_membership_af.clone())
+        if class_weights is not None:
+            self.register_buffer("class_weights", class_weights.clone())
+        else:
+            self.register_buffer("class_weights", None)
 
     def reset_parameters(self) -> None:
         super().reset_parameters()
         # SingleCellVariationalInference.__init__ calls reset_parameters() before the
-        # SCANVI-specific attributes have been built; skip them on that first call. They
-        # are initialized by the explicit reset_parameters() call at the end of
-        # SCANVI.__init__ and re-initialized here on later calls (e.g. after meta-device
-        # materialization in CellariumModule.configure_model).
+        # SCANVI-specific attributes are built; skip on that first call.
         if not hasattr(self, "cell_type_classifier"):
             return
         self.cell_type_classifier.apply(weights_init)
         self.u_encoder.apply(weights_init)
         self.z_prior_decoder.apply(weights_init)
-        # to_empty() during meta-device materialization leaves buffers as uninitialized
-        # memory, so restore y_prior from the stored probabilities.
         with torch.no_grad():
             self.y_prior.copy_(torch.as_tensor(self._y_prior_numpy, device=self.y_prior.device))
+            if self.classifier_type == "ontology":
+                self.active_descendant_tensor_cc.copy_(self._active_descendant_tensor_cc)
+                self.nonleaf_desc_cc.copy_(self._nonleaf_desc_cc)
+                self.perm.copy_(self._perm)
+                self.inv_perm.copy_(self._inv_perm)
+                self.frontier_active_idx.copy_(self._frontier_active_idx)
+                self.frontier_membership_af.copy_(self._frontier_membership_af)
+                if self._class_weights is not None:
+                    self.class_weights.copy_(self._class_weights)
 
     # ------------------------------------------------------------------
-    # Internal helper
+    # Classifier heads (mode-specific)
     # ------------------------------------------------------------------
 
-    def _compute_conditional_kls(
+    def _partition_probs(self, logits: torch.Tensor) -> torch.Tensor:
+        """Return ``q(c|z)`` over the partition, shape ``[N, n_partition]``."""
+        if self.classifier_type == "flat":
+            return F.softmax(logits, dim=-1)
+        return F.softmax(logits[:, self.frontier_active_idx], dim=-1)
+
+    def _propagate_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        fn = propagate_logits if self.use_torch_compile else _propagate_logits_impl
+        return fn(logits, self.nonleaf_desc_cc, self.perm, self.inv_perm)
+
+    def _propagate_probs(self, probs: torch.Tensor) -> torch.Tensor:
+        fn = propagate_probs if self.use_torch_compile else _propagate_probs_impl
+        return fn(probs, self.active_descendant_tensor_cc)
+
+    def _supervised_ce(self, logits: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Per-cell (hierarchical, class-weighted) cross-entropy, shape ``[m]``."""
+        if self.classifier_type == "flat":
+            return F.cross_entropy(logits, target, reduction="none")
+        propagated = logits
+        if self.probability_propagation_flag:
+            propagated = self._propagate_logits(logits)
+        return F.cross_entropy(propagated, target, reduction="none", weight=self.class_weights)
+
+    # ------------------------------------------------------------------
+    # Marginalization
+    # ------------------------------------------------------------------
+
+    def _conditional_kls(
         self,
         z: torch.Tensor,
         qz_mean: torch.Tensor,
         qz_std: torch.Tensor,
         c_onehot: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Compute ``KL(q(z|x) || p(z|u,c))`` and ``KL(q(u|z,c) || N(0,I))`` for cell-class pairs.
-
-        All inputs must be 2D: ``[N, ...]``.  The caller reshapes from 3D when batching over
-        the class dimension.
+        """Compute ``KL(q(z|x) || p(z|u,c))`` and ``KL(q(u|z,c) || N(0,I))`` for 2D inputs.
 
         Args:
-            z: Latent sample from ``q(z|x)``, shape ``[N, n_latent]``.
-            qz_mean: Mean of ``q(z|x)``, shape ``[N, n_latent]``.
-            qz_std: Std of ``q(z|x)``, shape ``[N, n_latent]``.
-            c_onehot: One-hot cell-type encoding, shape ``[N, n_classes]``.
+            z: Latent sample ``[N, n_latent]``.
+            qz_mean: Mean of ``q(z|x)`` ``[N, n_latent]``.
+            qz_std: Std of ``q(z|x)`` ``[N, n_latent]``.
+            c_onehot: One-hot partition membership ``[N, n_partition]``.
 
         Returns:
-            ``kl_z``: ``[N]`` tensor — KL divergence for z.
-            ``kl_u``: ``[N]`` tensor — KL divergence for u.
+            ``(kl_z, kl_u)`` each ``[N]``.
         """
         zc = torch.cat([z, c_onehot], dim=-1)
         qu = self.u_encoder(zc)
         u = qu.rsample()
-
         uc = torch.cat([u, c_onehot], dim=-1)
         pz = self.z_prior_decoder(uc)
-
         qz = Normal(qz_mean, qz_std)
         pu = Normal(torch.zeros_like(u), torch.ones_like(u))
-
-        kl_z = kl(qz, pz).sum(dim=-1)
-        kl_u = kl(qu, pu).sum(dim=-1)
+        kl_z = torch.distributions.kl_divergence(qz, pz).sum(dim=-1)
+        kl_u = torch.distributions.kl_divergence(qu, pu).sum(dim=-1)
         return kl_z, kl_u
+
+    def _marginalize_over_set(
+        self,
+        z_m: torch.Tensor,
+        qz_mean_m: torch.Tensor,
+        qz_std_m: torch.Tensor,
+        q_partition_m: torch.Tensor,
+        set_idx: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Marginalize ``kl_z``/``kl_u`` over a partition subset and compute the restricted ``kl_c``.
+
+        Args:
+            z_m: Latent samples for the group ``[m, n_latent]``.
+            qz_mean_m: ``q(z|x)`` mean ``[m, n_latent]``.
+            qz_std_m: ``q(z|x)`` std ``[m, n_latent]``.
+            q_partition_m: Full partition posterior for the group ``[m, n_partition]``.
+            set_idx: Partition indices ``S`` to marginalize over ``[s]``.
+
+        Returns:
+            ``(kl_z, kl_u, kl_c)`` each ``[m]``. ``kl_c`` is exactly 0 when ``|S| == 1``.
+        """
+        m = z_m.shape[0]
+        s = int(set_idx.numel())
+        device = z_m.device
+
+        q_S = q_partition_m[:, set_idx]  # [m, s]
+        q_S_norm = q_S / q_S.sum(dim=-1, keepdim=True).clamp_min(_EPS)  # [m, s]
+
+        # Restricted kl_c = KL(q(.|z, c in S) || p(.|c in S))
+        p_S = self.y_prior[set_idx]
+        p_S = p_S / p_S.sum().clamp_min(_EPS)
+        kl_c = (q_S_norm * (q_S_norm.clamp_min(_EPS).log() - p_S.unsqueeze(0).clamp_min(_EPS).log())).sum(dim=-1)
+
+        kl_z = torch.zeros(m, device=device)
+        kl_u = torch.zeros(m, device=device)
+        for start in range(0, s, self.chunk_size):
+            end = min(start + self.chunk_size, s)
+            chunk = end - start
+            members = set_idx[start:end]  # [chunk]
+            c_onehot = F.one_hot(members, self.n_partition).float()  # [chunk, n_partition]
+
+            z_exp = z_m.unsqueeze(1).expand(-1, chunk, -1).reshape(m * chunk, -1)
+            qzm_exp = qz_mean_m.unsqueeze(1).expand(-1, chunk, -1).reshape(m * chunk, -1)
+            qzs_exp = qz_std_m.unsqueeze(1).expand(-1, chunk, -1).reshape(m * chunk, -1)
+            c_exp = c_onehot.unsqueeze(0).expand(m, -1, -1).reshape(m * chunk, -1)
+
+            kl_z_c, kl_u_c = self._conditional_kls(z_exp, qzm_exp, qzs_exp, c_exp)
+            kl_z_c = kl_z_c.view(m, chunk)
+            kl_u_c = kl_u_c.view(m, chunk)
+            w = q_S_norm[:, start:end]
+            kl_z = kl_z + (w * kl_z_c).sum(dim=-1)
+            kl_u = kl_u + (w * kl_u_c).sum(dim=-1)
+
+        return kl_z, kl_u, kl_c
+
+    def _resolve_group(self, label: str) -> tuple[torch.Tensor, int | None]:
+        """Resolve a label string to ``(marg_partition_idx, ce_target_or_None)``.
+
+        ``ce_target`` indexes the classifier output space (partition idx in flat mode, active
+        node idx in ontology mode). It is ``None`` for the unlabeled category.
+        """
+        all_frontier = torch.arange(self.n_partition, dtype=torch.long)
+        if label == self.unlabeled_category:
+            return all_frontier, None
+        if self.classifier_type == "flat":
+            if label not in self._label_to_partition_idx:
+                raise ValueError(f"Unknown cell type label {label!r} (not in cell_type_categories).")
+            idx = self._label_to_partition_idx[label]
+            return torch.tensor([idx], dtype=torch.long), idx
+        if label not in self._label_to_active_idx:
+            raise ValueError(f"Cell type label {label!r} does not map to any active ontology node.")
+        active_idx = self._label_to_active_idx[label]
+        set_idx = (self.frontier_membership_af[active_idx] > 0).nonzero(as_tuple=True)[0].cpu()
+        return set_idx, active_idx
 
     # ------------------------------------------------------------------
     # Forward
@@ -271,9 +651,9 @@ class SCANVI(SingleCellVariationalInference):
         continuous_covariates_nc: torch.Tensor | None = None,
         categorical_covariate_index_nd: torch.Tensor | None = None,
         total_mrna_umis_n: torch.Tensor | None = None,
-        cell_type_index_n: torch.Tensor | None = None,
+        cell_type_labels_n: np.ndarray | None = None,
     ) -> dict:
-        """Compute scANVI ELBO and auxiliary classification loss.
+        """Compute the scANVI ELBO and auxiliary classification loss.
 
         Args:
             x_ng: Gene counts matrix ``[N, G]``.
@@ -282,21 +662,15 @@ class SCANVI(SingleCellVariationalInference):
             continuous_covariates_nc: Continuous covariates ``[N, C]``.
             categorical_covariate_index_nd: Integer categorical covariate codes ``[N, D]``.
             total_mrna_umis_n: Total mRNA UMIs per cell (not log-scaled).
-            cell_type_index_n: Integer cell-type codes ``[N]``.  Cells with code equal to
-                ``unlabeled_category_index`` (default ``-1``) are treated as unlabeled.
-                If ``None``, all cells are treated as unlabeled.
+            cell_type_labels_n: Per-cell string labels ``[N]``. Cells equal to
+                ``unlabeled_category`` (default ``"unknown"``) are treated as unlabeled. Finer-than-
+                frontier labels are binned to their frontier ancestor; coarse labels marginalize
+                over their subtree. If ``None``, all cells are treated as unlabeled.
 
         Returns:
-            A dictionary with keys:
-                - ``"loss"``: Scalar training loss.
-                - ``"reconstruction_loss"``: Per-cell NLL ``[N]``.
-                - ``"kl_divergence_z"``: Per-cell ``KL(q(z|x) || p(z|u,c))`` ``[N]``.
-                - ``"kl_divergence_u"``: Per-cell ``KL(q(u|z,c) || N(0,I))`` ``[N]``.
-                - ``"kl_divergence_c"``: Per-cell ``KL(q(c|z) || p(c))`` (unlabeled only) ``[N]``.
-                - ``"kl_divergence_batch"``: Per-cell batch-embedding KL (if configured) ``[N]``.
-                - ``"classification_loss"``: Per-cell cross-entropy (labeled only) ``[N]``.
-                - ``"z_nk"``: Latent samples ``[N, n_latent]``.
-                - ``"cell_type_logits_nc"``: Raw classifier logits ``[N, n_classes]``.
+            A dict with ``loss``, ``reconstruction_loss``, ``kl_divergence_z``, ``kl_divergence_u``,
+            ``kl_divergence_c``, ``kl_divergence_batch``, ``classification_loss``, ``z_nk``, and
+            ``cell_type_logits_nc`` (classifier logits in its output space).
         """
         assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
         assert_arrays_equal("var_names_g", var_names_g, "var_names_g", self.var_names_g)
@@ -304,8 +678,10 @@ class SCANVI(SingleCellVariationalInference):
         n = x_ng.shape[0]
         device = x_ng.device
 
-        if cell_type_index_n is None:
-            cell_type_index_n = torch.full((n,), self.unlabeled_category_index, dtype=torch.long, device=device)
+        if cell_type_labels_n is None:
+            labels = np.array([self.unlabeled_category] * n, dtype=object)
+        else:
+            labels = np.asarray(cell_type_labels_n).reshape(-1)
 
         batch_nb = self.batch_representation_from_batch_index(batch_index_n)
         categorical_covariate_np = self.categorical_onehot_from_categorical_index(categorical_covariate_index_nd)
@@ -323,7 +699,6 @@ class SCANVI(SingleCellVariationalInference):
         else:
             inference_input_x_ng = x_ng
 
-        # --- scVI encoder q(z|x) and decoder p(x|z) — unchanged from parent ---
         inference_outputs = self.inference(
             x_ng=inference_input_x_ng,
             batch_nb=batch_nb,
@@ -338,14 +713,13 @@ class SCANVI(SingleCellVariationalInference):
             categorical_covariate_np=categorical_covariate_np,
         )
 
-        z = inference_outputs["z"]  # [N, n_latent]
-        qz = inference_outputs["qz"]  # Normal with batch_shape [N, n_latent]
-        qz_mean = qz.mean  # [N, n_latent]
-        qz_std = qz.stddev  # [N, n_latent]
+        z = inference_outputs["z"]
+        qz = inference_outputs["qz"]
+        qz_mean = qz.mean
+        qz_std = qz.stddev
 
-        rec_loss_n = -generative_outputs["px"].log_prob(x_ng).sum(dim=-1)  # [N]
+        rec_loss_n = -generative_outputs["px"].log_prob(x_ng).sum(dim=-1)
 
-        # KL annealing weight — applied to kl_z and kl_u only, per user spec
         kl_annealing_weight = compute_annealed_kl_weight(
             epoch=self.epoch,
             step=self.step,
@@ -355,101 +729,50 @@ class SCANVI(SingleCellVariationalInference):
             min_kl_weight=self.kl_annealing_start,
         )
 
-        # Optional batch-embedding KL (inherited from scVI; annealed with kl_z/kl_u)
         kl_divergence_batch_n = torch.zeros(n, device=device)
         if self.batch_representation_sampled and (self.batch_kl_weight_max > 0):
-            kl_divergence_batch_n = kl(
+            kl_divergence_batch_n = torch.distributions.kl_divergence(
                 self.batch_embedding_distribution(batch_index_n=batch_index_n),
                 Normal(torch.zeros_like(batch_nb), torch.ones_like(batch_nb)),
             ).sum(dim=1)
 
-        # --- Classifier q(c|z): use qz.mean for stability ---
-        logits_nc = self.cell_type_classifier(qz_mean)  # [N, n_classes]
-        probs_nc = F.softmax(logits_nc, dim=-1)  # [N, n_classes]
-
-        # --- Labeled / unlabeled split ---
-        labeled_mask = cell_type_index_n != self.unlabeled_category_index
-        unlabeled_mask = ~labeled_mask
+        # Classifier logits (batch-agnostic: depends only on z via qz.mean).
+        logits = self.cell_type_classifier(qz_mean)  # [n, classifier_out_dim]
+        q_partition = self._partition_probs(logits)  # [n, n_partition]
 
         kl_z_n = torch.zeros(n, device=device)
         kl_u_n = torch.zeros(n, device=device)
         kl_c_n = torch.zeros(n, device=device)
         ce_loss_n = torch.zeros(n, device=device)
 
-        # --- Labeled cells: use known class, add cross-entropy loss ---
-        if labeled_mask.any():
-            idx_lab = labeled_mask.nonzero(as_tuple=True)[0]
-            true_labels = cell_type_index_n[idx_lab]  # [N_lab]
-            c_true = F.one_hot(true_labels, self.n_classes).float()  # [N_lab, n_classes]
+        # Group cells by label string: same label -> same marginalization set and CE target.
+        for label in np.unique(labels):
+            group = np.where(labels == label)[0]
+            idx = torch.as_tensor(group, dtype=torch.long, device=device)
+            set_idx, ce_target = self._resolve_group(str(label))
+            set_idx = set_idx.to(device)
 
-            kl_z_lab, kl_u_lab = self._compute_conditional_kls(
-                z=z[idx_lab],
-                qz_mean=qz_mean[idx_lab],
-                qz_std=qz_std[idx_lab],
-                c_onehot=c_true,
+            if self.classifier_type == "ontology" and ce_target is not None and set_idx.numel() > 1:
+                frac = set_idx.numel() / max(self.n_partition, 1)
+                if frac > self.marginalization_warn_fraction and label not in self._warned_marg_labels:
+                    self._warned_marg_labels.add(str(label))
+                    warnings.warn(
+                        f"Coarse label {label!r} marginalizes over {set_idx.numel()}/{self.n_partition} "
+                        f"frontier nodes ({frac:.0%}); this costs nearly as much as an unlabeled cell.",
+                        UserWarning,
+                    )
+
+            kl_z_g, kl_u_g, kl_c_g = self._marginalize_over_set(
+                z[idx], qz_mean[idx], qz_std[idx], q_partition[idx], set_idx
             )
-            kl_z_n[idx_lab] = kl_z_lab
-            kl_u_n[idx_lab] = kl_u_lab
-            ce_loss_n[idx_lab] = F.cross_entropy(logits_nc[idx_lab], true_labels, reduction="none")
+            kl_z_n[idx] = kl_z_g
+            kl_u_n[idx] = kl_u_g
+            kl_c_n[idx] = kl_c_g
 
-        # --- Unlabeled cells: marginalize over classes in chunks ---
-        if unlabeled_mask.any():
-            idx_unl = unlabeled_mask.nonzero(as_tuple=True)[0]
-            n_unl = idx_unl.shape[0]
+            if ce_target is not None:
+                target = torch.full((idx.numel(),), ce_target, dtype=torch.long, device=device)
+                ce_loss_n[idx] = self._supervised_ce(logits[idx], target)
 
-            z_unl = z[idx_unl]  # [N_unl, n_latent]
-            qz_mean_unl = qz_mean[idx_unl]  # [N_unl, n_latent]
-            qz_std_unl = qz_std[idx_unl]  # [N_unl, n_latent]
-            probs_unl = probs_nc[idx_unl]  # [N_unl, n_classes]
-
-            kl_z_sum = torch.zeros(n_unl, device=device)
-            kl_u_sum = torch.zeros(n_unl, device=device)
-
-            for start in range(0, self.n_classes, self.chunk_size):
-                end = min(start + self.chunk_size, self.n_classes)
-                chunk = end - start
-
-                # One-hot vectors for this chunk's classes: [chunk, n_classes]
-                c_chunk = F.one_hot(torch.arange(start, end, device=device), self.n_classes).float()
-
-                # Expand to [N_unl, chunk, ...]
-                c_expanded = c_chunk.unsqueeze(0).expand(n_unl, -1, -1)  # [N_unl, chunk, n_classes]
-                z_expanded = z_unl.unsqueeze(1).expand(-1, chunk, -1)  # [N_unl, chunk, n_latent]
-                qz_mean_exp = qz_mean_unl.unsqueeze(1).expand(-1, chunk, -1)  # [N_unl, chunk, n_latent]
-                qz_std_exp = qz_std_unl.unsqueeze(1).expand(-1, chunk, -1)  # [N_unl, chunk, n_latent]
-
-                # Reshape to 2D for network forward passes (avoids BatchNorm1d shape issues)
-                nc = n_unl * chunk
-                zc_2d = torch.cat([z_expanded, c_expanded], dim=-1).reshape(nc, -1)
-                c_2d = c_expanded.reshape(nc, -1)
-
-                qu_chunk = self.u_encoder(zc_2d)  # Normal([nc, n_latent])
-                u_sample = qu_chunk.rsample()  # [nc, n_latent]
-
-                pz_chunk = self.z_prior_decoder(torch.cat([u_sample, c_2d], dim=-1))  # Normal([nc, n_latent])
-
-                qz_chunk = Normal(qz_mean_exp.reshape(nc, -1), qz_std_exp.reshape(nc, -1))
-                pu_chunk = Normal(torch.zeros_like(u_sample), torch.ones_like(u_sample))
-
-                # Per-chunk KLs, reshaped to [N_unl, chunk]
-                kl_z_chunk = kl(qz_chunk, pz_chunk).sum(dim=-1).view(n_unl, chunk)
-                kl_u_chunk = kl(qu_chunk, pu_chunk).sum(dim=-1).view(n_unl, chunk)
-
-                # Weight by predicted class probabilities and accumulate
-                probs_chunk = probs_unl[:, start:end]  # [N_unl, chunk]
-                kl_z_sum += (probs_chunk * kl_z_chunk).sum(dim=-1)
-                kl_u_sum += (probs_chunk * kl_u_chunk).sum(dim=-1)
-
-            kl_z_n[idx_unl] = kl_z_sum
-            kl_u_n[idx_unl] = kl_u_sum
-
-            # KL(q(c|z) || p(c)) for unlabeled cells — not annealed
-            kl_c_n[idx_unl] = kl(
-                Categorical(probs=probs_unl),
-                Categorical(probs=self.y_prior.unsqueeze(0).expand(n_unl, -1)),
-            )
-
-        # --- Loss assembly ---
         loss = torch.mean(
             rec_loss_n
             + kl_annealing_weight
@@ -467,14 +790,14 @@ class SCANVI(SingleCellVariationalInference):
             "kl_divergence_batch": kl_divergence_batch_n,
             "classification_loss": ce_loss_n,
             "z_nk": z,
-            "cell_type_logits_nc": logits_nc,
+            "cell_type_logits_nc": logits,
         }
 
     # ------------------------------------------------------------------
     # Validation
     # ------------------------------------------------------------------
 
-    def validate(
+    def validate(  # type: ignore[override]
         self,
         trainer: pl.Trainer,
         pl_module: pl.LightningModule,
@@ -485,88 +808,57 @@ class SCANVI(SingleCellVariationalInference):
         continuous_covariates_nc: torch.Tensor | None = None,
         categorical_covariate_index_nd: torch.Tensor | None = None,
         total_mrna_umis_n: torch.Tensor | None = None,
-        validation_cell_type_index_n: torch.Tensor | None = None,
-        cell_type_index_n: torch.Tensor | None = None,
+        cell_type_labels_n: np.ndarray | None = None,
     ) -> None:
-        n = x_ng.shape[0]
+        """Log ``val_loss`` (ELBO) and a SOCAM-style cell-type accuracy on labeled cells.
 
+        The accuracy is the mean propagated probability at the resolved ground-truth node
+        (ontology mode) or the mean predicted probability of the true class (flat mode).
+        """
         output = self(
             x_ng=x_ng,
             var_names_g=var_names_g,
             batch_index_n=batch_index_n,
-            cell_type_index_n=cell_type_index_n,
             continuous_covariates_nc=continuous_covariates_nc,
             categorical_covariate_index_nd=categorical_covariate_index_nd,
             total_mrna_umis_n=total_mrna_umis_n,
+            cell_type_labels_n=cell_type_labels_n,
         )
+        loss = output["loss"]
+        if isinstance(loss, torch.Tensor):
+            pl_module.log("val_loss", loss, sync_dist=True, on_epoch=True, batch_size=x_ng.shape[0])
 
-        if isinstance(output["loss"], torch.Tensor):
-            pl_module.log("val_loss", output["loss"], sync_dist=True, on_epoch=True, batch_size=n)
+        if cell_type_labels_n is None:
+            return
+        labels = np.asarray(cell_type_labels_n).reshape(-1)
+        labeled = labels != self.unlabeled_category
+        if not labeled.any():
+            return
 
-        # Full ELBO includes kl_u and kl_c (unlike base scVI)
-        kl_batch = output["kl_divergence_batch"]
-        rec_loss = output["reconstruction_loss"]
-        kl_z_val = output["kl_divergence_z"]
-        kl_u_val = output["kl_divergence_u"]
-        kl_c_val = output["kl_divergence_c"]
-        z_nk = output["z_nk"]
-        assert isinstance(kl_batch, torch.Tensor)
-        assert isinstance(rec_loss, torch.Tensor)
-        assert isinstance(kl_z_val, torch.Tensor)
-        assert isinstance(kl_u_val, torch.Tensor)
-        assert isinstance(kl_c_val, torch.Tensor)
-        assert isinstance(z_nk, torch.Tensor)
+        logits = output["cell_type_logits_nc"]
+        assert isinstance(logits, torch.Tensor)
 
-        elbo_n = -(rec_loss + kl_z_val + kl_u_val + kl_c_val + kl_batch)
-        self._val_elbo_sum += elbo_n.sum().detach()
-        self._val_rec_sum += rec_loss.sum().detach()
-        self._val_n_cells += n
+        if self.classifier_type == "flat":
+            probs = F.softmax(logits, dim=-1)
+            scores = []
+            for i in np.where(labeled)[0]:
+                label = str(labels[i])
+                if label not in self._label_to_partition_idx:
+                    continue
+                scores.append(probs[i, self._label_to_partition_idx[label]])
+        else:
+            probs = self._propagate_probs(F.softmax(logits, dim=-1))
+            scores = []
+            for i in np.where(labeled)[0]:
+                label = str(labels[i])
+                if label not in self._label_to_active_idx:
+                    continue
+                scores.append(probs[i, self._label_to_active_idx[label]])
 
-        z_nk = z_nk.detach()
-
-        # Per-class z sums for ontology metric (uses validation labels, not training labels)
-        if validation_cell_type_index_n is not None and self.num_classes is not None:
-            idx = validation_cell_type_index_n.long()
-            self._val_z_sum_kd.index_add_(0, idx, z_nk)
-            self._val_class_count_k.index_add_(0, idx, torch.ones(n, device=x_ng.device))
-
-        # Per-batch z sums for batch silhouette metric
-        if self.n_batch > 1:
-            bidx = batch_index_n.long()
-            self._val_batch_z_sum_bk.index_add_(0, bidx, z_nk)
-            self._val_batch_z_sq_sum_b.index_add_(0, bidx, (z_nk**2).sum(dim=-1))
-            self._val_batch_count_b.index_add_(0, bidx, torch.ones(n, device=x_ng.device))
-
-        # Reservoir sampling for cell-type logistic-regression classifier
-        if validation_cell_type_index_n is not None and self.num_classes is not None:
-            if batch_idx % 2 == 0:
-                buf_z, buf_y = self._val_cl_train_z, self._val_cl_train_y
-                fill, seen = self._val_cl_train_fill, self._val_cl_train_seen
-            else:
-                buf_z, buf_y = self._val_cl_test_z, self._val_cl_test_y
-                fill, seen = self._val_cl_test_fill, self._val_cl_test_seen
-
-            rs = self.val_cell_type_classifier_reservoir_size
-            labels = validation_cell_type_index_n.long()
-
-            space = rs - fill
-            direct = min(space, n)
-            if direct > 0:
-                buf_z[fill : fill + direct] = z_nk[:direct]
-                buf_y[fill : fill + direct] = labels[:direct]
-                fill += direct
-
-            for i in range(direct, n):
-                j = int(torch.randint(0, seen + i - direct + 1, (1,)).item())
-                if j < rs:
-                    buf_z[j] = z_nk[i]
-                    buf_y[j] = labels[i]
-
-            seen += n
-            if batch_idx % 2 == 0:
-                self._val_cl_train_fill, self._val_cl_train_seen = fill, seen
-            else:
-                self._val_cl_test_fill, self._val_cl_test_seen = fill, seen
+        if scores:
+            metric = torch.stack(scores).mean()
+            name = "val_ontology_accuracy" if self.classifier_type == "ontology" else "val_accuracy"
+            pl_module.log(name, metric, sync_dist=True, on_epoch=True, batch_size=len(scores))
 
     # ------------------------------------------------------------------
     # Predict
@@ -588,19 +880,16 @@ class SCANVI(SingleCellVariationalInference):
         Args:
             x_ng: Gene counts matrix ``[N, G]``.
             var_names_g: Variable names for input validation.
-            batch_index_n: Integer batch indices ``[N]``.
+            batch_index_n: Integer batch indices ``[N]``. (Consumed by the encoder; may be a dummy
+                when the encoder is configured batch-agnostic.)
             continuous_covariates_nc: Continuous covariates ``[N, C]``.
             categorical_covariate_index_nd: Integer categorical covariate codes ``[N, D]``.
 
         Returns:
-            A dictionary with keys:
-
-            - ``"x_ng"``: Latent embeddings ``[N, n_latent]`` (keyed ``"x_ng"`` for
-              pipeline compatibility).
-            - ``"cell_type_probs_nc"``: Soft cell-type probabilities ``[N, n_classes]``.
-
-            When :attr:`reconstruct_counts_on_predict` is ``True`` the dict contains only
-            the reconstructed counts under ``"x_ng"`` (parent behaviour).
+            A dict with ``x_ng`` (latent embeddings ``[N, n_latent]``) and ``cell_type_probs_nc``.
+            In ontology mode ``cell_type_probs_nc`` is the propagated probability over all active
+            nodes (``[N, n_active]``, columns = :attr:`active_cl_names`); in flat mode it is the
+            softmax over the partition (``[N, n_partition]``).
         """
         if self.reconstruct_counts_on_predict:
             return super().predict(
@@ -625,8 +914,11 @@ class SCANVI(SingleCellVariationalInference):
         )
         qz = inference_outputs["qz"]
         z_nk = self._latent_value_from_latent_distribution(qz)
-        logits_nc = self.cell_type_classifier(qz.mean)
-        probs_nc = F.softmax(logits_nc, dim=-1)
+        logits = self.cell_type_classifier(qz.mean)
+        if self.classifier_type == "flat":
+            probs_nc = F.softmax(logits, dim=-1)
+        else:
+            probs_nc = self._propagate_probs(F.softmax(logits, dim=-1))
 
         return {
             "x_ng": z_nk,

--- a/cellarium/ml/models/scvi.py
+++ b/cellarium/ml/models/scvi.py
@@ -600,6 +600,7 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
         cell_type_categories: list[str] | None = None,
         ontology_distance_matrix: pd.DataFrame | None = None,
         val_cell_type_classifier_reservoir_size: int = 50_000,
+        use_torch_compile: bool = False,
     ):
         super().__init__()
         self.var_names_g = np.array(var_names_g)
@@ -840,6 +841,13 @@ class SingleCellVariationalInference(CellariumModel, PredictMixin, ValidateMixin
             and len(self.n_cats_per_cov) > 0
             and sum(self.n_cats_per_cov) > 0
         )
+
+        self.use_torch_compile = use_torch_compile
+        if use_torch_compile:
+            # Wraps each module in an OptimizedModule; state_dict keys gain an _orig_mod. prefix,
+            # so checkpoints are only compatible across runs with the same use_torch_compile setting.
+            self.z_encoder = torch.compile(self.z_encoder, dynamic=True)  # type: ignore[assignment]
+            self.decoder = torch.compile(self.decoder, dynamic=True)  # type: ignore[assignment]
 
         self.reset_parameters()
 

--- a/cellarium/ml/models/socam.py
+++ b/cellarium/ml/models/socam.py
@@ -6,6 +6,7 @@ from typing import TypedDict
 
 import lightning.pytorch as pl
 import numpy as np
+import pandas as pd
 import torch
 import torch.nn.functional
 
@@ -81,8 +82,7 @@ def _build_nonleaf_info(desc_matrix_cc: torch.Tensor) -> NonleafInfo:
     return {"nonleaf_desc_cc": nonleaf_desc_cc, "perm": perm, "inv_perm": inv_perm}
 
 
-@torch.compile()
-def propagate_probs(probs_nc: torch.Tensor, descendant_tensor_cc: torch.Tensor) -> torch.Tensor:
+def _propagate_probs_impl(probs_nc: torch.Tensor, descendant_tensor_cc: torch.Tensor) -> torch.Tensor:
     """
     Propagate probabilities up the hierarchy defined by ``descendant_tensor_cc`` using matrix multiplication.
     This effectively sums the probabilities of all descendant categories for each category.
@@ -103,13 +103,17 @@ def propagate_probs(probs_nc: torch.Tensor, descendant_tensor_cc: torch.Tensor) 
     return torch.clamp(propagated_probs_nc, max=1.0)
 
 
+# Compiled wrapper (used by SOCAM). The plain ``_propagate_probs_impl`` is importable by callers
+# (e.g. SCANVI) that want to avoid recompilation for variable-shape inputs.
+propagate_probs = torch.compile(_propagate_probs_impl)
+
+
 def _logsumexp_propagated(logits_nc: torch.Tensor, desc_matrix_cc: torch.Tensor) -> torch.Tensor:
     temp = torch.where(desc_matrix_cc.T == 0, float("-inf"), logits_nc.unsqueeze(dim=-1) * desc_matrix_cc.T)
     return temp.logsumexp(dim=1)
 
 
-@torch.compile()
-def propagate_logits(
+def _propagate_logits_impl(
     logits_nc: torch.Tensor,
     nonleaf_desc_cc: torch.Tensor,
     perm: torch.Tensor,
@@ -143,6 +147,69 @@ def propagate_logits(
     leaf_part = logits_reordered[:, c_nonleaf:]  # (n, c_leaf)
     out = torch.cat([nonleaf_part, leaf_part], dim=1)[:, inv_perm]  # (n, c) original order
     return out - torch.logsumexp(logits_nc, dim=1, keepdim=True)
+
+
+# Compiled wrapper (used by SOCAM). The plain ``_propagate_logits_impl`` is importable by callers
+# (e.g. SCANVI) that want an eager version to avoid recompilation for variable-shape inputs.
+propagate_logits = torch.compile(_propagate_logits_impl)
+
+
+def compute_class_weights(
+    active_cl_names: list[str],
+    class_counts: "pd.Series | None",
+    active_descendant_tensor_cc: torch.Tensor,
+    propagate_class_counts: bool = False,
+    normalize: str = "class_mean",
+) -> torch.Tensor | None:
+    """Compute per-class cross-entropy weights from training cell counts.
+
+    Classes absent from ``class_counts`` (typically pure-ancestor nodes with no direct cell
+    labels) and classes with a count of zero are treated as unlabeled and receive a neutral
+    weight of 1.0. Inverse-frequency weights are computed over the nonzero-count classes only.
+
+    Args:
+        active_cl_names: Ordered list of active category names (defines the output order).
+        class_counts: Optional pandas Series mapping class names to training cell counts.
+            When ``None`` this returns ``None`` (no weighting). Extra entries not in
+            ``active_cl_names`` are ignored. Negative counts raise a ``ValueError``.
+        active_descendant_tensor_cc: ``(c, c)`` binary descendant submatrix over the active
+            categories (diagonal included). Used only when ``propagate_class_counts`` is True.
+        propagate_class_counts: If True, propagate raw counts up the ontology
+            (``active_descendant_tensor_cc @ counts``) so each node's effective count becomes
+            its own count plus the sum of all descendant counts.
+        normalize: Normalization convention for the inverse-frequency weights.
+            ``"class_mean"`` (SOCAM, self-normalizing ``reduction="mean"`` CE) divides by the
+            unweighted class mean. ``"data_mean"`` (SCANVI, ``reduction="none"`` CE) leaves the
+            weights with a data-frequency-weighted mean of 1 so an outer scalar weight keeps
+            its meaning.
+
+    Returns:
+        A float tensor of length ``len(active_cl_names)``, or ``None`` if ``class_counts`` is None.
+    """
+    if class_counts is None:
+        return None
+    provided_counts = {c: class_counts[c] for c in active_cl_names if c in class_counts.index}
+    if any(v < 0 for v in provided_counts.values()):
+        raise ValueError("All class_counts values must be >= 0.")
+    # Pin to CPU so this works inside a torch.device("meta") construction context.
+    counts = torch.tensor(
+        [float(provided_counts.get(c, 0.0)) for c in active_cl_names], dtype=torch.float, device="cpu"
+    )
+    if propagate_class_counts:
+        counts = active_descendant_tensor_cc.cpu() @ counts
+    nonzero = counts > 0
+    weights = torch.ones(len(active_cl_names), dtype=torch.float, device="cpu")
+    if nonzero.any():
+        total = counts[nonzero].sum()
+        n_nonzero = nonzero.sum().float()
+        raw = total / (n_nonzero * counts[nonzero])  # data-frequency-weighted mean of 1
+        if normalize == "class_mean":
+            weights[nonzero] = raw / raw.mean()
+        elif normalize == "data_mean":
+            weights[nonzero] = raw
+        else:
+            raise ValueError(f"normalize must be 'class_mean' or 'data_mean', got {normalize!r}.")
+    return weights
 
 
 class SOCAM(CellariumModel, PredictMixin, ValidateMixin):

--- a/cellarium/ml/models/socam.py
+++ b/cellarium/ml/models/socam.py
@@ -334,25 +334,15 @@ class SOCAM(CellariumModel, PredictMixin, ValidateMixin):
         self.b_c = torch.nn.Parameter(torch.empty(self.n_active_cats, dtype=torch.float))
 
         # Class weights for cross-entropy loss
-        if class_counts is not None:
-            provided_counts = {c: class_counts[c] for c in active_cl_names if c in class_counts.index}
-            if any(v < 0 for v in provided_counts.values()):
-                raise ValueError("All class_counts values must be >= 0.")
-            counts = torch.tensor([float(provided_counts.get(c, 0.0)) for c in active_cl_names], dtype=torch.float)
-            if propagate_class_counts:
-                counts = active_descendant_tensor_cc @ counts
-            nonzero = counts > 0
-            weights = torch.ones(self.n_active_cats, dtype=torch.float)
-            if nonzero.any():
-                total = counts[nonzero].sum()
-                n_nonzero = nonzero.sum().float()
-                raw = total / (n_nonzero * counts[nonzero])
-                weights[nonzero] = raw / raw.mean()
-            self._class_weights: torch.Tensor | None = weights
-            self.register_buffer("class_weights", weights.clone())
-        else:
-            self._class_weights = None
-            self.register_buffer("class_weights", None)
+        weights = compute_class_weights(
+            active_cl_names=active_cl_names,
+            class_counts=class_counts,
+            active_descendant_tensor_cc=active_descendant_tensor_cc,
+            propagate_class_counts=propagate_class_counts,
+            normalize="class_mean",
+        )
+        self._class_weights: torch.Tensor | None = weights
+        self.register_buffer("class_weights", weights.clone() if weights is not None else None)
 
         self.reset_parameters()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import pytest
 import torch
 
@@ -1201,7 +1202,7 @@ SINGLE_DEVICE_CONFIGS = [
                 "model": {
                     "class_path": "cellarium.ml.models.SCANVI",
                     "init_args": {
-                        "n_classes": 5,
+                        "classifier_type": "flat",
                         "n_batch": None,
                         "use_size_factor_key": False,
                         "encoder": {
@@ -1250,6 +1251,10 @@ SINGLE_DEVICE_CONFIGS = [
                         "key": "dataset_id",
                         "convert_fn": "cellarium.ml.utilities.data.categories_to_codes",
                     },
+                    "cell_type_labels_n": {
+                        "attr": "obs",
+                        "key": "cell_type",
+                    },
                 },
                 "batch_size": "50",
                 "num_workers": "0",
@@ -1263,6 +1268,115 @@ SINGLE_DEVICE_CONFIGS = [
         },
     },
 ]
+
+
+def _build_scanvi_ontology_inputs() -> tuple[torch.Tensor, list[str], pd.Series]:
+    """Build a small hierarchical ontology for the SCANVI ``classifier_type="ontology"`` CLI test.
+
+    Reuses the SOCAM CL-ID leaves (which cover the labels present in the public test shards) and
+    stacks a synthetic two-level hierarchy on top: ``CL_ROOT -> GROUP_i -> leaves``. Counts are
+    chosen so that the last group's leaves are individually under-supported and roll up to their
+    ``GROUP_*`` node, exercising the frontier cut, finer-than-frontier binning, and propagation
+    over internal active nodes.
+    """
+    socam_cfg = next(c for c in SINGLE_DEVICE_CONFIGS if c["model_name"] == "socam")
+    leaves: list[str] = list(socam_cfg["fit"]["model"]["model"]["init_args"]["cl_names"])  # type: ignore[index]
+    groups = [f"GROUP_{i}" for i in range(5)]
+    root = "CL_ROOT"
+    cl_names = [root] + groups + leaves
+    index = {name: i for i, name in enumerate(cl_names)}
+    desc = torch.eye(len(cl_names))
+    per_group = -(-len(leaves) // len(groups))  # ceil division
+    counts: dict[str, float] = {}
+    for name in groups + leaves:
+        desc[index[root], index[name]] = 1.0  # root is an ancestor of every node
+    for li, leaf in enumerate(leaves):
+        group = groups[min(li // per_group, len(groups) - 1)]
+        desc[index[group], index[leaf]] = 1.0
+        # last group's leaves are sparse -> the GROUP node becomes the frontier and they bin up
+        counts[leaf] = 5.0 if group == groups[-1] else 100.0
+    return desc, cl_names, pd.Series(counts)
+
+
+_SCANVI_ONT_DESC, _SCANVI_ONT_CL_NAMES, _SCANVI_ONT_COUNTS = _build_scanvi_ontology_inputs()
+
+SINGLE_DEVICE_CONFIGS.append(
+    {
+        "model_name": "scanvi",
+        "_display_id": "scanvi_ontology",
+        "subcommand": "fit",
+        "fit": {
+            "model": {
+                "model": {
+                    "class_path": "cellarium.ml.models.SCANVI",
+                    "init_args": {
+                        "classifier_type": "ontology",
+                        "descendant_tensor": _SCANVI_ONT_DESC,
+                        "cl_names": _SCANVI_ONT_CL_NAMES,
+                        "class_counts": _SCANVI_ONT_COUNTS,
+                        "frontier_min_cells": 50,
+                        "propagate_class_counts": True,
+                        "classifier_n_hidden": [32],
+                        "secondary_n_hidden": [32],
+                        "n_batch": None,
+                        "use_size_factor_key": False,
+                        "encoder": {
+                            "hidden_layers": [],
+                            "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}},
+                        },
+                        "decoder": {
+                            "hidden_layers": [
+                                {
+                                    "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                                    "init_args": {"out_features": 128, "label_to_bias_hidden_layers": []},
+                                }
+                            ],
+                            "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}},
+                            "final_additive_bias": True,
+                        },
+                    },
+                },
+                "optim_fn": "torch.optim.Adam",
+                "optim_kwargs": {"lr": "1e-3"},
+            },
+            "data": {
+                "dadc": {
+                    "class_path": "cellarium.ml.data.DistributedAnnDataCollection",
+                    "init_args": {
+                        "filenames": "https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_{0..1}.h5ad",
+                        "shard_size": "100",
+                        "max_cache_size": "2",
+                        "obs_columns_to_validate": ["cell_type_ontology_term_id"],
+                    },
+                },
+                "batch_keys": {
+                    "x_ng": {
+                        "attr": "X",
+                        "convert_fn": "cellarium.ml.utilities.data.densify",
+                    },
+                    "var_names_g": {"attr": "var_names"},
+                    "batch_index_n": {
+                        "attr": "obs",
+                        "key": "dataset_id",
+                        "convert_fn": "cellarium.ml.utilities.data.categories_to_codes",
+                    },
+                    "cell_type_labels_n": {
+                        "attr": "obs",
+                        "key": "cell_type_ontology_term_id",
+                    },
+                },
+                "batch_size": "50",
+                "num_workers": "0",
+                "val_size": "0.1",
+            },
+            "trainer": {
+                "accelerator": "cpu",
+                "devices": devices,
+                "max_epochs": 3,
+            },
+        },
+    }
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1193,6 +1193,75 @@ SINGLE_DEVICE_CONFIGS = [
             },
         },
     },
+    {
+        "model_name": "scanvi",
+        "subcommand": "fit",
+        "fit": {
+            "model": {
+                "model": {
+                    "class_path": "cellarium.ml.models.SCANVI",
+                    "init_args": {
+                        "n_classes": 5,
+                        "n_batch": None,
+                        "use_size_factor_key": False,
+                        "encoder": {
+                            "hidden_layers": [],
+                            "final_layer": {
+                                "class_path": "torch.nn.Linear",
+                                "init_args": {},
+                            },
+                        },
+                        "decoder": {
+                            "hidden_layers": [
+                                {
+                                    "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+                                    "init_args": {"out_features": 128, "label_to_bias_hidden_layers": []},
+                                }
+                            ],
+                            "final_layer": {
+                                "class_path": "torch.nn.Linear",
+                                "init_args": {},
+                            },
+                            "final_additive_bias": True,
+                        },
+                    },
+                },
+                "optim_fn": "torch.optim.Adam",
+                "optim_kwargs": {"lr": "1e-3"},
+            },
+            "data": {
+                "dadc": {
+                    "class_path": "cellarium.ml.data.DistributedAnnDataCollection",
+                    "init_args": {
+                        "filenames": "https://storage.googleapis.com/dsp-cellarium-cas-public/test-data/test_{0..1}.h5ad",
+                        "shard_size": "100",
+                        "max_cache_size": "2",
+                        "obs_columns_to_validate": [],
+                    },
+                },
+                "batch_keys": {
+                    "x_ng": {
+                        "attr": "X",
+                        "convert_fn": "cellarium.ml.utilities.data.densify",
+                    },
+                    "var_names_g": {"attr": "var_names"},
+                    "batch_index_n": {
+                        "attr": "obs",
+                        "key": "dataset_id",
+                        "convert_fn": "cellarium.ml.utilities.data.categories_to_codes",
+                    },
+                },
+                "batch_size": "50",
+                "num_workers": "0",
+                "val_size": "0.1",
+            },
+            "trainer": {
+                "accelerator": "cpu",
+                "devices": devices,
+                "max_epochs": 3,
+            },
+        },
+    },
 ]
 
 

--- a/tests/test_scanvi.py
+++ b/tests/test_scanvi.py
@@ -1,0 +1,241 @@
+# Copyright Contributors to the Cellarium project.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+from pathlib import Path
+
+import lightning.pytorch as pl
+import numpy as np
+import pytest
+import torch
+
+from cellarium.ml import CellariumModule
+from cellarium.ml.models import SCANVI
+from cellarium.ml.utilities.data import collate_fn
+from tests.common import BoringDatasetSCVI
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+
+class BoringDatasetSCANVI(BoringDatasetSCVI):
+    """BoringDatasetSCVI extended with cell_type_index_n."""
+
+    def __init__(
+        self,
+        data: np.ndarray,
+        batch_index_n: np.ndarray,
+        cell_type_index_n: np.ndarray,
+        var_names: np.ndarray | None = None,
+    ) -> None:
+        super().__init__(data=data, batch_index_n=batch_index_n, var_names=var_names)
+        self.cell_type_index_n = cell_type_index_n
+
+    def __getitem__(self, idx: int) -> dict[str, np.ndarray]:
+        return super().__getitem__(idx) | {"cell_type_index_n": self.cell_type_index_n[idx, None]}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_ENCODER_CFG = {
+    "hidden_layers": [
+        {
+            "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+            "init_args": {"out_features": 32, "label_to_bias_hidden_layers": []},
+        },
+    ],
+    "final_layer": {
+        "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+        "init_args": {"label_to_bias_hidden_layers": []},
+    },
+}
+
+_DECODER_CFG = {
+    "hidden_layers": [
+        {
+            "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+            "init_args": {"out_features": 32, "label_to_bias_hidden_layers": []},
+        },
+    ],
+    "final_layer": {
+        "class_path": "cellarium.ml.models.scvi.LinearWithBatch",
+        "init_args": {"label_to_bias_hidden_layers": []},
+    },
+    "final_additive_bias": False,
+}
+
+
+def _make_scanvi(var_names_g, *, n_batch: int = 2, n_latent: int = 8, n_classes: int = 5) -> SCANVI:
+    return SCANVI(
+        n_classes=n_classes,
+        classifier_n_hidden=[32],
+        secondary_n_hidden=[32],
+        chunk_size=3,  # forces multiple chunks with n_classes=5
+        var_names_g=var_names_g,
+        n_batch=n_batch,
+        n_latent=n_latent,
+        encoder=_ENCODER_CFG,
+        decoder=_DECODER_CFG,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_loss_structure() -> None:
+    """Labeled and unlabeled cells contribute distinct loss terms."""
+    n, g, n_batch, n_classes = 16, 50, 2, 5
+    n_labeled = 8
+    var_names_g = np.array([f"gene_{i}" for i in range(g)])
+
+    torch.manual_seed(0)
+    model = _make_scanvi(var_names_g, n_batch=n_batch, n_classes=n_classes)
+    model.eval()
+
+    x_ng = torch.poisson(torch.ones(n, g) * 2).float()
+    batch_index_n = torch.zeros(n, dtype=torch.long)
+
+    # First n_labeled cells are labeled; the rest use the unlabeled sentinel (-1)
+    cell_type_index_n = torch.full((n,), -1, dtype=torch.long)
+    cell_type_index_n[:n_labeled] = torch.randint(0, n_classes, (n_labeled,))
+
+    with torch.no_grad():
+        out = model(
+            x_ng=x_ng,
+            var_names_g=var_names_g,
+            batch_index_n=batch_index_n,
+            cell_type_index_n=cell_type_index_n,
+        )
+
+    ce = out["classification_loss"]
+    kl_c = out["kl_divergence_c"]
+    kl_z = out["kl_divergence_z"]
+    kl_u = out["kl_divergence_u"]
+    loss = out["loss"]
+    assert isinstance(ce, torch.Tensor)
+    assert isinstance(kl_c, torch.Tensor)
+    assert isinstance(kl_z, torch.Tensor)
+    assert isinstance(kl_u, torch.Tensor)
+    assert isinstance(loss, torch.Tensor)
+
+    # Cross-entropy is positive for labeled cells, exactly zero for unlabeled
+    assert (ce[:n_labeled] > 0).all(), "Expected positive CE loss for labeled cells"
+    assert ce[n_labeled:].sum() == 0.0, "Expected zero CE loss for unlabeled cells"
+
+    # kl_c is exactly zero for labeled cells, positive for unlabeled
+    assert kl_c[:n_labeled].sum() == 0.0, "Expected zero kl_c for labeled cells"
+    assert (kl_c[n_labeled:] > 0).all(), "Expected positive kl_c for unlabeled cells"
+
+    # KL terms are non-negative for all cells
+    assert (kl_z >= 0).all(), "kl_z must be non-negative"
+    assert (kl_u >= 0).all(), "kl_u must be non-negative"
+
+    assert loss.isfinite(), "Scalar loss must be finite"
+
+
+def test_predict_shapes() -> None:
+    """predict() returns embeddings and normalized class probabilities."""
+    n, g, n_batch, n_classes, n_latent = 16, 50, 2, 5, 8
+    var_names_g = np.array([f"gene_{i}" for i in range(g)])
+
+    model = _make_scanvi(var_names_g, n_batch=n_batch, n_latent=n_latent, n_classes=n_classes)
+    model.eval()
+
+    x_ng = torch.poisson(torch.ones(n, g) * 2).float()
+    batch_index_n = torch.zeros(n, dtype=torch.long)
+
+    with torch.no_grad():
+        pred = model.predict(x_ng=x_ng, var_names_g=var_names_g, batch_index_n=batch_index_n)
+
+    assert pred["x_ng"].shape == (n, n_latent), f"Expected [{n}, {n_latent}], got {pred['x_ng'].shape}"
+    assert pred["cell_type_probs_nc"].shape == (n, n_classes), (
+        f"Expected [{n}, {n_classes}], got {pred['cell_type_probs_nc'].shape}"
+    )
+    assert torch.allclose(pred["cell_type_probs_nc"].sum(dim=-1), torch.ones(n), atol=1e-5), (
+        "Cell-type probabilities must sum to 1"
+    )
+    assert (pred["cell_type_probs_nc"] >= 0).all(), "Probabilities must be non-negative"
+
+
+def test_checkpoint_roundtrip(tmp_path: Path) -> None:
+    """Saving and reloading a checkpoint preserves predict() outputs exactly."""
+    n, g, n_batch, n_classes = 32, 50, 2, 5
+    batch_size = 8
+    var_names_g = np.array([f"gene_{i}" for i in range(g)])
+    devices = int(os.environ.get("TEST_DEVICES", "1"))
+
+    rng = np.random.default_rng(42)
+    x = rng.poisson(lam=2.0, size=(n, g)).astype(np.float32)
+    batch_idx = rng.integers(0, n_batch, size=n)
+    # ~half labeled, half unlabeled
+    labeled_mask = rng.random(n) < 0.5
+    cell_type_idx = np.where(labeled_mask, rng.integers(0, n_classes, size=n), -1)
+
+    train_loader = torch.utils.data.DataLoader(
+        BoringDatasetSCANVI(
+            data=x,
+            batch_index_n=batch_idx,
+            cell_type_index_n=cell_type_idx,
+            var_names=var_names_g,
+        ),
+        collate_fn=collate_fn,
+        batch_size=batch_size,
+    )
+
+    torch.manual_seed(0)
+    model = _make_scanvi(var_names_g, n_batch=n_batch, n_classes=n_classes)
+    module = CellariumModule(model=model, optim_fn=torch.optim.Adam, optim_kwargs={"lr": 1e-3})
+
+    trainer = pl.Trainer(
+        accelerator="cpu",
+        devices=devices,
+        max_steps=2,
+        enable_checkpointing=False,
+    )
+    trainer.fit(module, train_dataloaders=train_loader)
+
+    ckpt_path = tmp_path / "scanvi.ckpt"
+    trainer.save_checkpoint(ckpt_path)
+
+    # Capture predict() output from the original model
+    x_t = torch.tensor(x)
+    b_t = torch.tensor(batch_idx, dtype=torch.long)
+    model.eval()
+    with torch.no_grad():
+        pre = model.predict(x_ng=x_t, var_names_g=var_names_g, batch_index_n=b_t)
+
+    # Reload and verify outputs are identical
+    loaded_model = CellariumModule.load_from_checkpoint(ckpt_path).model
+    assert isinstance(loaded_model, SCANVI)
+    loaded_model.eval()
+    with torch.no_grad():
+        post = loaded_model.predict(x_ng=x_t, var_names_g=var_names_g, batch_index_n=b_t)
+
+    torch.testing.assert_close(pre["x_ng"], post["x_ng"])
+    torch.testing.assert_close(pre["cell_type_probs_nc"], post["cell_type_probs_nc"])
+
+
+def test_guard_use_flow_raises() -> None:
+    """SCANVI must reject use_flow=True at construction time."""
+    var_names_g = np.array([f"gene_{i}" for i in range(10)])
+    with pytest.raises(ValueError, match="use_flow"):
+        SCANVI(
+            n_classes=3,
+            var_names_g=var_names_g,
+            n_batch=1,
+            use_flow=True,
+            encoder={
+                "hidden_layers": [],
+                "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}},
+            },
+            decoder={
+                "hidden_layers": [],
+                "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}},
+                "final_additive_bias": False,
+            },
+        )

--- a/tests/test_scanvi.py
+++ b/tests/test_scanvi.py
@@ -6,11 +6,13 @@ from pathlib import Path
 
 import lightning.pytorch as pl
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
 from cellarium.ml import CellariumModule
 from cellarium.ml.models import SCANVI
+from cellarium.ml.models.scanvi import compute_frontier
 from cellarium.ml.utilities.data import collate_fn
 from tests.common import BoringDatasetSCVI
 
@@ -20,20 +22,20 @@ from tests.common import BoringDatasetSCVI
 
 
 class BoringDatasetSCANVI(BoringDatasetSCVI):
-    """BoringDatasetSCVI extended with cell_type_index_n."""
+    """BoringDatasetSCVI extended with string cell-type labels."""
 
     def __init__(
         self,
         data: np.ndarray,
         batch_index_n: np.ndarray,
-        cell_type_index_n: np.ndarray,
+        cell_type_labels_n: np.ndarray,
         var_names: np.ndarray | None = None,
     ) -> None:
         super().__init__(data=data, batch_index_n=batch_index_n, var_names=var_names)
-        self.cell_type_index_n = cell_type_index_n
+        self.cell_type_labels_n = cell_type_labels_n
 
     def __getitem__(self, idx: int) -> dict[str, np.ndarray]:
-        return super().__getitem__(idx) | {"cell_type_index_n": self.cell_type_index_n[idx, None]}
+        return super().__getitem__(idx) | {"cell_type_labels_n": self.cell_type_labels_n[idx, None]}
 
 
 # ---------------------------------------------------------------------------
@@ -68,12 +70,13 @@ _DECODER_CFG = {
 }
 
 
-def _make_scanvi(var_names_g, *, n_batch: int = 2, n_latent: int = 8, n_classes: int = 5) -> SCANVI:
+def _make_flat(var_names_g, *, n_batch=2, n_latent=8, cell_type_categories=("T", "B", "NK", "Mono", "DC")):
     return SCANVI(
-        n_classes=n_classes,
+        classifier_type="flat",
+        cell_type_categories=list(cell_type_categories),
         classifier_n_hidden=[32],
         secondary_n_hidden=[32],
-        chunk_size=3,  # forces multiple chunks with n_classes=5
+        chunk_size=3,
         var_names_g=var_names_g,
         n_batch=n_batch,
         n_latent=n_latent,
@@ -82,89 +85,283 @@ def _make_scanvi(var_names_g, *, n_batch: int = 2, n_latent: int = 8, n_classes:
     )
 
 
+def _toy_ontology():
+    """Return (cl_names, descendant_tensor) for R -> {T -> {CD4, CD8}, B, Mono}."""
+    cl_names = ["R", "T", "B", "Mono", "CD4", "CD8", "unknown"]
+    idx = {n: i for i, n in enumerate(cl_names)}
+    c = len(cl_names)
+    desc = torch.eye(c)
+    # R is an ancestor of everything (except unknown)
+    for child in ["T", "B", "Mono", "CD4", "CD8"]:
+        desc[idx["R"], idx[child]] = 1.0
+    # T is an ancestor of CD4, CD8
+    desc[idx["T"], idx["CD4"]] = 1.0
+    desc[idx["T"], idx["CD8"]] = 1.0
+    return cl_names, desc
+
+
+def _make_ontology(var_names_g, *, n_batch=2, n_latent=8, class_counts=None, **kwargs):
+    cl_names, desc = _toy_ontology()
+    if class_counts is None:
+        class_counts = pd.Series({"CD4": 100.0, "CD8": 80.0, "B": 60.0, "Mono": 70.0, "T": 15.0})
+    return SCANVI(
+        classifier_type="ontology",
+        descendant_tensor=desc,
+        cl_names=cl_names,
+        class_counts=class_counts,
+        frontier_min_cells=50,
+        classifier_n_hidden=[32],
+        secondary_n_hidden=[32],
+        chunk_size=2,
+        var_names_g=var_names_g,
+        n_batch=n_batch,
+        n_latent=n_latent,
+        cell_type_categories=cl_names,
+        encoder=_ENCODER_CFG,
+        decoder=_DECODER_CFG,
+        **kwargs,
+    )
+
+
 # ---------------------------------------------------------------------------
-# Tests
+# Frontier construction
 # ---------------------------------------------------------------------------
 
 
-def test_loss_structure() -> None:
-    """Labeled and unlabeled cells contribute distinct loss terms."""
-    n, g, n_batch, n_classes = 16, 50, 2, 5
+def test_frontier_basic_cut():
+    """A > 50 with children C > 50 and B = 5 -> frontier {B, C} (B added by coverage repair)."""
+    cl = ["A", "B", "C", "unknown"]
+    desc = torch.eye(4)
+    desc[0, 1] = 1.0
+    desc[0, 2] = 1.0
+    counts = torch.tensor([0.0, 5.0, 100.0, 0.0])
+    frontier, under = compute_frontier(desc, cl, counts, min_cells=50, excluded_names={"unknown"})
+    assert set(frontier) == {"B", "C"}
+    assert under == ["B"]
+
+
+def test_frontier_deep_orphan_rolls_up_to_shallowest():
+    """A deep orphan (A -> B -> B1, B1=5; A -> C, C=100) rolls up to B, not B1."""
+    cl = ["A", "B", "B1", "C", "unknown"]
+    desc = torch.eye(5)
+    desc[0, 1] = desc[0, 2] = desc[0, 3] = 1.0  # A ancestor of B, B1, C
+    desc[1, 2] = 1.0  # B ancestor of B1
+    counts = torch.tensor([0.0, 0.0, 5.0, 100.0, 0.0])
+    frontier, _ = compute_frontier(desc, cl, counts, min_cells=50, excluded_names={"unknown"})
+    assert set(frontier) == {"B", "C"}
+
+
+def test_frontier_and_active_set_on_model():
+    var_names_g = np.array([f"g{i}" for i in range(20)])
+    # T has only 15 direct cells but its subtree (CD4+CD8+T) is large, so T is coarse (not frontier).
+    model = _make_ontology(var_names_g)
+    # frontier = deepest nodes with >= 50 subtree support = {CD4, CD8, B, Mono}
+    assert set(model.frontier_cl_names) == {"CD4", "CD8", "B", "Mono"}
+    assert model.n_partition == 4
+    # active set = frontier + ancestors {R, T}
+    assert set(model.active_cl_names) == {"CD4", "CD8", "B", "Mono", "R", "T"}
+
+
+# ---------------------------------------------------------------------------
+# Flat mode
+# ---------------------------------------------------------------------------
+
+
+def test_flat_loss_structure():
+    n, g = 16, 50
     n_labeled = 8
     var_names_g = np.array([f"gene_{i}" for i in range(g)])
+    categories = ["T", "B", "NK", "Mono", "DC"]
 
     torch.manual_seed(0)
-    model = _make_scanvi(var_names_g, n_batch=n_batch, n_classes=n_classes)
+    model = _make_flat(var_names_g, cell_type_categories=categories)
     model.eval()
 
     x_ng = torch.poisson(torch.ones(n, g) * 2).float()
     batch_index_n = torch.zeros(n, dtype=torch.long)
 
-    # First n_labeled cells are labeled; the rest use the unlabeled sentinel (-1)
-    cell_type_index_n = torch.full((n,), -1, dtype=torch.long)
-    cell_type_index_n[:n_labeled] = torch.randint(0, n_classes, (n_labeled,))
+    rng = np.random.default_rng(0)
+    labels = np.array(["unknown"] * n, dtype=object)
+    labels[:n_labeled] = rng.choice(categories, size=n_labeled)
 
+    with torch.no_grad():
+        out = model(x_ng=x_ng, var_names_g=var_names_g, batch_index_n=batch_index_n, cell_type_labels_n=labels)
+
+    ce = out["classification_loss"]
+    kl_c = out["kl_divergence_c"]
+    assert isinstance(ce, torch.Tensor)
+    assert isinstance(kl_c, torch.Tensor)
+
+    labeled = labels != "unknown"
+    unlabeled = ~labeled
+    assert (ce[labeled] > 0).all()
+    assert ce[unlabeled].sum() == 0.0
+    assert torch.allclose(kl_c[labeled], torch.zeros(int(labeled.sum())), atol=1e-5)
+    assert (kl_c[unlabeled] > 0).all()
+    assert out["loss"].isfinite()
+
+
+def test_flat_requires_cell_type_categories():
+    var_names_g = np.array([f"g{i}" for i in range(10)])
+    with pytest.raises(ValueError, match="cell_type_categories"):
+        SCANVI(
+            classifier_type="flat",
+            var_names_g=var_names_g,
+            n_batch=1,
+            encoder={"hidden_layers": [], "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}}},
+            decoder={
+                "hidden_layers": [],
+                "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}},
+                "final_additive_bias": False,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ontology mode
+# ---------------------------------------------------------------------------
+
+
+def test_ontology_loss_structure():
+    """Frontier labels -> kl_c 0; coarse/unlabeled -> kl_c > 0; labeled -> CE > 0."""
+    n, g = 18, 50
+    var_names_g = np.array([f"gene_{i}" for i in range(g)])
+    torch.manual_seed(0)
+    model = _make_ontology(var_names_g)
+    model.eval()
+
+    x_ng = torch.poisson(torch.ones(n, g) * 2).float()
+    batch_index_n = torch.zeros(n, dtype=torch.long)
+    # CD4/CD8/B/Mono are frontier leaves; T is coarse (marginalize CD4,CD8); unknown is unlabeled
+    labels = np.array(
+        ["CD4", "CD8", "B", "Mono", "T", "unknown"] * 3,
+        dtype=object,
+    )
+
+    with torch.no_grad():
+        out = model(x_ng=x_ng, var_names_g=var_names_g, batch_index_n=batch_index_n, cell_type_labels_n=labels)
+
+    ce = out["classification_loss"]
+    kl_c = out["kl_divergence_c"]
+    assert isinstance(ce, torch.Tensor)
+    assert isinstance(kl_c, torch.Tensor)
+
+    frontier_mask = np.isin(labels, ["CD4", "CD8", "B", "Mono"])
+    coarse_mask = labels == "T"
+    unlabeled_mask = labels == "unknown"
+
+    # frontier (known) labels: kl_c == 0 (restricted kl_c over a singleton set)
+    assert torch.allclose(kl_c[frontier_mask], torch.zeros(int(frontier_mask.sum())), atol=1e-5)
+    # coarse and unlabeled: kl_c > 0 (marginalize over a set of size > 1)
+    assert (kl_c[coarse_mask] > 0).all()
+    assert (kl_c[unlabeled_mask] > 0).all()
+    # CE positive for any label, zero for unlabeled
+    assert (ce[~unlabeled_mask] > 0).all()
+    assert ce[unlabeled_mask].sum() == 0.0
+    assert out["loss"].isfinite()
+
+
+def test_ontology_finer_than_frontier_bins_up():
+    """A label finer than the frontier is binned to its frontier ancestor (no error)."""
+    n, g = 6, 30
+    var_names_g = np.array([f"g{i}" for i in range(g)])
+    # Add a finer node CD4mem under CD4 with too few cells to be its own frontier node.
+    cl_names = ["R", "T", "B", "Mono", "CD4", "CD8", "CD4mem", "unknown"]
+    idx = {nm: i for i, nm in enumerate(cl_names)}
+    desc = torch.eye(len(cl_names))
+    for child in ["T", "B", "Mono", "CD4", "CD8", "CD4mem"]:
+        desc[idx["R"], idx[child]] = 1.0
+    desc[idx["T"], idx["CD4"]] = desc[idx["T"], idx["CD8"]] = desc[idx["T"], idx["CD4mem"]] = 1.0
+    desc[idx["CD4"], idx["CD4mem"]] = 1.0
+    counts = pd.Series({"CD4": 100.0, "CD8": 80.0, "B": 60.0, "Mono": 70.0, "CD4mem": 3.0})
+
+    torch.manual_seed(0)
+    model = SCANVI(
+        classifier_type="ontology",
+        descendant_tensor=desc,
+        cl_names=cl_names,
+        class_counts=counts,
+        frontier_min_cells=50,
+        classifier_n_hidden=[16],
+        secondary_n_hidden=[16],
+        var_names_g=var_names_g,
+        n_batch=1,
+        n_latent=6,
+        cell_type_categories=cl_names,
+        encoder=_ENCODER_CFG,
+        decoder=_DECODER_CFG,
+    )
+    # CD4mem should resolve to the CD4 frontier leaf
+    assert model._label_to_active_idx["CD4mem"] == model._label_to_active_idx["CD4"]
+
+    model.eval()
+    x_ng = torch.poisson(torch.ones(n, g) * 2).float()
+    labels = np.array(["CD4mem", "CD4", "CD8", "B", "Mono", "unknown"], dtype=object)
     with torch.no_grad():
         out = model(
             x_ng=x_ng,
             var_names_g=var_names_g,
-            batch_index_n=batch_index_n,
-            cell_type_index_n=cell_type_index_n,
+            batch_index_n=torch.zeros(n, dtype=torch.long),
+            cell_type_labels_n=labels,
         )
-
-    ce = out["classification_loss"]
+    # CD4mem behaves like CD4 (frontier leaf): kl_c == 0
     kl_c = out["kl_divergence_c"]
-    kl_z = out["kl_divergence_z"]
-    kl_u = out["kl_divergence_u"]
-    loss = out["loss"]
-    assert isinstance(ce, torch.Tensor)
     assert isinstance(kl_c, torch.Tensor)
-    assert isinstance(kl_z, torch.Tensor)
-    assert isinstance(kl_u, torch.Tensor)
-    assert isinstance(loss, torch.Tensor)
-
-    # Cross-entropy is positive for labeled cells, exactly zero for unlabeled
-    assert (ce[:n_labeled] > 0).all(), "Expected positive CE loss for labeled cells"
-    assert ce[n_labeled:].sum() == 0.0, "Expected zero CE loss for unlabeled cells"
-
-    # kl_c is exactly zero for labeled cells, positive for unlabeled
-    assert kl_c[:n_labeled].sum() == 0.0, "Expected zero kl_c for labeled cells"
-    assert (kl_c[n_labeled:] > 0).all(), "Expected positive kl_c for unlabeled cells"
-
-    # KL terms are non-negative for all cells
-    assert (kl_z >= 0).all(), "kl_z must be non-negative"
-    assert (kl_u >= 0).all(), "kl_u must be non-negative"
-
-    assert loss.isfinite(), "Scalar loss must be finite"
+    assert torch.allclose(kl_c[0], torch.tensor(0.0), atol=1e-5)
 
 
-def test_predict_shapes() -> None:
-    """predict() returns embeddings and normalized class probabilities."""
-    n, g, n_batch, n_classes, n_latent = 16, 50, 2, 5, 8
-    var_names_g = np.array([f"gene_{i}" for i in range(g)])
+def test_ontology_class_weights_shape_and_default():
+    var_names_g = np.array([f"g{i}" for i in range(20)])
+    model = _make_ontology(var_names_g, propagate_class_counts=True)
+    assert model.class_weights is not None
+    assert model.class_weights.shape == (model.n_active,)
+    # data-frequency-weighted mean of weights ~ 1 is not asserted here (depends on propagation);
+    # just check all weights are positive and finite
+    assert bool((model.class_weights > 0).all())
+    assert bool(torch.isfinite(model.class_weights).all())
 
-    model = _make_scanvi(var_names_g, n_batch=n_batch, n_latent=n_latent, n_classes=n_classes)
+
+# ---------------------------------------------------------------------------
+# Predict
+# ---------------------------------------------------------------------------
+
+
+def test_flat_predict_shapes():
+    n, g, n_latent = 12, 50, 8
+    categories = ["T", "B", "NK", "Mono", "DC"]
+    var_names_g = np.array([f"g{i}" for i in range(g)])
+    model = _make_flat(var_names_g, n_latent=n_latent, cell_type_categories=categories)
     model.eval()
-
     x_ng = torch.poisson(torch.ones(n, g) * 2).float()
-    batch_index_n = torch.zeros(n, dtype=torch.long)
-
     with torch.no_grad():
-        pred = model.predict(x_ng=x_ng, var_names_g=var_names_g, batch_index_n=batch_index_n)
-
-    assert pred["x_ng"].shape == (n, n_latent), f"Expected [{n}, {n_latent}], got {pred['x_ng'].shape}"
-    assert pred["cell_type_probs_nc"].shape == (n, n_classes), (
-        f"Expected [{n}, {n_classes}], got {pred['cell_type_probs_nc'].shape}"
-    )
-    assert torch.allclose(pred["cell_type_probs_nc"].sum(dim=-1), torch.ones(n), atol=1e-5), (
-        "Cell-type probabilities must sum to 1"
-    )
-    assert (pred["cell_type_probs_nc"] >= 0).all(), "Probabilities must be non-negative"
+        pred = model.predict(x_ng=x_ng, var_names_g=var_names_g, batch_index_n=torch.zeros(n, dtype=torch.long))
+    assert pred["x_ng"].shape == (n, n_latent)
+    assert pred["cell_type_probs_nc"].shape == (n, len(categories))
+    assert torch.allclose(pred["cell_type_probs_nc"].sum(-1), torch.ones(n), atol=1e-5)
 
 
-def test_checkpoint_roundtrip(tmp_path: Path) -> None:
-    """Saving and reloading a checkpoint preserves predict() outputs exactly."""
-    n, g, n_batch, n_classes = 32, 50, 2, 5
+def test_ontology_predict_shapes():
+    n, g, n_latent = 12, 50, 8
+    var_names_g = np.array([f"g{i}" for i in range(g)])
+    model = _make_ontology(var_names_g, n_latent=n_latent)
+    model.eval()
+    x_ng = torch.poisson(torch.ones(n, g) * 2).float()
+    with torch.no_grad():
+        pred = model.predict(x_ng=x_ng, var_names_g=var_names_g, batch_index_n=torch.zeros(n, dtype=torch.long))
+    assert pred["x_ng"].shape == (n, n_latent)
+    # propagated probabilities over all active nodes
+    assert pred["cell_type_probs_nc"].shape == (n, model.n_active)
+    assert (pred["cell_type_probs_nc"] >= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint round-trip (also exercises the meta-device path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["flat", "ontology"])
+def test_checkpoint_roundtrip(mode, tmp_path: Path):
+    n, g, n_batch = 40, 50, 2
     batch_size = 8
     var_names_g = np.array([f"gene_{i}" for i in range(g)])
     devices = int(os.environ.get("TEST_DEVICES", "1"))
@@ -172,67 +369,63 @@ def test_checkpoint_roundtrip(tmp_path: Path) -> None:
     rng = np.random.default_rng(42)
     x = rng.poisson(lam=2.0, size=(n, g)).astype(np.float32)
     batch_idx = rng.integers(0, n_batch, size=n)
-    # ~half labeled, half unlabeled
-    labeled_mask = rng.random(n) < 0.5
-    cell_type_idx = np.where(labeled_mask, rng.integers(0, n_classes, size=n), -1)
+
+    if mode == "flat":
+        categories = ["T", "B", "NK", "Mono", "DC"]
+        pool = np.array(categories + ["unknown"], dtype=object)
+        labels = rng.choice(pool, size=n)
+        torch.manual_seed(0)
+        model = _make_flat(var_names_g, n_batch=n_batch, cell_type_categories=categories)
+    else:
+        pool = np.array(["CD4", "CD8", "B", "Mono", "T", "unknown"], dtype=object)
+        labels = rng.choice(pool, size=n)
+        torch.manual_seed(0)
+        model = _make_ontology(var_names_g, n_batch=n_batch)
 
     train_loader = torch.utils.data.DataLoader(
-        BoringDatasetSCANVI(
-            data=x,
-            batch_index_n=batch_idx,
-            cell_type_index_n=cell_type_idx,
-            var_names=var_names_g,
-        ),
+        BoringDatasetSCANVI(data=x, batch_index_n=batch_idx, cell_type_labels_n=labels, var_names=var_names_g),
         collate_fn=collate_fn,
         batch_size=batch_size,
     )
 
-    torch.manual_seed(0)
-    model = _make_scanvi(var_names_g, n_batch=n_batch, n_classes=n_classes)
     module = CellariumModule(model=model, optim_fn=torch.optim.Adam, optim_kwargs={"lr": 1e-3})
-
-    trainer = pl.Trainer(
-        accelerator="cpu",
-        devices=devices,
-        max_steps=2,
-        enable_checkpointing=False,
-    )
+    trainer = pl.Trainer(accelerator="cpu", devices=devices, max_steps=2, enable_checkpointing=False)
     trainer.fit(module, train_dataloaders=train_loader)
 
     ckpt_path = tmp_path / "scanvi.ckpt"
     trainer.save_checkpoint(ckpt_path)
 
-    # Capture predict() output from the original model
     x_t = torch.tensor(x)
     b_t = torch.tensor(batch_idx, dtype=torch.long)
     model.eval()
     with torch.no_grad():
         pre = model.predict(x_ng=x_t, var_names_g=var_names_g, batch_index_n=b_t)
 
-    # Reload and verify outputs are identical
-    loaded_model = CellariumModule.load_from_checkpoint(ckpt_path).model
-    assert isinstance(loaded_model, SCANVI)
-    loaded_model.eval()
+    loaded = CellariumModule.load_from_checkpoint(ckpt_path).model
+    assert isinstance(loaded, SCANVI)
+    loaded.eval()
     with torch.no_grad():
-        post = loaded_model.predict(x_ng=x_t, var_names_g=var_names_g, batch_index_n=b_t)
+        post = loaded.predict(x_ng=x_t, var_names_g=var_names_g, batch_index_n=b_t)
 
     torch.testing.assert_close(pre["x_ng"], post["x_ng"])
     torch.testing.assert_close(pre["cell_type_probs_nc"], post["cell_type_probs_nc"])
 
 
-def test_guard_use_flow_raises() -> None:
-    """SCANVI must reject use_flow=True at construction time."""
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+
+def test_guard_use_flow_raises():
     var_names_g = np.array([f"gene_{i}" for i in range(10)])
     with pytest.raises(ValueError, match="use_flow"):
         SCANVI(
-            n_classes=3,
+            classifier_type="flat",
+            cell_type_categories=["A", "B", "C"],
             var_names_g=var_names_g,
             n_batch=1,
             use_flow=True,
-            encoder={
-                "hidden_layers": [],
-                "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}},
-            },
+            encoder={"hidden_layers": [], "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}}},
             decoder={
                 "hidden_layers": [],
                 "final_layer": {"class_path": "torch.nn.Linear", "init_args": {}},

--- a/tests/test_socam.py
+++ b/tests/test_socam.py
@@ -12,7 +12,13 @@ import pytest
 import torch
 
 from cellarium.ml import CellariumModule
-from cellarium.ml.models.socam import SOCAM, _build_nonleaf_info, _expand_with_ancestors, _logsumexp_propagated
+from cellarium.ml.models.socam import (
+    SOCAM,
+    _build_nonleaf_info,
+    _expand_with_ancestors,
+    _logsumexp_propagated,
+    compute_class_weights,
+)
 from cellarium.ml.utilities.data import collate_fn
 
 
@@ -671,6 +677,85 @@ def test_logsumexp_propagated_mixed_extreme_logits():
     result.sum().backward()
     assert isinstance(logits_nc.grad, torch.Tensor)
     assert torch.all(torch.isfinite(logits_nc.grad)), f"Non-finite gradient: {logits_nc.grad}"
+
+
+# ---------------------------------------------------------------------------
+# compute_class_weights direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def _flat_desc(c: int) -> torch.Tensor:
+    """Identity descendant tensor (all leaves, no hierarchy)."""
+    return torch.eye(c, dtype=torch.float)
+
+
+def test_compute_class_weights_none_returns_none():
+    result = compute_class_weights(
+        active_cl_names=["A", "B"],
+        class_counts=None,
+        active_descendant_tensor_cc=_flat_desc(2),
+    )
+    assert result is None
+
+
+def test_compute_class_weights_class_mean_matches_socam():
+    """compute_class_weights(normalize='class_mean') must equal SOCAM's stored class_weights."""
+    c = 5
+    cl_names = [f"cell_type_{i}" for i in range(c)]
+    counts = pd.Series({f"cell_type_{i}": (i + 1) * 10 for i in range(c)})
+    desc = _flat_desc(c)
+    model = _make_socam(c=c, class_counts=counts)
+    direct = compute_class_weights(
+        active_cl_names=cl_names,
+        class_counts=counts,
+        active_descendant_tensor_cc=desc,
+        normalize="class_mean",
+    )
+    assert direct is not None
+    assert model.class_weights is not None
+    assert torch.allclose(model.class_weights, direct, atol=1e-6)
+
+
+def test_compute_class_weights_data_mean_has_weighted_mean_one():
+    """normalize='data_mean': the data-frequency-weighted mean of weights over nonzero classes is 1."""
+    c = 5
+    cl_names = [f"cell_type_{i}" for i in range(c)]
+    raw_counts = torch.tensor([(i + 1) * 10.0 for i in range(c)])
+    counts = pd.Series({f"cell_type_{i}": float(raw_counts[i]) for i in range(c)})
+    weights = compute_class_weights(
+        active_cl_names=cl_names,
+        class_counts=counts,
+        active_descendant_tensor_cc=_flat_desc(c),
+        normalize="data_mean",
+    )
+    assert weights is not None
+    # data-frequency-weighted mean: sum(w_i * n_i) / sum(n_i) == 1
+    weighted_mean = (weights * raw_counts).sum() / raw_counts.sum()
+    assert torch.allclose(weighted_mean, torch.tensor(1.0), atol=1e-6)
+
+
+def test_compute_class_weights_data_mean_vs_class_mean_same_ordering():
+    """Both normalizations must produce identical relative weight ordering."""
+    c = 5
+    cl_names = [f"cell_type_{i}" for i in range(c)]
+    counts = pd.Series({f"cell_type_{i}": (i + 1) * 10 for i in range(c)})
+    desc = _flat_desc(c)
+    w_cm = compute_class_weights(cl_names, counts, desc, normalize="class_mean")
+    w_dm = compute_class_weights(cl_names, counts, desc, normalize="data_mean")
+    assert w_cm is not None and w_dm is not None
+    # Ratios between any two nonzero-count classes must be identical across both normalizations.
+    for i in range(c - 1):
+        ratio_cm = (w_cm[i] / w_cm[i + 1]).item()
+        ratio_dm = (w_dm[i] / w_dm[i + 1]).item()
+        assert abs(ratio_cm - ratio_dm) < 1e-5, f"Ratio mismatch at i={i}: {ratio_cm} vs {ratio_dm}"
+
+
+def test_compute_class_weights_invalid_normalize_raises():
+    c = 3
+    cl_names = [f"cell_type_{i}" for i in range(c)]
+    counts = pd.Series({f"cell_type_{i}": 10 for i in range(c)})
+    with pytest.raises(ValueError, match="normalize"):
+        compute_class_weights(cl_names, counts, _flat_desc(c), normalize="bogus")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implement the scANVI model
https://docs.scvi-tools.org/en/stable/user_guide/models/scanvi.html

scANVI is a super cool model for cell type annotation that was published by Xu et al in 2021, and is based on the M1+M2 model from Kingma's 2014 "semi-supervised deep learning with deep generative models".

This implementation re-uses as much of the scVI implementation as possible.

In the future it may be possible to extend this in two very interesting ways for CAS:
1. calibrate the uncertainties in cell type label prediction to be accurate
2. compute an estimate for out-of-distribution probability, i.e. the probability that an observation is "novel"