### PR TITLE
NMF: automatic stopping strategy per k

### DIFF
--- a/cellarium/ml/models/nmf.py
+++ b/cellarium/ml/models/nmf.py
@@ -1751,8 +1751,7 @@ class NMFOutput:
             model = module.model
             if not is_subclass_by_name(model, "NonNegativeMatrixFactorization"):
                 raise ValueError(
-                    f"Checkpoint {path!r} model must be NonNegativeMatrixFactorization, "
-                    f"got {type(model).__name__}"
+                    f"Checkpoint {path!r} model must be NonNegativeMatrixFactorization, got {type(model).__name__}"
                 )
 
             if reference_var_names_g is None:
@@ -2030,7 +2029,6 @@ class NMFOutput:
 
         dataloader = self.datamodule.predict_dataloader()
         for full_batch in tqdm(dataloader):
-
             # get the batch used for inference (HVGs, same transforms as used for training)
             inference_batch = copy.deepcopy(full_batch)
             for transform in inference_transforms:
@@ -2053,9 +2051,9 @@ class NMFOutput:
             # incremental OLS fit update
             if ols_solver is None:
                 ols_solver = StreamingOrdinaryLeastSquares(
-                    var_names_g=np.arange(k).astype(str), 
-                    n_targets=len(full_batch["var_names_g"]), 
-                    univariate=False, 
+                    var_names_g=np.arange(k).astype(str),
+                    n_targets=len(full_batch["var_names_g"]),
+                    univariate=False,
                     ridge_penalty=0.0,
                 )
             assert isinstance(ols_solver, StreamingOrdinaryLeastSquares)

--- a/cellarium/ml/models/nmf.py
+++ b/cellarium/ml/models/nmf.py
@@ -184,6 +184,48 @@ def compute_reconstruction_error_compiled(
     return squared_error_r
 
 
+@torch.compile()
+@torch.no_grad()
+def frobenius_loss_trace_compiled(
+    x_ng: torch.Tensor,
+    h_rnk: torch.Tensor,
+    w_rkg: torch.Tensor,
+    # x_squared_sum: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """
+    Per-replicate ``||X - H W||_F^2`` computed *without* materializing the reconstruction.
+
+    Uses :math:`\\|X - HW\\|_F^2 = \\|X\\|^2 - 2\\langle HX, W\\rangle + \\langle H^\\top H,
+    WW^\\top\\rangle`, so the intermediates are ``(r, k, g)`` and ``(r, k, k)`` rather than
+    ``(r, n, g)``.  At ``r=100, n=2048, g=2000`` that is 80 MB instead of 1.6 GB.  And because
+    ``H`` is detached and ``X`` is data, both ``HX`` and ``H^T H`` are autograd constants: the
+    entire backward reduces to :math:`\\nabla_W = -2 HX + 2 (H^\\top H) W`.
+
+    This is why the loss is Frobenius rather than Poisson KL.  KL does not factorize this way, and
+    its Poisson justification does not survive per-gene rescaling of the input anyway.
+
+    Args:
+        x_ng: Data, shape ``(n, g)``.
+        h_rnk: Loadings, shape ``(r, n, k)``.
+        w_rkg: Factors, shape ``(r, k, g)``.
+        x_squared_sum: Optional precomputed ``(x_ng ** 2).sum()``, shared across replicates.
+
+    Returns:
+        Sum of squared errors per replicate, shape ``(r,)``.
+    """
+    # if x_squared_sum is None:
+    #     x_squared_sum = x_ng.pow(2).sum()
+    x_squared_sum = x_ng.pow(2).sum()
+    hx_rkg = torch.einsum("rnk,ng->rkg", h_rnk, x_ng)
+    hth_rkk = torch.einsum("rnk,rnj->rkj", h_rnk, h_rnk)
+    wwt_rkk = torch.einsum("rkg,rjg->rkj", w_rkg, w_rkg)
+    cross_r = (hx_rkg * w_rkg).sum(dim=(-2, -1))
+    quad_r = (hth_rkk * wwt_rkk).sum(dim=(-2, -1))
+    # Upcasting only the three reduced scalars is free and removes any cancellation concern.
+    sse_r = x_squared_sum.double() - 2.0 * cross_r.double() + quad_r.double()
+    return sse_r.clamp(min=0.0).to(w_rkg.dtype)
+
+
 def solve_nnls_fista(A, B, max_iter=1000, tol=1e-6):
     """
     FISTA algorithm for NNLS solving Ax = B for x >= 0

--- a/cellarium/ml/models/nmf_amortized.py
+++ b/cellarium/ml/models/nmf_amortized.py
@@ -385,7 +385,7 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         if self._train_nmf_loss_ema is not None:
             beta_pow_t = np.exp(-step / self.n_batches_for_forgetting_momentum)
             nmf_loss_ema_unbiased = self._train_nmf_loss_ema / (1 - beta_pow_t)
-            module.log("reconstruction_error", nmf_loss_ema_unbiased, prog_bar=True)
+            module.log("rec_error", nmf_loss_ema_unbiased, prog_bar=True)
 
         # --- log consensus metrics ---
         local_neighborhood_size = 0.3
@@ -415,7 +415,7 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
                     try:
                         if isinstance(logger, pl.loggers.TensorBoardLogger):
                             logger.experiment.add_histogram(
-                                f"k={k}__consensus_histogram",
+                                f"k={k}_consensus_histogram",
                                 mean_neighbor_distance_m,
                                 global_step=step,
                                 bins=np.linspace(0, 1, 75),
@@ -423,8 +423,8 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
                     except Exception as e:
                         warnings.warn(f"Failed to log histogram for k={k} step={step} due to {e}")
 
-                module.log(f"k={k}__consensus_L1", mean_neighbor_distance_m.mean(), prog_bar=False)
-                module.log(f"k={k}__consensus_q75", mean_neighbor_distance_m.quantile(0.75), prog_bar=True)
+                module.log(f"k={k}_consensus_L1", mean_neighbor_distance_m.mean(), prog_bar=False)
+                module.log(f"k={k}_consensus_q75", mean_neighbor_distance_m.quantile(0.75), prog_bar=True)
 
         # --- per-k forgetting convergence check and forgetting ---
         assert isinstance(trainer.max_epochs, int)

--- a/cellarium/ml/models/nmf_amortized.py
+++ b/cellarium/ml/models/nmf_amortized.py
@@ -478,6 +478,16 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
             getattr(self, f"A_{k}_rkk").zero_()
             getattr(self, f"B_{k}_rkg").zero_()
 
+        n_k_still_training = sum(
+            not (
+                self._k_in_final_epoch[k]
+                and isinstance(self._k_final_epoch_start[k], int)
+                and step - self._k_final_epoch_start[k] >= self.n_batches_per_epoch  # type: ignore[operator]
+            )
+            for k in self.k_values
+        )
+        module.log("k_training", float(n_k_still_training), prog_bar=True)
+
         if all_done:
             trainer.should_stop = True
             print("Stopping early: all k values have completed their final epoch")

--- a/cellarium/ml/models/nmf_amortized.py
+++ b/cellarium/ml/models/nmf_amortized.py
@@ -159,8 +159,8 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         forgetting_patience: int = 5,
         exploration_epochs: int = 2,
         cooldown_periods: int | None = None,
-        max_solver_iter_train: int = 100,
-        max_solver_iter_cooldown: int = 100,
+        max_solver_iter_train: int = 50,
+        max_solver_iter_cooldown: int = 200,
         init: Literal["sklearn_random", "uniform_random"] = "uniform_random",
         transformed_data_mean: None | float = None,
     ) -> None:

--- a/cellarium/ml/models/nmf_amortized.py
+++ b/cellarium/ml/models/nmf_amortized.py
@@ -18,6 +18,7 @@ from cellarium.ml.models.nmf import (
     NMFInitUniformRandom,
     NonNegativeMatrixFactorization,
     compute_reconstruction_error_compiled,
+    frobenius_loss_trace_compiled,
     nmf_frobenius_loss,
     online_dictionary_update_fista,
     online_dictionary_update_nmf_torch_hals,
@@ -154,8 +155,8 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         total_n_cells: int,
         batch_size: int,
         solver: Literal["hals", "fista"] = "fista",
-        forgetting_drift_threshold: float = 0.02,
-        forgetting_patience: int = 3,
+        forgetting_drift_threshold: float = 0.1,
+        forgetting_patience: int = 5,
         exploration_epochs: int = 2,
         init: Literal["sklearn_random", "uniform_random"] = "uniform_random",
         transformed_data_mean: None | float = None,
@@ -336,10 +337,15 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
             # if we want to track the NMF loss
             with torch.no_grad():
                 factors_rkg = getattr(self, f"D_{k}_rkg")
-                squared_error_r = compute_reconstruction_error_compiled(
+                # squared_error_r = compute_reconstruction_error_compiled(
+                #     x_ng=x_ng,
+                #     loadings_rnk=solver_loadings_rnk,
+                #     factors_rkg=factors_rkg,
+                # )
+                squared_error_r = frobenius_loss_trace_compiled(
                     x_ng=x_ng,
-                    loadings_rnk=solver_loadings_rnk,
-                    factors_rkg=factors_rkg,
+                    h_rnk=solver_loadings_rnk,
+                    w_rkg=factors_rkg,
                 )
                 nmf_reconstruction_error = squared_error_r.mean() / (x_ng.shape[0] * x_ng.shape[1])
                 nmf_reconstruction_errors.append(nmf_reconstruction_error)

--- a/cellarium/ml/models/nmf_amortized.py
+++ b/cellarium/ml/models/nmf_amortized.py
@@ -23,7 +23,6 @@ from cellarium.ml.models.nmf import (
     online_dictionary_update_nmf_torch_hals,
     solve_nnls_fista,
 )
-from cellarium.ml.utilities.convergence import NoisyConvergenceTracker
 from cellarium.ml.utilities.testing import (
     assert_arrays_equal,
     assert_columns_and_array_lengths_equal,
@@ -155,8 +154,9 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         total_n_cells: int,
         batch_size: int,
         solver: Literal["hals", "fista"] = "fista",
-        q75_convergence_threshold: float = 0.15,
-        check_convergence_every_n_steps: int = 5,
+        forgetting_drift_threshold: float = 0.02,
+        forgetting_patience: int = 3,
+        exploration_epochs: int = 2,
         init: Literal["sklearn_random", "uniform_random"] = "uniform_random",
         transformed_data_mean: None | float = None,
     ) -> None:
@@ -193,14 +193,10 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         # for training the encoder
         self.encoder_loss_fn = torch.nn.SmoothL1Loss(reduction="mean")
 
-        # self._D_tol = 1e-5
         self._alpha_tol = 1e-5
-        # self._hals_tol = 1e-4
-        # Sentinel parameter used to track the current device (mirrors OnlineNMF pattern)
-        # self._dummy_param = torch.nn.Parameter(torch.empty(()))
-        self.q75_convergence_threshold = q75_convergence_threshold
-        self.check_convergence_every_n_steps = check_convergence_every_n_steps
-        self.convergence_tracker = NoisyConvergenceTracker(window_size=25, patience=20, min_delta=1e-4)
+        self.forgetting_drift_threshold = forgetting_drift_threshold
+        self.forgetting_patience = forgetting_patience
+        self.exploration_epochs = exploration_epochs
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
@@ -222,7 +218,10 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
 
         self._train_nmf_loss_ema: torch.Tensor | None = None
         self._val_nmf_loss_ema: torch.Tensor | None = None
-        self.convergence_tracker.reset()
+        self._D_prev_snapshots: dict[int, torch.Tensor | None] = {k: None for k in self.k_values}
+        self._forgetting_patience_counters: dict[int, int] = {k: 0 for k in self.k_values}
+        self._k_in_final_epoch: dict[int, bool] = {k: False for k in self.k_values}
+        self._k_final_epoch_start: dict[int, int | None] = {k: None for k in self.k_values}
 
     @property
     def factors_dict(self) -> dict[int, torch.Tensor]:
@@ -313,8 +312,8 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         assert_columns_and_array_lengths_equal("x_ng", x_ng, "var_names_g", var_names_g)
         assert_arrays_equal("var_names_g", var_names_g, "self.var_names_g", self.var_names_g)
 
-        encoder_losses = []
-        nmf_reconstruction_errors = []
+        encoder_losses: list[torch.Tensor] = []
+        nmf_reconstruction_errors: list[torch.Tensor] = []
         for k in self.k_values:
             out = self.online_dictionary_update(x_ng=x_ng, k=k)
             encoder_loss = out["loss"]
@@ -351,15 +350,18 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
                 sum(nmf_reconstruction_errors) / len(nmf_reconstruction_errors) if nmf_reconstruction_errors else None
             )
             beta = np.exp(-1 / self.n_batches_for_forgetting_momentum)  # momentum term for exponential moving average
-            self._train_nmf_loss_ema = (
+            val = (
                 beta * self._train_nmf_loss_ema + (1 - beta) * minibatch_nmf_loss
                 if self._train_nmf_loss_ema is not None
                 else minibatch_nmf_loss
             )
+            assert isinstance(val, torch.Tensor)
+            self._train_nmf_loss_ema = val
 
-        return {
-            "loss": sum(encoder_losses) / len(encoder_losses) if encoder_losses else None,
-        }
+        loss = sum(encoder_losses) / len(encoder_losses) if encoder_losses else None
+        assert isinstance(loss, torch.Tensor) or loss is None
+
+        return {"loss": loss}
 
     def on_train_start(self, trainer: pl.Trainer) -> None:
         if trainer.world_size > 1:
@@ -372,17 +374,20 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
             )
 
     def on_train_batch_end(self, trainer: pl.Trainer) -> None:
-        if trainer.global_step % self.check_convergence_every_n_steps != 0:
+        step = trainer.global_step
+        if step == 0 or step % self.n_batches_for_forgetting_momentum != 0:
             return
 
-        beta_pow_t = np.exp(-trainer.global_step / self.n_batches_for_forgetting_momentum)
+        module = trainer.model
+        assert isinstance(module, pl.LightningModule)
 
-        nmf_loss_ema = self._train_nmf_loss_ema
-        nmf_loss_ema_unbiased = nmf_loss_ema / (1 - beta_pow_t)
-        trainer.model.log("reconstruction_error", nmf_loss_ema_unbiased, prog_bar=True)
-        nmf_loss_converged = self.convergence_tracker.check_convergence(nmf_loss_ema_unbiased.item())
+        # --- log reconstruction error EMA ---
+        if self._train_nmf_loss_ema is not None:
+            beta_pow_t = np.exp(-step / self.n_batches_for_forgetting_momentum)
+            nmf_loss_ema_unbiased = self._train_nmf_loss_ema / (1 - beta_pow_t)
+            module.log("reconstruction_error", nmf_loss_ema_unbiased, prog_bar=True)
 
-        # look at the actual consensus procedure histogram
+        # --- log consensus metrics ---
         local_neighborhood_size = 0.3
         for k in self.k_values:
             D_rkg = getattr(self, f"D_{k}_rkg")
@@ -400,62 +405,82 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
                         "We want n_neighbors >= 2. Increase local_neighborhood_size."
                     )
 
-                # euclidean distance to every other run
                 euclidean_dist_mm = torch.cdist(d_norm_mg, d_norm_mg, p=2)
-                euclidean_dist_mm.fill_diagonal_(0)  # correct for roundoff errors that may be present
-
-                # top n_neighbors plus self (distance 0)
+                euclidean_dist_mm.fill_diagonal_(0)
                 n_nearest_dist_including_self_mL, _ = torch.topk(euclidean_dist_mm, n_neighbors + 1, largest=False)
-
-                # distances to top n_neighbors
                 n_nearest_dist_ml = n_nearest_dist_including_self_mL[:, 1:]
-
-                # mean distance to top n_neighbors
                 mean_neighbor_distance_m = n_nearest_dist_ml.mean(dim=1)
 
-                # log historgram
                 for logger in trainer.loggers:
                     try:
                         if isinstance(logger, pl.loggers.TensorBoardLogger):
                             logger.experiment.add_histogram(
                                 f"k={k}__consensus_histogram",
                                 mean_neighbor_distance_m,
-                                global_step=trainer.global_step,
+                                global_step=step,
                                 bins=np.linspace(0, 1, 75),
                             )
                     except Exception as e:
-                        warnings.warn(f"Failed to log histogram for k={k} step={trainer.global_step} due to {e}")
+                        warnings.warn(f"Failed to log histogram for k={k} step={step} due to {e}")
 
-                trainer.model.log(f"k={k}__consensus_L1", mean_neighbor_distance_m.mean(), prog_bar=False)
-                # trainer.model.log(f"k={k}__consensus_L2", mean_neighbor_distance_m.pow(2).mean(), prog_bar=False)
-                trainer.model.log(f"k={k}__consensus_q75", mean_neighbor_distance_m.quantile(0.75), prog_bar=True)
+                module.log(f"k={k}__consensus_L1", mean_neighbor_distance_m.mean(), prog_bar=False)
+                module.log(f"k={k}__consensus_q75", mean_neighbor_distance_m.quantile(0.75), prog_bar=True)
 
-        # implement convergence check: reconstruction error plateaued and consensus_q75 is below the threshold
-        # at least one epoch
-        # do not stop near an A, B reset
-        # look for loss convergence
-        # and look for consensus convergence (q75 of mean distance to neighbors below threshold)
-        converged = (
-            (trainer.global_step > self.n_batches_for_forgetting_momentum)
-            and (
-                trainer.global_step % self.n_batches_for_forgetting_momentum
-                >= min(100, self.n_batches_for_forgetting_momentum * 0.75)
-            )
-            and nmf_loss_converged
-            and (
-                max([trainer.callback_metrics.get(f"k={k}__consensus_q75", float("inf")) for k in self.k_values])
-                <= self.q75_convergence_threshold
-            )
-        )
-        if converged:
+        # --- per-k forgetting convergence check and forgetting ---
+        assert isinstance(trainer.max_epochs, int)
+        steps_remaining = trainer.max_epochs * self.n_batches_per_epoch - step
+        min_steps_before_stop = self.exploration_epochs * self.n_batches_per_epoch
+
+        all_done = True
+        for k in self.k_values:
+            # check if a previously started final epoch has completed
+            if self._k_in_final_epoch[k]:
+                k_start = self._k_final_epoch_start[k]
+                assert k_start is not None
+                if step - k_start >= self.n_batches_per_epoch:
+                    continue  # this k is done; don't touch A/B
+                else:
+                    all_done = False
+                    continue  # still in final epoch; don't forget
+            all_done = False
+
+            # force into final epoch if not enough steps remain for another full period + final epoch
+            if steps_remaining < self.n_batches_per_epoch:
+                self._k_in_final_epoch[k] = True
+                self._k_final_epoch_start[k] = step
+                continue  # don't forget; let A/B accumulate
+
+            # compute drift relative to previous period endpoint
+            D_rkg = getattr(self, f"D_{k}_rkg").detach()
+            prev = self._D_prev_snapshots[k]
+            if prev is not None and step >= min_steps_before_stop:
+                prev_norm = prev.norm()
+                if prev_norm < 1e-8:
+                    drift = float("inf")
+                else:
+                    drift = ((D_rkg - prev).norm() / prev_norm).item()
+                module.log(f"k={k}__forgetting_drift", drift, prog_bar=False)
+
+                if drift < self.forgetting_drift_threshold:
+                    self._forgetting_patience_counters[k] += 1
+                else:
+                    self._forgetting_patience_counters[k] = 0
+
+                if self._forgetting_patience_counters[k] >= self.forgetting_patience:
+                    self._k_in_final_epoch[k] = True
+                    self._k_final_epoch_start[k] = step
+                    continue  # don't forget; let A/B accumulate
+
+            # snapshot current D before forgetting
+            self._D_prev_snapshots[k] = D_rkg.clone()
+
+            # forget
+            getattr(self, f"A_{k}_rkk").zero_()
+            getattr(self, f"B_{k}_rkg").zero_()
+
+        if all_done:
             trainer.should_stop = True
-            print("Stopping early: converged")
-
-        if trainer.global_step % self.n_batches_for_forgetting_momentum == 0:
-            # this hard reset to zero is equivalent to forgetting momentum
-            for i in self.k_values:
-                getattr(self, f"A_{i}_rkk").zero_()
-                getattr(self, f"B_{i}_rkg").zero_()
+            print("Stopping early: all k values have completed their final epoch")
 
     def on_end(self, trainer: pl.Trainer) -> None:
         trainer.save_checkpoint(trainer.default_root_dir + "/NMF.ckpt")
@@ -530,14 +555,17 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
             sum(nmf_reconstruction_errors) / len(nmf_reconstruction_errors) if nmf_reconstruction_errors else None
         )
         beta = np.exp(-1 / self.n_batches_for_forgetting_momentum)  # momentum term for exponential moving average
-        self._val_nmf_loss_ema = (
+        val = (
             beta * self._val_nmf_loss_ema + (1 - beta) * minibatch_nmf_loss
             if self._val_nmf_loss_ema is not None
             else minibatch_nmf_loss
         )
+        assert isinstance(val, torch.Tensor) or val is None
+        self._val_nmf_loss_ema = val
 
         # Logging to TensorBoard by default
-        pl_module.log("val_nmf_loss", self._val_nmf_loss_ema, sync_dist=True, on_epoch=True)
+        if self._val_nmf_loss_ema is not None:
+            pl_module.log("val_nmf_loss", self._val_nmf_loss_ema, sync_dist=True, on_epoch=True)
 
     @torch.no_grad()
     def reconstruction_error(

--- a/cellarium/ml/models/nmf_amortized.py
+++ b/cellarium/ml/models/nmf_amortized.py
@@ -158,6 +158,9 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         forgetting_drift_threshold: float = 0.1,
         forgetting_patience: int = 5,
         exploration_epochs: int = 2,
+        cooldown_periods: int | None = None,
+        max_solver_iter_train: int = 100,
+        max_solver_iter_cooldown: int = 100,
         init: Literal["sklearn_random", "uniform_random"] = "uniform_random",
         transformed_data_mean: None | float = None,
     ) -> None:
@@ -198,6 +201,13 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         self.forgetting_drift_threshold = forgetting_drift_threshold
         self.forgetting_patience = forgetting_patience
         self.exploration_epochs = exploration_epochs
+        self.cooldown_periods = (
+            cooldown_periods
+            if cooldown_periods is not None
+            else int(np.ceil(self.n_batches_per_epoch / self.n_batches_for_forgetting_momentum))
+        )
+        self.max_solver_iter_train = max_solver_iter_train
+        self.max_solver_iter_cooldown = max_solver_iter_cooldown
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
@@ -229,7 +239,7 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         """Return the learned factors for each k value."""
         return {k: getattr(self, f"D_{k}_rkg") for k in self.k_values}
 
-    def online_dictionary_update(self, x_ng: torch.Tensor, k: int) -> dict[str, torch.Tensor]:
+    def online_dictionary_update(self, x_ng: torch.Tensor, k: int, n_iterations: int = 100) -> dict[str, torch.Tensor]:
         """
         Algorithm 1 from Mairal et al. [1] for online dictionary learning.
 
@@ -260,7 +270,7 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
                 loadings_rnk=solver_loadings_rnk,  # hals does inplace update
                 A_rkk=A_rkk,
                 B_rkg=B_rkg,
-                n_iterations=500,
+                n_iterations=n_iterations,
                 alpha_tol=0.01,
                 D_tol=0.05,
                 exponential_decay_rho=self.exponential_decay_rho,
@@ -272,7 +282,7 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
                 loadings_rnk=encoder_loadings_rnk.detach(),
                 A_rkk=A_rkk,
                 B_rkg=B_rkg,
-                n_iterations=100,
+                n_iterations=n_iterations,
                 exponential_decay_rho=self.exponential_decay_rho,
             )
             solver_loadings_rnk = updated_values["loadings_rnk"]  # not inplace like hals
@@ -316,7 +326,8 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         encoder_losses: list[torch.Tensor] = []
         nmf_reconstruction_errors: list[torch.Tensor] = []
         for k in self.k_values:
-            out = self.online_dictionary_update(x_ng=x_ng, k=k)
+            n_iter = self.max_solver_iter_cooldown if self._k_in_final_epoch[k] else self.max_solver_iter_train
+            out = self.online_dictionary_update(x_ng=x_ng, k=k, n_iterations=n_iter)
             encoder_loss = out["loss"]
             solver_loadings_rnk = out["solver_loadings_rnk"]
             encoder_losses.append(encoder_loss)
@@ -440,18 +451,19 @@ class AmortizedOnlineNonNegativeMatrixFactorization(NonNegativeMatrixFactorizati
         all_done = True
         for k in self.k_values:
             # check if a previously started final epoch has completed
+            cooldown_steps = self.cooldown_periods * self.n_batches_for_forgetting_momentum
             if self._k_in_final_epoch[k]:
                 k_start = self._k_final_epoch_start[k]
                 assert k_start is not None
-                if step - k_start >= self.n_batches_per_epoch:
+                if step - k_start >= cooldown_steps:
                     continue  # this k is done; don't touch A/B
                 else:
                     all_done = False
-                    continue  # still in final epoch; don't forget
+                    continue  # still in cooldown; don't forget
             all_done = False
 
-            # force into final epoch if not enough steps remain for another full period + final epoch
-            if steps_remaining < self.n_batches_per_epoch:
+            # force into cooldown if not enough steps remain
+            if steps_remaining < cooldown_steps:
                 self._k_in_final_epoch[k] = True
                 self._k_final_epoch_start[k] = step
                 continue  # don't forget; let A/B accumulate


### PR DESCRIPTION
This PR implements the following stopping strategy:

- train a min number of epochs with catastrophic forgetting of A and B at periodic intervals
- start tracking a metric: the relative change in frobenius norm of the factor matrix (r, k, g) for each K, distilled to one scalar
- user can provide a threshold and a patience criterion which have defaults
- after stopping criteria are met for a given K, that K is send into its cooldown, which is a (user specified with default) number of additional periods. during this time there is no catastrophic forgetting of A and B and the FISTA or HALS solver does more iterations.  if the previous training was the exploration phase, this is the exploitation phase, meant for each replicate to drill down as deep as possible into its local min
- after every K is done, the whole thing is over

The metric being tracked for stopping is intentionally chosen to be separate from the consensus procedure and independent of stability.

This was chosen over per-replicate stopping (which I also tried) for a number of reasons, not least of which was that tensor shapes change and it triggers recompilation and everything is slower.  It doesn't really hurt to train a replicate more.  But systematically training certain K values more is problematic, because then stability becomes a less fair comparison.